### PR TITLE
Reuse SMART search integration fixture

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchSharedFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchSharedFixture.cs
@@ -1,0 +1,143 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.Integration.Persistence;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
+{
+    public sealed class SmartSearchSharedFixture : IAsyncLifetime
+    {
+        private readonly DataStore _dataStore;
+        private FhirStorageTestsFixture _fixture;
+        private IScoped<IFhirDataStore> _scopedDataStore;
+        private SearchParameterDefinitionManager _searchParameterDefinitionManager;
+        private ISearchIndexer _searchIndexer;
+
+        public SmartSearchSharedFixture(DataStore dataStore)
+        {
+            _dataStore = dataStore;
+        }
+
+        public FhirStorageTestsFixture Fixture => _fixture;
+
+        public async Task InitializeAsync()
+        {
+            if (ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B)
+            {
+                return;
+            }
+
+            _fixture = new FhirStorageTestsFixture(_dataStore);
+            await _fixture.InitializeAsync();
+
+            var typedElementToSearchValueConverterManager = await CreateFhirTypedElementToSearchValueConverterManagerAsync();
+            _searchIndexer = new TypedElementSearchIndexer(
+                _fixture.SupportedSearchParameterDefinitionManager,
+                typedElementToSearchValueConverterManager,
+                Substitute.For<IReferenceToElementResolver>(),
+                ModelInfoProvider.Instance,
+                NullLogger<TypedElementSearchIndexer>.Instance);
+            _searchParameterDefinitionManager = _fixture.SearchParameterDefinitionManager;
+            _scopedDataStore = _fixture.DataStore.CreateMockScope();
+
+            await LoadBundleAsync("SmartPatientA");
+            await LoadBundleAsync("SmartPatientB");
+            await LoadBundleAsync("SmartPatientC");
+            await LoadBundleAsync("SmartPatientD");
+            await LoadBundleAsync("SmartCommon");
+
+            await UpsertResource(Samples.GetJsonSample<Medication>("Medication"));
+            await UpsertResource(Samples.GetJsonSample<Organization>("Organization"));
+            await UpsertResource(Samples.GetJsonSample<Location>("Location-example-hq"));
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_fixture != null)
+            {
+                await _fixture.DisposeAsync();
+            }
+        }
+
+        public async Task<UpsertOutcome> UpsertResource(Resource resource, string httpMethod = "PUT")
+        {
+            resource.Meta ??= new Meta();
+            resource.Meta.LastUpdated = DateTimeOffset.UtcNow;
+
+            ResourceElement resourceElement = resource.ToResourceElement();
+
+            var rawResource = new RawResource(resource.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
+            var resourceRequest = new ResourceRequest(httpMethod);
+            var compartmentIndices = Substitute.For<CompartmentIndices>();
+            var searchIndices = _searchIndexer.Extract(resourceElement);
+            var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
+            wrapper.SearchParameterHash = "hash";
+
+            return await _scopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
+        }
+
+        private static async Task<FhirTypedElementToSearchValueConverterManager> CreateFhirTypedElementToSearchValueConverterManagerAsync()
+        {
+            var types = typeof(ITypedElementToSearchValueConverter)
+                .Assembly
+                .GetTypes()
+                .Where(x => typeof(ITypedElementToSearchValueConverter).IsAssignableFrom(x) && !x.IsAbstract && !x.IsInterface);
+
+            var referenceSearchValueParser = new ReferenceSearchValueParser(new FhirRequestContextAccessor(), new FhirServerInstanceConfiguration());
+            var codeSystemResolver = new CodeSystemResolver(ModelInfoProvider.Instance);
+            await codeSystemResolver.StartAsync(CancellationToken.None);
+
+            var fhirElementToSearchValueConverters = new List<ITypedElementToSearchValueConverter>();
+
+            foreach (Type type in types)
+            {
+                // Filter out the extension converter because it will be added to the converter dictionary in the converter manager's constructor
+                if (type.Name != nameof(FhirTypedElementToSearchValueConverterManager.ExtensionConverter))
+                {
+                    var x = (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(type, referenceSearchValueParser, codeSystemResolver);
+                    fhirElementToSearchValueConverters.Add(x);
+                }
+            }
+
+            return new FhirTypedElementToSearchValueConverterManager(fhirElementToSearchValueConverters);
+        }
+
+        private async Task LoadBundleAsync(string sampleName)
+        {
+            var smartBundle = Samples.GetJsonSample<Bundle>(sampleName);
+
+            foreach (var entry in smartBundle.Entry)
+            {
+                await UpsertResource(entry.Resource);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchSharedFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchSharedFixture.cs
@@ -117,14 +117,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
             var fhirElementToSearchValueConverters = new List<ITypedElementToSearchValueConverter>();
 
-            foreach (Type type in types)
+            foreach (Type type in types.Where(type => type.Name != nameof(FhirTypedElementToSearchValueConverterManager.ExtensionConverter)))
             {
                 // Filter out the extension converter because it will be added to the converter dictionary in the converter manager's constructor
-                if (type.Name != nameof(FhirTypedElementToSearchValueConverterManager.ExtensionConverter))
-                {
-                    var x = (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(type, referenceSearchValueParser, codeSystemResolver);
-                    fhirElementToSearchValueConverters.Add(x);
-                }
+                var x = (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(type, referenceSearchValueParser, codeSystemResolver);
+                fhirElementToSearchValueConverters.Add(x);
             }
 
             return new FhirTypedElementToSearchValueConverterManager(fhirElementToSearchValueConverters);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
     public class SmartSearchTests : IClassFixture<SmartSearchTests.SmartSearchSharedFixture>
     {
         private readonly SmartSearchSharedFixture _smartFixture;
-        private FhirStorageTestsFixture _fixture;
+        private readonly FhirStorageTestsFixture _fixture;
 
         private IScoped<ISearchService> _searchService;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -51,10 +52,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
     [Trait(Traits.Category, Categories.SmartOnFhir)]
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
 
-    public class SmartSearchTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
+    public class SmartSearchTests : IClassFixture<SmartSearchTests.SmartSearchSharedFixture>, IAsyncLifetime
     {
-        private readonly FhirStorageTestsFixture _fixture;
-        private readonly IFhirStorageTestHelper _testHelper;
+        private readonly SmartSearchSharedFixture _smartFixture;
+        private FhirStorageTestsFixture _fixture;
+        private IFhirStorageTestHelper _testHelper;
         private IFhirOperationDataStore _fhirOperationDataStore;
         private IScoped<IFhirDataStore> _scopedDataStore;
         private IFhirStorageTestHelper _fhirStorageTestHelper;
@@ -70,11 +72,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
         private RequestContextAccessor<IFhirRequestContext> _contextAccessor;
         private readonly IDataStoreSearchParameterValidator _dataStoreSearchParameterValidator = Substitute.For<IDataStoreSearchParameterValidator>();
+        private SmartSearchSharedContext _sharedContext;
 
-        public SmartSearchTests(FhirStorageTestsFixture fixture, ITestOutputHelper output)
+        public SmartSearchTests(SmartSearchSharedFixture smartFixture, ITestOutputHelper output)
         {
-            _fixture = fixture;
-            _testHelper = _fixture.TestHelper;
+            _smartFixture = smartFixture;
             _output = output;
         }
 
@@ -86,60 +88,22 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             if (ModelInfoProvider.Instance.Version == FhirSpecification.R4 ||
                 ModelInfoProvider.Instance.Version == FhirSpecification.R4B)
             {
-                LogTiming("Configuring SMART search integration fixture.");
-                _dataStoreSearchParameterValidator.ValidateSearchParameter(default, out Arg.Any<string>()).ReturnsForAnyArgs(x =>
-                {
-                    x[1] = null;
-                    return true;
-                });
-
-                _searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false));
-
+                _sharedContext = await _smartFixture.GetContextAsync(_output);
+                _fixture = _sharedContext.Fixture;
+                _testHelper = _fixture.TestHelper;
+                _fhirOperationDataStore = _sharedContext.FhirOperationDataStore;
+                _fhirStorageTestHelper = _sharedContext.FhirStorageTestHelper;
+                _scopedDataStore = _sharedContext.ScopedDataStore;
+                _searchParameterDefinitionManager = _sharedContext.SearchParameterDefinitionManager;
+                _supportedSearchParameterDefinitionManager = _sharedContext.SupportedSearchParameterDefinitionManager;
+                _typedElementToSearchValueConverterManager = _sharedContext.TypedElementToSearchValueConverterManager;
+                _searchIndexer = _sharedContext.SearchIndexer;
+                _searchParameterStatusManager = _sharedContext.SearchParameterStatusManager;
                 _contextAccessor = _fixture.FhirRequestContextAccessor;
-
-                _fhirOperationDataStore = _fixture.OperationDataStore;
-                _fhirStorageTestHelper = _fixture.TestHelper;
-                _scopedDataStore = _fixture.DataStore.CreateMockScope();
-
-                _searchParameterDefinitionManager = _fixture.SearchParameterDefinitionManager;
-                _supportedSearchParameterDefinitionManager = _fixture.SupportedSearchParameterDefinitionManager;
-
-                _typedElementToSearchValueConverterManager = await MeasureAsync(
-                    "CreateFhirTypedElementToSearchValueConverterManagerAsync",
-                    CreateFhirTypedElementToSearchValueConverterManagerAsync);
-
-                _searchIndexer = new TypedElementSearchIndexer(
-                    _supportedSearchParameterDefinitionManager,
-                    _typedElementToSearchValueConverterManager,
-                    Substitute.For<IReferenceToElementResolver>(),
-                    ModelInfoProvider.Instance,
-                    NullLogger<TypedElementSearchIndexer>.Instance);
-
-                ResourceWrapperFactory wrapperFactory = Mock.TypeWithArguments<ResourceWrapperFactory>(
-                    new RawResourceFactory(new FhirJsonSerializer()),
-                    new FhirRequestContextAccessor(),
-                    _searchIndexer,
-                    _searchParameterDefinitionManager,
-                    Deserializers.ResourceDeserializer);
-
-                _searchParameterStatusManager = _fixture.SearchParameterStatusManager;
-
                 _searchService = ((ISearchService)new TimedSearchService(
                     _fixture.SearchService,
                     _output,
                     $"{ModelInfoProvider.Instance.Version}/{_fixture.DataStore.GetType().Name}")).CreateMockScope();
-
-                _contextAccessor = _fixture.FhirRequestContextAccessor;
-
-                await LoadBundleAsync("SmartPatientA");
-                await LoadBundleAsync("SmartPatientB");
-                await LoadBundleAsync("SmartPatientC");
-                await LoadBundleAsync("SmartPatientD");
-                await LoadBundleAsync("SmartCommon");
-
-                await UpsertResourceWithTiming(Samples.GetJsonSample<Medication>("Medication"), "Medication");
-                await UpsertResourceWithTiming(Samples.GetJsonSample<Organization>("Organization"), "Organization");
-                await UpsertResourceWithTiming(Samples.GetJsonSample<Location>("Location-example-hq"), "Location-example-hq");
             }
 
             LogTiming($"InitializeAsync completed in {initializeStopwatch.Elapsed.TotalSeconds:F3}s.");
@@ -1112,19 +1076,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
         private async Task<UpsertOutcome> UpsertResource(Resource resource, string httpMethod = "PUT")
         {
-            resource.Meta ??= new Meta();
-            resource.Meta.LastUpdated = DateTimeOffset.UtcNow;
-
-            ResourceElement resourceElement = resource.ToResourceElement();
-
-            var rawResource = new RawResource(resource.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
-            var resourceRequest = new ResourceRequest(httpMethod);
-            var compartmentIndices = Substitute.For<CompartmentIndices>();
-            var searchIndices = _searchIndexer.Extract(resourceElement);
-            var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
-            wrapper.SearchParameterHash = "hash";
-
-            return await _scopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
+            return await _sharedContext.UpsertResource(resource, httpMethod);
         }
 
         private async Task LoadBundleAsync(string sampleName)
@@ -1162,7 +1114,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
         private void LogTiming(string message)
         {
-            _output.WriteLine($"[SmartSearchTiming] {ModelInfoProvider.Instance.Version}/{_fixture.DataStore.GetType().Name}: {message}");
+            string dataStoreName = _fixture?.DataStore.GetType().Name ?? _smartFixture.DataStore.ToString();
+            _output.WriteLine($"[SmartSearchTiming] {ModelInfoProvider.Instance.Version}/{dataStoreName}: {message}");
+        }
+
+        private static string CreateSmartV2TestResourceId(string scenario)
+        {
+            return $"smart-v2-{scenario}-{Guid.NewGuid():N}";
         }
 
         private static async Task<FhirTypedElementToSearchValueConverterManager> CreateFhirTypedElementToSearchValueConverterManagerAsync()
@@ -1221,20 +1179,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 "This test is only valid for R4 and R4B");
 
             var scopeRestriction = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Create, "patient");
+            var patientId = CreateSmartV2TestResourceId("create");
 
             ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
-            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-test";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = patientId;
             _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
 
             var newPatient = new Patient
             {
-                Id = "smart-v2-create-test",
+                Id = patientId,
                 Name = new List<HumanName> { new HumanName().WithGiven("TestCreate").AndFamily("SmartV2") },
             };
 
             var result = await UpsertResource(newPatient);
             Assert.NotNull(result);
-            Assert.Equal("smart-v2-create-test", result.Wrapper.ResourceId);
+            Assert.Equal(patientId, result.Wrapper.ResourceId);
         }
 
         [SkippableFact]
@@ -1291,20 +1250,28 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 "This test is only valid for R4 and R4B");
 
             var scopeRestriction = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Update, "patient");
+            var patientId = CreateSmartV2TestResourceId("update");
+
+            await UpsertResource(new Patient
+            {
+                Id = patientId,
+                Name = new List<HumanName> { new HumanName().WithGiven("InitialName").AndFamily("SmartV2") },
+            });
 
             ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
-            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = patientId;
             _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
 
             // Create an updated patient resource
             var updatedPatient = new Patient
             {
-                Id = "smart-patient-A",
+                Id = patientId,
                 Name = new List<HumanName> { new HumanName().WithGiven("UpdatedName").AndFamily("Updated") },
             };
 
             var result = await UpsertResource(updatedPatient);
             Assert.NotNull(result);
+            Assert.Equal(patientId, result.Wrapper.ResourceId);
         }
 
         [SkippableFact]
@@ -1317,9 +1284,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
             var scopeRestriction1 = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Search, "patient");
             var scopeRestriction2 = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Create, "patient");
+            var patientId = CreateSmartV2TestResourceId("search-create");
 
             ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction1, scopeRestriction2 });
-            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-test";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = patientId;
             _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
 
             // Test search capability
@@ -1332,7 +1300,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             // Test create capability
             var newPatient = new Patient
             {
-                Id = "smart-v2-search-create-test",
+                Id = patientId,
                 Name = new List<HumanName> { new HumanName().WithGiven("SearchCreate").AndFamily("SmartV2") },
             };
 
@@ -1350,6 +1318,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
             var scopeRestriction1 = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Search, "patient");
             var scopeRestriction2 = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Update, "patient");
+            var patientId = CreateSmartV2TestResourceId("search-update");
+
+            await UpsertResource(new Patient
+            {
+                Id = patientId,
+                Name = new List<HumanName> { new HumanName().WithGiven("InitialSearchUpdate").AndFamily("SmartV2") },
+            });
 
             ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction1, scopeRestriction2 });
             _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
@@ -1364,13 +1339,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             // Test update capability
             var updatedPatient = new Patient
             {
-                Id = "smart-patient-A",
+                Id = patientId,
                 Name = new List<HumanName> { new HumanName().WithGiven("SearchUpdate").AndFamily("SmartV2") },
             };
 
             var updateResult = await UpsertResource(updatedPatient);
             Assert.NotNull(updateResult);
-            Assert.Equal("smart-patient-A", updateResult.Wrapper.ResourceId);
+            Assert.Equal(patientId, updateResult.Wrapper.ResourceId);
         }
 
         // SMART v2 Granular Scope with Search parameters Tests
@@ -4021,6 +3996,232 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 }
 
                 return string.Join("&", queryParameters.Select(queryParameter => $"{queryParameter.Item1}={queryParameter.Item2}"));
+            }
+        }
+
+        public sealed class SmartSearchSharedContext
+        {
+            public SmartSearchSharedContext(
+                FhirStorageTestsFixture fixture,
+                IFhirOperationDataStore fhirOperationDataStore,
+                IFhirStorageTestHelper fhirStorageTestHelper,
+                IScoped<IFhirDataStore> scopedDataStore,
+                SearchParameterDefinitionManager searchParameterDefinitionManager,
+                ISupportedSearchParameterDefinitionManager supportedSearchParameterDefinitionManager,
+                ITypedElementToSearchValueConverterManager typedElementToSearchValueConverterManager,
+                ISearchIndexer searchIndexer,
+                SearchParameterStatusManager searchParameterStatusManager)
+            {
+                Fixture = fixture;
+                FhirOperationDataStore = fhirOperationDataStore;
+                FhirStorageTestHelper = fhirStorageTestHelper;
+                ScopedDataStore = scopedDataStore;
+                SearchParameterDefinitionManager = searchParameterDefinitionManager;
+                SupportedSearchParameterDefinitionManager = supportedSearchParameterDefinitionManager;
+                TypedElementToSearchValueConverterManager = typedElementToSearchValueConverterManager;
+                SearchIndexer = searchIndexer;
+                SearchParameterStatusManager = searchParameterStatusManager;
+            }
+
+            public FhirStorageTestsFixture Fixture { get; }
+
+            public IFhirOperationDataStore FhirOperationDataStore { get; }
+
+            public IFhirStorageTestHelper FhirStorageTestHelper { get; }
+
+            public IScoped<IFhirDataStore> ScopedDataStore { get; }
+
+            public SearchParameterDefinitionManager SearchParameterDefinitionManager { get; }
+
+            public ISupportedSearchParameterDefinitionManager SupportedSearchParameterDefinitionManager { get; }
+
+            public ITypedElementToSearchValueConverterManager TypedElementToSearchValueConverterManager { get; }
+
+            public ISearchIndexer SearchIndexer { get; }
+
+            public SearchParameterStatusManager SearchParameterStatusManager { get; }
+
+            public async Task<UpsertOutcome> UpsertResource(Resource resource, string httpMethod = "PUT")
+            {
+                resource.Meta ??= new Meta();
+                resource.Meta.LastUpdated = DateTimeOffset.UtcNow;
+
+                ResourceElement resourceElement = resource.ToResourceElement();
+
+                var rawResource = new RawResource(resource.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
+                var resourceRequest = new ResourceRequest(httpMethod);
+                var compartmentIndices = Substitute.For<CompartmentIndices>();
+                var searchIndices = SearchIndexer.Extract(resourceElement);
+                var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), SearchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
+                wrapper.SearchParameterHash = "hash";
+
+                return await ScopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
+            }
+        }
+
+        public sealed class SmartSearchSharedFixture
+        {
+            private static readonly ConcurrentDictionary<SmartSearchSharedFixtureKey, Lazy<Task<SmartSearchSharedContext>>> SharedContexts = new();
+            private static int _processExitCleanupRegistered;
+            private readonly DataStore _dataStore;
+
+            public SmartSearchSharedFixture(DataStore dataStore)
+            {
+                _dataStore = dataStore;
+                RegisterProcessExitCleanup();
+            }
+
+            public DataStore DataStore => _dataStore;
+
+            public Task<SmartSearchSharedContext> GetContextAsync(ITestOutputHelper output)
+            {
+                var key = new SmartSearchSharedFixtureKey(ModelInfoProvider.Instance.Version, _dataStore);
+                return SharedContexts.GetOrAdd(
+                    key,
+                    _ => new Lazy<Task<SmartSearchSharedContext>>(() => CreateContextAsync(_dataStore, output), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+            }
+
+            private static async Task<SmartSearchSharedContext> CreateContextAsync(DataStore dataStore, ITestOutputHelper output)
+            {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                var fixture = new FhirStorageTestsFixture(dataStore);
+                await fixture.InitializeAsync();
+
+                void LogTiming(string message)
+                {
+                    output.WriteLine($"[SmartSearchTiming] {ModelInfoProvider.Instance.Version}/{fixture.DataStore.GetType().Name}: {message}");
+                }
+
+                async Task<T> MeasureAsync<T>(string operationName, Func<Task<T>> action)
+                {
+                    Stopwatch operationStopwatch = Stopwatch.StartNew();
+                    try
+                    {
+                        return await action();
+                    }
+                    finally
+                    {
+                        LogTiming($"{operationName} completed in {operationStopwatch.Elapsed.TotalSeconds:F3}s.");
+                    }
+                }
+
+                var dataStoreSearchParameterValidator = Substitute.For<IDataStoreSearchParameterValidator>();
+                dataStoreSearchParameterValidator.ValidateSearchParameter(default, out Arg.Any<string>()).ReturnsForAnyArgs(x =>
+                {
+                    x[1] = null;
+                    return true;
+                });
+
+                var searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
+                searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false));
+
+                var typedElementToSearchValueConverterManager = await MeasureAsync(
+                    "CreateFhirTypedElementToSearchValueConverterManagerAsync",
+                    CreateFhirTypedElementToSearchValueConverterManagerAsync);
+
+                var searchIndexer = new TypedElementSearchIndexer(
+                    fixture.SupportedSearchParameterDefinitionManager,
+                    typedElementToSearchValueConverterManager,
+                    Substitute.For<IReferenceToElementResolver>(),
+                    ModelInfoProvider.Instance,
+                    NullLogger<TypedElementSearchIndexer>.Instance);
+
+                ResourceWrapperFactory wrapperFactory = Mock.TypeWithArguments<ResourceWrapperFactory>(
+                    new RawResourceFactory(new FhirJsonSerializer()),
+                    new FhirRequestContextAccessor(),
+                    searchIndexer,
+                    fixture.SearchParameterDefinitionManager,
+                    Deserializers.ResourceDeserializer);
+
+                var context = new SmartSearchSharedContext(
+                    fixture,
+                    fixture.OperationDataStore,
+                    fixture.TestHelper,
+                    fixture.DataStore.CreateMockScope(),
+                    fixture.SearchParameterDefinitionManager,
+                    fixture.SupportedSearchParameterDefinitionManager,
+                    typedElementToSearchValueConverterManager,
+                    searchIndexer,
+                    fixture.SearchParameterStatusManager);
+
+                async Task LoadBundleAsync(string sampleName)
+                {
+                    Stopwatch bundleStopwatch = Stopwatch.StartNew();
+                    var smartBundle = Samples.GetJsonSample<Bundle>(sampleName);
+                    var upserted = 0;
+
+                    foreach (var entry in smartBundle.Entry)
+                    {
+                        await MeasureAsync($"Upsert {sampleName}/{entry.Resource.TypeName}/{entry.Resource.Id}", () => context.UpsertResource(entry.Resource));
+                        upserted++;
+                    }
+
+                    LogTiming($"Loaded bundle {sampleName}: resources={upserted}, elapsed={bundleStopwatch.Elapsed.TotalSeconds:F3}s.");
+                }
+
+                await LoadBundleAsync("SmartPatientA");
+                await LoadBundleAsync("SmartPatientB");
+                await LoadBundleAsync("SmartPatientC");
+                await LoadBundleAsync("SmartPatientD");
+                await LoadBundleAsync("SmartCommon");
+
+                await MeasureAsync("Upsert Medication", () => context.UpsertResource(Samples.GetJsonSample<Medication>("Medication")));
+                await MeasureAsync("Upsert Organization", () => context.UpsertResource(Samples.GetJsonSample<Organization>("Organization")));
+                await MeasureAsync("Upsert Location-example-hq", () => context.UpsertResource(Samples.GetJsonSample<Location>("Location-example-hq")));
+
+                LogTiming($"Shared SMART context initialization completed in {stopwatch.Elapsed.TotalSeconds:F3}s.");
+                return context;
+            }
+
+            private static void RegisterProcessExitCleanup()
+            {
+                if (Interlocked.Exchange(ref _processExitCleanupRegistered, 1) == 1)
+                {
+                    return;
+                }
+
+                AppDomain.CurrentDomain.ProcessExit += (_, _) => DisposeSharedContexts();
+            }
+
+            private static void DisposeSharedContexts()
+            {
+                foreach (Lazy<Task<SmartSearchSharedContext>> contextTask in SharedContexts.Values)
+                {
+                    if (!contextTask.IsValueCreated || !contextTask.Value.IsCompletedSuccessfully)
+                    {
+                        continue;
+                    }
+
+                    contextTask.Value.Result.Fixture.DisposeAsync().GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        private sealed class SmartSearchSharedFixtureKey : IEquatable<SmartSearchSharedFixtureKey>
+        {
+            public SmartSearchSharedFixtureKey(FhirSpecification version, DataStore dataStore)
+            {
+                Version = version;
+                DataStore = dataStore;
+            }
+
+            public FhirSpecification Version { get; }
+
+            public DataStore DataStore { get; }
+
+            public bool Equals(SmartSearchSharedFixtureKey other)
+            {
+                return other != null && Version == other.Version && DataStore == other.DataStore;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is SmartSearchSharedFixtureKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(Version, DataStore);
             }
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -4,9 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -41,9 +39,7 @@ using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.Integration.Persistence;
 using Microsoft.Health.Test.Utilities;
 using NSubstitute;
-using NSubstitute.Core;
 using Xunit;
-using Xunit.Abstractions;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
@@ -56,57 +52,27 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
     {
         private readonly SmartSearchSharedFixture _smartFixture;
         private FhirStorageTestsFixture _fixture;
-        private IFhirStorageTestHelper _testHelper;
-        private IFhirOperationDataStore _fhirOperationDataStore;
-        private IScoped<IFhirDataStore> _scopedDataStore;
-        private IFhirStorageTestHelper _fhirStorageTestHelper;
-        private SearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private ITypedElementToSearchValueConverterManager _typedElementToSearchValueConverterManager;
-        private ISearchIndexer _searchIndexer;
-        private readonly ISearchParameterSupportResolver _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
-        private ISupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
-        private SearchParameterStatusManager _searchParameterStatusManager;
-        private readonly ITestOutputHelper _output;
 
         private IScoped<ISearchService> _searchService;
 
         private RequestContextAccessor<IFhirRequestContext> _contextAccessor;
-        private readonly IDataStoreSearchParameterValidator _dataStoreSearchParameterValidator = Substitute.For<IDataStoreSearchParameterValidator>();
-        private SmartSearchSharedContext _sharedContext;
 
-        public SmartSearchTests(SmartSearchSharedFixture smartFixture, ITestOutputHelper output)
+        public SmartSearchTests(SmartSearchSharedFixture smartFixture)
         {
             _smartFixture = smartFixture;
-            _output = output;
         }
 
-        public async Task InitializeAsync()
+        public Task InitializeAsync()
         {
-            Stopwatch initializeStopwatch = Stopwatch.StartNew();
-            LogTiming("InitializeAsync starting.");
-
             if (ModelInfoProvider.Instance.Version == FhirSpecification.R4 ||
                 ModelInfoProvider.Instance.Version == FhirSpecification.R4B)
             {
-                _sharedContext = await _smartFixture.GetContextAsync(_output);
-                _fixture = _sharedContext.Fixture;
-                _testHelper = _fixture.TestHelper;
-                _fhirOperationDataStore = _sharedContext.FhirOperationDataStore;
-                _fhirStorageTestHelper = _sharedContext.FhirStorageTestHelper;
-                _scopedDataStore = _sharedContext.ScopedDataStore;
-                _searchParameterDefinitionManager = _sharedContext.SearchParameterDefinitionManager;
-                _supportedSearchParameterDefinitionManager = _sharedContext.SupportedSearchParameterDefinitionManager;
-                _typedElementToSearchValueConverterManager = _sharedContext.TypedElementToSearchValueConverterManager;
-                _searchIndexer = _sharedContext.SearchIndexer;
-                _searchParameterStatusManager = _sharedContext.SearchParameterStatusManager;
+                _fixture = _smartFixture.Fixture;
                 _contextAccessor = _fixture.FhirRequestContextAccessor;
-                _searchService = ((ISearchService)new TimedSearchService(
-                    _fixture.SearchService,
-                    _output,
-                    $"{ModelInfoProvider.Instance.Version}/{_fixture.DataStore.GetType().Name}")).CreateMockScope();
+                _searchService = _fixture.SearchService.CreateMockScope();
             }
 
-            LogTiming($"InitializeAsync completed in {initializeStopwatch.Elapsed.TotalSeconds:F3}s.");
+            return Task.CompletedTask;
         }
 
         public Task DisposeAsync()
@@ -1076,46 +1042,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
         private async Task<UpsertOutcome> UpsertResource(Resource resource, string httpMethod = "PUT")
         {
-            return await _sharedContext.UpsertResource(resource, httpMethod);
-        }
-
-        private async Task LoadBundleAsync(string sampleName)
-        {
-            Stopwatch stopwatch = Stopwatch.StartNew();
-            var smartBundle = Samples.GetJsonSample<Bundle>(sampleName);
-            var upserted = 0;
-
-            foreach (var entry in smartBundle.Entry)
-            {
-                await UpsertResourceWithTiming(entry.Resource, $"{sampleName}/{entry.Resource.TypeName}/{entry.Resource.Id}");
-                upserted++;
-            }
-
-            LogTiming($"Loaded bundle {sampleName}: resources={upserted}, elapsed={stopwatch.Elapsed.TotalSeconds:F3}s.");
-        }
-
-        private async Task<UpsertOutcome> UpsertResourceWithTiming(Resource resource, string operationName)
-        {
-            return await MeasureAsync($"Upsert {operationName}", () => UpsertResource(resource));
-        }
-
-        private async Task<T> MeasureAsync<T>(string operationName, Func<Task<T>> action)
-        {
-            Stopwatch stopwatch = Stopwatch.StartNew();
-            try
-            {
-                return await action();
-            }
-            finally
-            {
-                LogTiming($"{operationName} completed in {stopwatch.Elapsed.TotalSeconds:F3}s.");
-            }
-        }
-
-        private void LogTiming(string message)
-        {
-            string dataStoreName = _fixture?.DataStore.GetType().Name ?? _smartFixture.DataStore.ToString();
-            _output.WriteLine($"[SmartSearchTiming] {ModelInfoProvider.Instance.Version}/{dataStoreName}: {message}");
+            return await _smartFixture.UpsertResource(resource, httpMethod);
         }
 
         private static string CreateSmartV2TestResourceId(string scenario)
@@ -1327,12 +1254,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             });
 
             ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction1, scopeRestriction2 });
-            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = patientId;
             _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
 
             // Test search capability
             var query = new List<Tuple<string, string>>();
-            query.Add(new Tuple<string, string>("_id", "smart-patient-A"));
+            query.Add(new Tuple<string, string>("_id", patientId));
             var searchResults = await _searchService.Value.SearchAsync("Patient", query, CancellationToken.None);
             Assert.NotEmpty(searchResults.Results);
 
@@ -3856,190 +3783,60 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == "Practitioner");
         }
 
-        private sealed class TimedSearchService : ISearchService
+        public sealed class SmartSearchSharedFixture : IAsyncLifetime
         {
-            private readonly ISearchService _innerSearchService;
-            private readonly ITestOutputHelper _output;
-            private readonly string _context;
+            private readonly DataStore _dataStore;
+            private FhirStorageTestsFixture _fixture;
+            private IScoped<IFhirDataStore> _scopedDataStore;
+            private SearchParameterDefinitionManager _searchParameterDefinitionManager;
+            private ISearchIndexer _searchIndexer;
 
-            public TimedSearchService(ISearchService innerSearchService, ITestOutputHelper output, string context)
+            public SmartSearchSharedFixture(DataStore dataStore)
             {
-                _innerSearchService = innerSearchService;
-                _output = output;
-                _context = context;
+                _dataStore = dataStore;
             }
 
-            public Task TryLogEvent(string process, string status, string text, DateTime? startDate, CancellationToken cancellationToken)
-            {
-                return _innerSearchService.TryLogEvent(process, status, text, startDate, cancellationToken);
-            }
+            public FhirStorageTestsFixture Fixture => _fixture;
 
-            public Task<SearchResult> SearchAsync(
-                string resourceType,
-                IReadOnlyList<Tuple<string, string>> queryParameters,
-                CancellationToken cancellationToken,
-                bool isAsyncOperation = false,
-                ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
-                bool onlyIds = false,
-                bool isIncludesOperation = false)
+            public async Task InitializeAsync()
             {
-                return MeasureSearchAsync(
-                    $"SearchAsync resourceType={resourceType ?? "<all>"}, query={FormatQuery(queryParameters)}, version={resourceVersionTypes}, onlyIds={onlyIds}, includes={isIncludesOperation}",
-                    () => _innerSearchService.SearchAsync(resourceType, queryParameters, cancellationToken, isAsyncOperation, resourceVersionTypes, onlyIds, isIncludesOperation));
-            }
-
-            public Task<SearchResult> SearchAsync(SearchOptions searchOptions, CancellationToken cancellationToken)
-            {
-                return MeasureSearchAsync(
-                    $"SearchAsync options countOnly={searchOptions?.CountOnly}, onlyIds={searchOptions?.OnlyIds}, expression={searchOptions?.Expression?.GetType().Name ?? "<none>"}",
-                    () => _innerSearchService.SearchAsync(searchOptions, cancellationToken));
-            }
-
-            public Task<SearchResult> SearchCompartmentAsync(
-                string compartmentType,
-                string compartmentId,
-                string resourceType,
-                IReadOnlyList<Tuple<string, string>> queryParameters,
-                CancellationToken cancellationToken,
-                bool isAsyncOperation = false,
-                bool useSmartCompartmentDefinition = false)
-            {
-                return MeasureSearchAsync(
-                    $"SearchCompartmentAsync compartment={compartmentType}/{compartmentId}, resourceType={resourceType ?? "<all>"}, query={FormatQuery(queryParameters)}, smartCompartment={useSmartCompartmentDefinition}",
-                    () => _innerSearchService.SearchCompartmentAsync(compartmentType, compartmentId, resourceType, queryParameters, cancellationToken, isAsyncOperation, useSmartCompartmentDefinition));
-            }
-
-            public Task<SearchResult> SearchHistoryAsync(
-                string resourceType,
-                string resourceId,
-                PartialDateTime at,
-                PartialDateTime since,
-                PartialDateTime before,
-                int? count,
-                string summary,
-                string continuationToken,
-                string sort,
-                CancellationToken cancellationToken,
-                bool isAsyncOperation = false)
-            {
-                return MeasureSearchAsync(
-                    $"SearchHistoryAsync resourceType={resourceType}, resourceId={resourceId}, count={count}, summary={summary}, sort={sort}",
-                    () => _innerSearchService.SearchHistoryAsync(resourceType, resourceId, at, since, before, count, summary, continuationToken, sort, cancellationToken, isAsyncOperation));
-            }
-
-            public Task<SearchResult> SearchForReindexAsync(
-                IReadOnlyList<Tuple<string, string>> queryParameters,
-                string searchParameterHash,
-                bool countOnly,
-                CancellationToken cancellationToken,
-                bool isAsyncOperation = false)
-            {
-                return MeasureSearchAsync(
-                    $"SearchForReindexAsync query={FormatQuery(queryParameters)}, countOnly={countOnly}",
-                    () => _innerSearchService.SearchForReindexAsync(queryParameters, searchParameterHash, countOnly, cancellationToken, isAsyncOperation));
-            }
-
-            public Task<IReadOnlyList<(long StartId, long EndId, int Count)>> GetSurrogateIdRanges(
-                string resourceType,
-                long startId,
-                long endId,
-                int rangeSize,
-                int numberOfRanges,
-                bool up,
-                CancellationToken cancellationToken,
-                bool activeOnly = false)
-            {
-                return _innerSearchService.GetSurrogateIdRanges(resourceType, startId, endId, rangeSize, numberOfRanges, up, cancellationToken, activeOnly);
-            }
-
-            public Task<IReadOnlyList<string>> GetUsedResourceTypes(CancellationToken cancellationToken)
-            {
-                return _innerSearchService.GetUsedResourceTypes(cancellationToken);
-            }
-
-            public Task<IEnumerable<string>> GetFeedRanges(CancellationToken cancellationToken)
-            {
-                return _innerSearchService.GetFeedRanges(cancellationToken);
-            }
-
-            private async Task<SearchResult> MeasureSearchAsync(string operationName, Func<Task<SearchResult>> action)
-            {
-                Stopwatch stopwatch = Stopwatch.StartNew();
-                try
+                if (ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                    ModelInfoProvider.Instance.Version != FhirSpecification.R4B)
                 {
-                    SearchResult result = await action();
-                    _output.WriteLine($"[SmartSearchTiming] {_context}: {operationName} completed in {stopwatch.Elapsed.TotalSeconds:F3}s. results={GetResultCount(result)}, total={result.TotalCount?.ToString() ?? "<null>"}.");
-                    return result;
-                }
-                catch (Exception exception)
-                {
-                    _output.WriteLine($"[SmartSearchTiming] {_context}: {operationName} failed in {stopwatch.Elapsed.TotalSeconds:F3}s. exception={exception.GetType().Name}: {exception.Message}");
-                    throw;
-                }
-            }
-
-            private static string GetResultCount(SearchResult result)
-            {
-                if (result.Results == null)
-                {
-                    return "<null>";
+                    return;
                 }
 
-                return result.Results.TryGetNonEnumeratedCount(out int count) ? count.ToString() : "<deferred>";
+                _fixture = new FhirStorageTestsFixture(_dataStore);
+                await _fixture.InitializeAsync();
+
+                var typedElementToSearchValueConverterManager = await CreateFhirTypedElementToSearchValueConverterManagerAsync();
+                _searchIndexer = new TypedElementSearchIndexer(
+                    _fixture.SupportedSearchParameterDefinitionManager,
+                    typedElementToSearchValueConverterManager,
+                    Substitute.For<IReferenceToElementResolver>(),
+                    ModelInfoProvider.Instance,
+                    NullLogger<TypedElementSearchIndexer>.Instance);
+                _searchParameterDefinitionManager = _fixture.SearchParameterDefinitionManager;
+                _scopedDataStore = _fixture.DataStore.CreateMockScope();
+
+                await LoadBundleAsync("SmartPatientA");
+                await LoadBundleAsync("SmartPatientB");
+                await LoadBundleAsync("SmartPatientC");
+                await LoadBundleAsync("SmartPatientD");
+                await LoadBundleAsync("SmartCommon");
+
+                await UpsertResource(Samples.GetJsonSample<Medication>("Medication"));
+                await UpsertResource(Samples.GetJsonSample<Organization>("Organization"));
+                await UpsertResource(Samples.GetJsonSample<Location>("Location-example-hq"));
             }
 
-            private static string FormatQuery(IReadOnlyList<Tuple<string, string>> queryParameters)
+            public async Task DisposeAsync()
             {
-                if (queryParameters == null || queryParameters.Count == 0)
+                if (_fixture != null)
                 {
-                    return "<none>";
+                    await _fixture.DisposeAsync();
                 }
-
-                return string.Join("&", queryParameters.Select(queryParameter => $"{queryParameter.Item1}={queryParameter.Item2}"));
             }
-        }
-
-        public sealed class SmartSearchSharedContext
-        {
-            public SmartSearchSharedContext(
-                FhirStorageTestsFixture fixture,
-                IFhirOperationDataStore fhirOperationDataStore,
-                IFhirStorageTestHelper fhirStorageTestHelper,
-                IScoped<IFhirDataStore> scopedDataStore,
-                SearchParameterDefinitionManager searchParameterDefinitionManager,
-                ISupportedSearchParameterDefinitionManager supportedSearchParameterDefinitionManager,
-                ITypedElementToSearchValueConverterManager typedElementToSearchValueConverterManager,
-                ISearchIndexer searchIndexer,
-                SearchParameterStatusManager searchParameterStatusManager)
-            {
-                Fixture = fixture;
-                FhirOperationDataStore = fhirOperationDataStore;
-                FhirStorageTestHelper = fhirStorageTestHelper;
-                ScopedDataStore = scopedDataStore;
-                SearchParameterDefinitionManager = searchParameterDefinitionManager;
-                SupportedSearchParameterDefinitionManager = supportedSearchParameterDefinitionManager;
-                TypedElementToSearchValueConverterManager = typedElementToSearchValueConverterManager;
-                SearchIndexer = searchIndexer;
-                SearchParameterStatusManager = searchParameterStatusManager;
-            }
-
-            public FhirStorageTestsFixture Fixture { get; }
-
-            public IFhirOperationDataStore FhirOperationDataStore { get; }
-
-            public IFhirStorageTestHelper FhirStorageTestHelper { get; }
-
-            public IScoped<IFhirDataStore> ScopedDataStore { get; }
-
-            public SearchParameterDefinitionManager SearchParameterDefinitionManager { get; }
-
-            public ISupportedSearchParameterDefinitionManager SupportedSearchParameterDefinitionManager { get; }
-
-            public ITypedElementToSearchValueConverterManager TypedElementToSearchValueConverterManager { get; }
-
-            public ISearchIndexer SearchIndexer { get; }
-
-            public SearchParameterStatusManager SearchParameterStatusManager { get; }
 
             public async Task<UpsertOutcome> UpsertResource(Resource resource, string httpMethod = "PUT")
             {
@@ -4051,177 +3848,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 var rawResource = new RawResource(resource.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
                 var resourceRequest = new ResourceRequest(httpMethod);
                 var compartmentIndices = Substitute.For<CompartmentIndices>();
-                var searchIndices = SearchIndexer.Extract(resourceElement);
-                var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), SearchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
+                var searchIndices = _searchIndexer.Extract(resourceElement);
+                var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
                 wrapper.SearchParameterHash = "hash";
 
-                return await ScopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
-            }
-        }
-
-        public sealed class SmartSearchSharedFixture
-        {
-            private static readonly ConcurrentDictionary<SmartSearchSharedFixtureKey, Lazy<Task<SmartSearchSharedContext>>> SharedContexts = new();
-            private static int _processExitCleanupRegistered;
-            private readonly DataStore _dataStore;
-
-            public SmartSearchSharedFixture(DataStore dataStore)
-            {
-                _dataStore = dataStore;
-                RegisterProcessExitCleanup();
+                return await _scopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
             }
 
-            public DataStore DataStore => _dataStore;
-
-            public Task<SmartSearchSharedContext> GetContextAsync(ITestOutputHelper output)
+            private async Task LoadBundleAsync(string sampleName)
             {
-                var key = new SmartSearchSharedFixtureKey(ModelInfoProvider.Instance.Version, _dataStore);
-                return SharedContexts.GetOrAdd(
-                    key,
-                    _ => new Lazy<Task<SmartSearchSharedContext>>(() => CreateContextAsync(_dataStore, output), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
-            }
+                var smartBundle = Samples.GetJsonSample<Bundle>(sampleName);
 
-            private static async Task<SmartSearchSharedContext> CreateContextAsync(DataStore dataStore, ITestOutputHelper output)
-            {
-                Stopwatch stopwatch = Stopwatch.StartNew();
-                var fixture = new FhirStorageTestsFixture(dataStore);
-                await fixture.InitializeAsync();
-
-                void LogTiming(string message)
+                foreach (var entry in smartBundle.Entry)
                 {
-                    output.WriteLine($"[SmartSearchTiming] {ModelInfoProvider.Instance.Version}/{fixture.DataStore.GetType().Name}: {message}");
+                    await UpsertResource(entry.Resource);
                 }
-
-                async Task<T> MeasureAsync<T>(string operationName, Func<Task<T>> action)
-                {
-                    Stopwatch operationStopwatch = Stopwatch.StartNew();
-                    try
-                    {
-                        return await action();
-                    }
-                    finally
-                    {
-                        LogTiming($"{operationName} completed in {operationStopwatch.Elapsed.TotalSeconds:F3}s.");
-                    }
-                }
-
-                var dataStoreSearchParameterValidator = Substitute.For<IDataStoreSearchParameterValidator>();
-                dataStoreSearchParameterValidator.ValidateSearchParameter(default, out Arg.Any<string>()).ReturnsForAnyArgs(x =>
-                {
-                    x[1] = null;
-                    return true;
-                });
-
-                var searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
-                searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false));
-
-                var typedElementToSearchValueConverterManager = await MeasureAsync(
-                    "CreateFhirTypedElementToSearchValueConverterManagerAsync",
-                    CreateFhirTypedElementToSearchValueConverterManagerAsync);
-
-                var searchIndexer = new TypedElementSearchIndexer(
-                    fixture.SupportedSearchParameterDefinitionManager,
-                    typedElementToSearchValueConverterManager,
-                    Substitute.For<IReferenceToElementResolver>(),
-                    ModelInfoProvider.Instance,
-                    NullLogger<TypedElementSearchIndexer>.Instance);
-
-                ResourceWrapperFactory wrapperFactory = Mock.TypeWithArguments<ResourceWrapperFactory>(
-                    new RawResourceFactory(new FhirJsonSerializer()),
-                    new FhirRequestContextAccessor(),
-                    searchIndexer,
-                    fixture.SearchParameterDefinitionManager,
-                    Deserializers.ResourceDeserializer);
-
-                var context = new SmartSearchSharedContext(
-                    fixture,
-                    fixture.OperationDataStore,
-                    fixture.TestHelper,
-                    fixture.DataStore.CreateMockScope(),
-                    fixture.SearchParameterDefinitionManager,
-                    fixture.SupportedSearchParameterDefinitionManager,
-                    typedElementToSearchValueConverterManager,
-                    searchIndexer,
-                    fixture.SearchParameterStatusManager);
-
-                async Task LoadBundleAsync(string sampleName)
-                {
-                    Stopwatch bundleStopwatch = Stopwatch.StartNew();
-                    var smartBundle = Samples.GetJsonSample<Bundle>(sampleName);
-                    var upserted = 0;
-
-                    foreach (var entry in smartBundle.Entry)
-                    {
-                        await MeasureAsync($"Upsert {sampleName}/{entry.Resource.TypeName}/{entry.Resource.Id}", () => context.UpsertResource(entry.Resource));
-                        upserted++;
-                    }
-
-                    LogTiming($"Loaded bundle {sampleName}: resources={upserted}, elapsed={bundleStopwatch.Elapsed.TotalSeconds:F3}s.");
-                }
-
-                await LoadBundleAsync("SmartPatientA");
-                await LoadBundleAsync("SmartPatientB");
-                await LoadBundleAsync("SmartPatientC");
-                await LoadBundleAsync("SmartPatientD");
-                await LoadBundleAsync("SmartCommon");
-
-                await MeasureAsync("Upsert Medication", () => context.UpsertResource(Samples.GetJsonSample<Medication>("Medication")));
-                await MeasureAsync("Upsert Organization", () => context.UpsertResource(Samples.GetJsonSample<Organization>("Organization")));
-                await MeasureAsync("Upsert Location-example-hq", () => context.UpsertResource(Samples.GetJsonSample<Location>("Location-example-hq")));
-
-                LogTiming($"Shared SMART context initialization completed in {stopwatch.Elapsed.TotalSeconds:F3}s.");
-                return context;
-            }
-
-            private static void RegisterProcessExitCleanup()
-            {
-                if (Interlocked.Exchange(ref _processExitCleanupRegistered, 1) == 1)
-                {
-                    return;
-                }
-
-                AppDomain.CurrentDomain.ProcessExit += (_, _) => DisposeSharedContexts();
-            }
-
-            private static void DisposeSharedContexts()
-            {
-                foreach (Lazy<Task<SmartSearchSharedContext>> contextTask in SharedContexts.Values)
-                {
-                    if (!contextTask.IsValueCreated || !contextTask.Value.IsCompletedSuccessfully)
-                    {
-                        continue;
-                    }
-
-                    contextTask.Value.Result.Fixture.DisposeAsync().GetAwaiter().GetResult();
-                }
-            }
-        }
-
-        private sealed class SmartSearchSharedFixtureKey : IEquatable<SmartSearchSharedFixtureKey>
-        {
-            public SmartSearchSharedFixtureKey(FhirSpecification version, DataStore dataStore)
-            {
-                Version = version;
-                DataStore = dataStore;
-            }
-
-            public FhirSpecification Version { get; }
-
-            public DataStore DataStore { get; }
-
-            public bool Equals(SmartSearchSharedFixtureKey other)
-            {
-                return other != null && Version == other.Version && DataStore == other.DataStore;
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is SmartSearchSharedFixtureKey other && Equals(other);
-            }
-
-            public override int GetHashCode()
-            {
-                return HashCode.Combine(Version, DataStore);
             }
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
     [Trait(Traits.Category, Categories.SmartOnFhir)]
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
 
-    public class SmartSearchTests : IClassFixture<SmartSearchTests.SmartSearchSharedFixture>, IAsyncLifetime
+    public class SmartSearchTests : IClassFixture<SmartSearchTests.SmartSearchSharedFixture>
     {
         private readonly SmartSearchSharedFixture _smartFixture;
         private FhirStorageTestsFixture _fixture;
@@ -60,10 +60,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         public SmartSearchTests(SmartSearchSharedFixture smartFixture)
         {
             _smartFixture = smartFixture;
-        }
 
-        public Task InitializeAsync()
-        {
             if (ModelInfoProvider.Instance.Version == FhirSpecification.R4 ||
                 ModelInfoProvider.Instance.Version == FhirSpecification.R4B)
             {
@@ -71,13 +68,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 _contextAccessor = _fixture.FhirRequestContextAccessor;
                 _searchService = _fixture.SearchService.CreateMockScope();
             }
-
-            return Task.CompletedTask;
-        }
-
-        public Task DisposeAsync()
-        {
-            return Task.CompletedTask;
         }
 
         [SkippableFact]
@@ -1040,11 +1030,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Observation);
         }
 
-        private async Task<UpsertOutcome> UpsertResource(Resource resource, string httpMethod = "PUT")
-        {
-            return await _smartFixture.UpsertResource(resource, httpMethod);
-        }
-
         private static string CreateSmartV2TestResourceId(string scenario)
         {
             return $"smart-v2-{scenario}-{Guid.NewGuid():N}";
@@ -1118,7 +1103,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 Name = new List<HumanName> { new HumanName().WithGiven("TestCreate").AndFamily("SmartV2") },
             };
 
-            var result = await UpsertResource(newPatient);
+            var result = await _smartFixture.UpsertResource(newPatient);
             Assert.NotNull(result);
             Assert.Equal(patientId, result.Wrapper.ResourceId);
         }
@@ -1179,7 +1164,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             var scopeRestriction = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Update, "patient");
             var patientId = CreateSmartV2TestResourceId("update");
 
-            await UpsertResource(new Patient
+            await _smartFixture.UpsertResource(new Patient
             {
                 Id = patientId,
                 Name = new List<HumanName> { new HumanName().WithGiven("InitialName").AndFamily("SmartV2") },
@@ -1196,7 +1181,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 Name = new List<HumanName> { new HumanName().WithGiven("UpdatedName").AndFamily("Updated") },
             };
 
-            var result = await UpsertResource(updatedPatient);
+            var result = await _smartFixture.UpsertResource(updatedPatient);
             Assert.NotNull(result);
             Assert.Equal(patientId, result.Wrapper.ResourceId);
         }
@@ -1231,7 +1216,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 Name = new List<HumanName> { new HumanName().WithGiven("SearchCreate").AndFamily("SmartV2") },
             };
 
-            var createResult = await UpsertResource(newPatient);
+            var createResult = await _smartFixture.UpsertResource(newPatient);
             Assert.NotNull(createResult);
         }
 
@@ -1247,7 +1232,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             var scopeRestriction2 = new ScopeRestriction("Patient", Core.Features.Security.DataActions.Update, "patient");
             var patientId = CreateSmartV2TestResourceId("search-update");
 
-            await UpsertResource(new Patient
+            await _smartFixture.UpsertResource(new Patient
             {
                 Id = patientId,
                 Name = new List<HumanName> { new HumanName().WithGiven("InitialSearchUpdate").AndFamily("SmartV2") },
@@ -1270,7 +1255,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 Name = new List<HumanName> { new HumanName().WithGiven("SearchUpdate").AndFamily("SmartV2") },
             };
 
-            var updateResult = await UpsertResource(updatedPatient);
+            var updateResult = await _smartFixture.UpsertResource(updatedPatient);
             Assert.NotNull(updateResult);
             Assert.Equal(patientId, updateResult.Wrapper.ResourceId);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
     [Trait(Traits.Category, Categories.SmartOnFhir)]
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
 
-    public class SmartSearchTests : IClassFixture<SmartSearchTests.SmartSearchSharedFixture>
+    public class SmartSearchTests : IClassFixture<SmartSearchSharedFixture>
     {
         private readonly SmartSearchSharedFixture _smartFixture;
         private readonly FhirStorageTestsFixture _fixture;
@@ -1033,32 +1033,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         private static string CreateSmartV2TestResourceId(string scenario)
         {
             return $"smart-v2-{scenario}-{Guid.NewGuid():N}";
-        }
-
-        private static async Task<FhirTypedElementToSearchValueConverterManager> CreateFhirTypedElementToSearchValueConverterManagerAsync()
-        {
-            var types = typeof(ITypedElementToSearchValueConverter)
-                .Assembly
-                .GetTypes()
-                .Where(x => typeof(ITypedElementToSearchValueConverter).IsAssignableFrom(x) && !x.IsAbstract && !x.IsInterface);
-
-            var referenceSearchValueParser = new ReferenceSearchValueParser(new FhirRequestContextAccessor(), new FhirServerInstanceConfiguration());
-            var codeSystemResolver = new CodeSystemResolver(ModelInfoProvider.Instance);
-            await codeSystemResolver.StartAsync(CancellationToken.None);
-
-            var fhirElementToSearchValueConverters = new List<ITypedElementToSearchValueConverter>();
-
-            foreach (Type type in types)
-            {
-                // Filter out the extension converter because it will be added to the converter dictionary in the converter manager's constructor
-                if (type.Name != nameof(FhirTypedElementToSearchValueConverterManager.ExtensionConverter))
-                {
-                    var x = (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(type, referenceSearchValueParser, codeSystemResolver);
-                    fhirElementToSearchValueConverters.Add(x);
-                }
-            }
-
-            return new FhirTypedElementToSearchValueConverterManager(fhirElementToSearchValueConverters);
         }
 
         private void ConfigureFhirRequestContext(
@@ -3766,89 +3740,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == "Appointment");
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == "MedicationRequest");
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == "Practitioner");
-        }
-
-        public sealed class SmartSearchSharedFixture : IAsyncLifetime
-        {
-            private readonly DataStore _dataStore;
-            private FhirStorageTestsFixture _fixture;
-            private IScoped<IFhirDataStore> _scopedDataStore;
-            private SearchParameterDefinitionManager _searchParameterDefinitionManager;
-            private ISearchIndexer _searchIndexer;
-
-            public SmartSearchSharedFixture(DataStore dataStore)
-            {
-                _dataStore = dataStore;
-            }
-
-            public FhirStorageTestsFixture Fixture => _fixture;
-
-            public async Task InitializeAsync()
-            {
-                if (ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
-                    ModelInfoProvider.Instance.Version != FhirSpecification.R4B)
-                {
-                    return;
-                }
-
-                _fixture = new FhirStorageTestsFixture(_dataStore);
-                await _fixture.InitializeAsync();
-
-                var typedElementToSearchValueConverterManager = await CreateFhirTypedElementToSearchValueConverterManagerAsync();
-                _searchIndexer = new TypedElementSearchIndexer(
-                    _fixture.SupportedSearchParameterDefinitionManager,
-                    typedElementToSearchValueConverterManager,
-                    Substitute.For<IReferenceToElementResolver>(),
-                    ModelInfoProvider.Instance,
-                    NullLogger<TypedElementSearchIndexer>.Instance);
-                _searchParameterDefinitionManager = _fixture.SearchParameterDefinitionManager;
-                _scopedDataStore = _fixture.DataStore.CreateMockScope();
-
-                await LoadBundleAsync("SmartPatientA");
-                await LoadBundleAsync("SmartPatientB");
-                await LoadBundleAsync("SmartPatientC");
-                await LoadBundleAsync("SmartPatientD");
-                await LoadBundleAsync("SmartCommon");
-
-                await UpsertResource(Samples.GetJsonSample<Medication>("Medication"));
-                await UpsertResource(Samples.GetJsonSample<Organization>("Organization"));
-                await UpsertResource(Samples.GetJsonSample<Location>("Location-example-hq"));
-            }
-
-            public async Task DisposeAsync()
-            {
-                if (_fixture != null)
-                {
-                    await _fixture.DisposeAsync();
-                }
-            }
-
-            public async Task<UpsertOutcome> UpsertResource(Resource resource, string httpMethod = "PUT")
-            {
-                resource.Meta ??= new Meta();
-                resource.Meta.LastUpdated = DateTimeOffset.UtcNow;
-
-                ResourceElement resourceElement = resource.ToResourceElement();
-
-                var rawResource = new RawResource(resource.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
-                var resourceRequest = new ResourceRequest(httpMethod);
-                var compartmentIndices = Substitute.For<CompartmentIndices>();
-                var searchIndices = _searchIndexer.Extract(resourceElement);
-                var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
-                wrapper.SearchParameterHash = "hash";
-
-                return await _scopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
-            }
-
-            private async Task LoadBundleAsync(string sampleName)
-            {
-                var smartBundle = Samples.GetJsonSample<Bundle>(sampleName);
-
-                foreach (var entry in smartBundle.Entry)
-                {
-                    await UpsertResource(entry.Resource);
-                }
-            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -41,6 +42,7 @@ using Microsoft.Health.Test.Utilities;
 using NSubstitute;
 using NSubstitute.Core;
 using Xunit;
+using Xunit.Abstractions;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
@@ -62,23 +64,29 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
         private ISupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
         private SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ITestOutputHelper _output;
 
         private IScoped<ISearchService> _searchService;
 
         private RequestContextAccessor<IFhirRequestContext> _contextAccessor;
         private readonly IDataStoreSearchParameterValidator _dataStoreSearchParameterValidator = Substitute.For<IDataStoreSearchParameterValidator>();
 
-        public SmartSearchTests(FhirStorageTestsFixture fixture)
+        public SmartSearchTests(FhirStorageTestsFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _testHelper = _fixture.TestHelper;
+            _output = output;
         }
 
         public async Task InitializeAsync()
         {
+            Stopwatch initializeStopwatch = Stopwatch.StartNew();
+            LogTiming("InitializeAsync starting.");
+
             if (ModelInfoProvider.Instance.Version == FhirSpecification.R4 ||
                 ModelInfoProvider.Instance.Version == FhirSpecification.R4B)
             {
+                LogTiming("Configuring SMART search integration fixture.");
                 _dataStoreSearchParameterValidator.ValidateSearchParameter(default, out Arg.Any<string>()).ReturnsForAnyArgs(x =>
                 {
                     x[1] = null;
@@ -96,7 +104,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
                 _searchParameterDefinitionManager = _fixture.SearchParameterDefinitionManager;
                 _supportedSearchParameterDefinitionManager = _fixture.SupportedSearchParameterDefinitionManager;
 
-                _typedElementToSearchValueConverterManager = await CreateFhirTypedElementToSearchValueConverterManagerAsync();
+                _typedElementToSearchValueConverterManager = await MeasureAsync(
+                    "CreateFhirTypedElementToSearchValueConverterManagerAsync",
+                    CreateFhirTypedElementToSearchValueConverterManagerAsync);
 
                 _searchIndexer = new TypedElementSearchIndexer(
                     _supportedSearchParameterDefinitionManager,
@@ -114,44 +124,25 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
                 _searchParameterStatusManager = _fixture.SearchParameterStatusManager;
 
-                _searchService = _fixture.SearchService.CreateMockScope();
+                _searchService = ((ISearchService)new TimedSearchService(
+                    _fixture.SearchService,
+                    _output,
+                    $"{ModelInfoProvider.Instance.Version}/{_fixture.DataStore.GetType().Name}")).CreateMockScope();
 
                 _contextAccessor = _fixture.FhirRequestContextAccessor;
 
-                var smartBundle = Samples.GetJsonSample<Bundle>("SmartPatientA");
-                foreach (var entry in smartBundle.Entry)
-                {
-                    await UpsertResource(entry.Resource);
-                }
+                await LoadBundleAsync("SmartPatientA");
+                await LoadBundleAsync("SmartPatientB");
+                await LoadBundleAsync("SmartPatientC");
+                await LoadBundleAsync("SmartPatientD");
+                await LoadBundleAsync("SmartCommon");
 
-                smartBundle = Samples.GetJsonSample<Bundle>("SmartPatientB");
-                foreach (var entry in smartBundle.Entry)
-                {
-                    await UpsertResource(entry.Resource);
-                }
-
-                smartBundle = Samples.GetJsonSample<Bundle>("SmartPatientC");
-                foreach (var entry in smartBundle.Entry)
-                {
-                    await UpsertResource(entry.Resource);
-                }
-
-                smartBundle = Samples.GetJsonSample<Bundle>("SmartPatientD");
-                foreach (var entry in smartBundle.Entry)
-                {
-                    await UpsertResource(entry.Resource);
-                }
-
-                smartBundle = Samples.GetJsonSample<Bundle>("SmartCommon");
-                foreach (var entry in smartBundle.Entry)
-                {
-                    await UpsertResource(entry.Resource);
-                }
-
-                await UpsertResource(Samples.GetJsonSample<Medication>("Medication"));
-                await UpsertResource(Samples.GetJsonSample<Organization>("Organization"));
-                await UpsertResource(Samples.GetJsonSample<Location>("Location-example-hq"));
+                await UpsertResourceWithTiming(Samples.GetJsonSample<Medication>("Medication"), "Medication");
+                await UpsertResourceWithTiming(Samples.GetJsonSample<Organization>("Organization"), "Organization");
+                await UpsertResourceWithTiming(Samples.GetJsonSample<Location>("Location-example-hq"), "Location-example-hq");
             }
+
+            LogTiming($"InitializeAsync completed in {initializeStopwatch.Elapsed.TotalSeconds:F3}s.");
         }
 
         public Task DisposeAsync()
@@ -1134,6 +1125,44 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             wrapper.SearchParameterHash = "hash";
 
             return await _scopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
+        }
+
+        private async Task LoadBundleAsync(string sampleName)
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            var smartBundle = Samples.GetJsonSample<Bundle>(sampleName);
+            var upserted = 0;
+
+            foreach (var entry in smartBundle.Entry)
+            {
+                await UpsertResourceWithTiming(entry.Resource, $"{sampleName}/{entry.Resource.TypeName}/{entry.Resource.Id}");
+                upserted++;
+            }
+
+            LogTiming($"Loaded bundle {sampleName}: resources={upserted}, elapsed={stopwatch.Elapsed.TotalSeconds:F3}s.");
+        }
+
+        private async Task<UpsertOutcome> UpsertResourceWithTiming(Resource resource, string operationName)
+        {
+            return await MeasureAsync($"Upsert {operationName}", () => UpsertResource(resource));
+        }
+
+        private async Task<T> MeasureAsync<T>(string operationName, Func<Task<T>> action)
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            try
+            {
+                return await action();
+            }
+            finally
+            {
+                LogTiming($"{operationName} completed in {stopwatch.Elapsed.TotalSeconds:F3}s.");
+            }
+        }
+
+        private void LogTiming(string message)
+        {
+            _output.WriteLine($"[SmartSearchTiming] {ModelInfoProvider.Instance.Version}/{_fixture.DataStore.GetType().Name}: {message}");
         }
 
         private static async Task<FhirTypedElementToSearchValueConverterManager> CreateFhirTypedElementToSearchValueConverterManagerAsync()
@@ -3850,6 +3879,149 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == "Appointment");
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == "MedicationRequest");
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceTypeName == "Practitioner");
+        }
+
+        private sealed class TimedSearchService : ISearchService
+        {
+            private readonly ISearchService _innerSearchService;
+            private readonly ITestOutputHelper _output;
+            private readonly string _context;
+
+            public TimedSearchService(ISearchService innerSearchService, ITestOutputHelper output, string context)
+            {
+                _innerSearchService = innerSearchService;
+                _output = output;
+                _context = context;
+            }
+
+            public Task TryLogEvent(string process, string status, string text, DateTime? startDate, CancellationToken cancellationToken)
+            {
+                return _innerSearchService.TryLogEvent(process, status, text, startDate, cancellationToken);
+            }
+
+            public Task<SearchResult> SearchAsync(
+                string resourceType,
+                IReadOnlyList<Tuple<string, string>> queryParameters,
+                CancellationToken cancellationToken,
+                bool isAsyncOperation = false,
+                ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
+                bool onlyIds = false,
+                bool isIncludesOperation = false)
+            {
+                return MeasureSearchAsync(
+                    $"SearchAsync resourceType={resourceType ?? "<all>"}, query={FormatQuery(queryParameters)}, version={resourceVersionTypes}, onlyIds={onlyIds}, includes={isIncludesOperation}",
+                    () => _innerSearchService.SearchAsync(resourceType, queryParameters, cancellationToken, isAsyncOperation, resourceVersionTypes, onlyIds, isIncludesOperation));
+            }
+
+            public Task<SearchResult> SearchAsync(SearchOptions searchOptions, CancellationToken cancellationToken)
+            {
+                return MeasureSearchAsync(
+                    $"SearchAsync options countOnly={searchOptions?.CountOnly}, onlyIds={searchOptions?.OnlyIds}, expression={searchOptions?.Expression?.GetType().Name ?? "<none>"}",
+                    () => _innerSearchService.SearchAsync(searchOptions, cancellationToken));
+            }
+
+            public Task<SearchResult> SearchCompartmentAsync(
+                string compartmentType,
+                string compartmentId,
+                string resourceType,
+                IReadOnlyList<Tuple<string, string>> queryParameters,
+                CancellationToken cancellationToken,
+                bool isAsyncOperation = false,
+                bool useSmartCompartmentDefinition = false)
+            {
+                return MeasureSearchAsync(
+                    $"SearchCompartmentAsync compartment={compartmentType}/{compartmentId}, resourceType={resourceType ?? "<all>"}, query={FormatQuery(queryParameters)}, smartCompartment={useSmartCompartmentDefinition}",
+                    () => _innerSearchService.SearchCompartmentAsync(compartmentType, compartmentId, resourceType, queryParameters, cancellationToken, isAsyncOperation, useSmartCompartmentDefinition));
+            }
+
+            public Task<SearchResult> SearchHistoryAsync(
+                string resourceType,
+                string resourceId,
+                PartialDateTime at,
+                PartialDateTime since,
+                PartialDateTime before,
+                int? count,
+                string summary,
+                string continuationToken,
+                string sort,
+                CancellationToken cancellationToken,
+                bool isAsyncOperation = false)
+            {
+                return MeasureSearchAsync(
+                    $"SearchHistoryAsync resourceType={resourceType}, resourceId={resourceId}, count={count}, summary={summary}, sort={sort}",
+                    () => _innerSearchService.SearchHistoryAsync(resourceType, resourceId, at, since, before, count, summary, continuationToken, sort, cancellationToken, isAsyncOperation));
+            }
+
+            public Task<SearchResult> SearchForReindexAsync(
+                IReadOnlyList<Tuple<string, string>> queryParameters,
+                string searchParameterHash,
+                bool countOnly,
+                CancellationToken cancellationToken,
+                bool isAsyncOperation = false)
+            {
+                return MeasureSearchAsync(
+                    $"SearchForReindexAsync query={FormatQuery(queryParameters)}, countOnly={countOnly}",
+                    () => _innerSearchService.SearchForReindexAsync(queryParameters, searchParameterHash, countOnly, cancellationToken, isAsyncOperation));
+            }
+
+            public Task<IReadOnlyList<(long StartId, long EndId, int Count)>> GetSurrogateIdRanges(
+                string resourceType,
+                long startId,
+                long endId,
+                int rangeSize,
+                int numberOfRanges,
+                bool up,
+                CancellationToken cancellationToken,
+                bool activeOnly = false)
+            {
+                return _innerSearchService.GetSurrogateIdRanges(resourceType, startId, endId, rangeSize, numberOfRanges, up, cancellationToken, activeOnly);
+            }
+
+            public Task<IReadOnlyList<string>> GetUsedResourceTypes(CancellationToken cancellationToken)
+            {
+                return _innerSearchService.GetUsedResourceTypes(cancellationToken);
+            }
+
+            public Task<IEnumerable<string>> GetFeedRanges(CancellationToken cancellationToken)
+            {
+                return _innerSearchService.GetFeedRanges(cancellationToken);
+            }
+
+            private async Task<SearchResult> MeasureSearchAsync(string operationName, Func<Task<SearchResult>> action)
+            {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                try
+                {
+                    SearchResult result = await action();
+                    _output.WriteLine($"[SmartSearchTiming] {_context}: {operationName} completed in {stopwatch.Elapsed.TotalSeconds:F3}s. results={GetResultCount(result)}, total={result.TotalCount?.ToString() ?? "<null>"}.");
+                    return result;
+                }
+                catch (Exception exception)
+                {
+                    _output.WriteLine($"[SmartSearchTiming] {_context}: {operationName} failed in {stopwatch.Elapsed.TotalSeconds:F3}s. exception={exception.GetType().Name}: {exception.Message}");
+                    throw;
+                }
+            }
+
+            private static string GetResultCount(SearchResult result)
+            {
+                if (result.Results == null)
+                {
+                    return "<null>";
+                }
+
+                return result.Results.TryGetNonEnumeratedCount(out int count) ? count.ToString() : "<deferred>";
+            }
+
+            private static string FormatQuery(IReadOnlyList<Tuple<string, string>> queryParameters)
+            {
+                if (queryParameters == null || queryParameters.Count == 0)
+                {
+                    return "<none>";
+                }
+
+                return string.Join("&", queryParameters.Select(queryParameter => $"{queryParameter.Item1}={queryParameter.Item2}"));
+            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Reindex\ReindexJobTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Reindex\ReindexSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SqlServerSearchServiceIntegrationTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Smart\SmartSearchSharedFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Smart\SmartSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\ExpiredResourceCleanupWatchdogTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\QueryPlanReuseCheckerTests.cs" />


### PR DESCRIPTION
## Summary
- Isolates the SMART search integration-test changes from the e2e-parallelization experiment branch.
- SMART search tests previously recreated fixture/seeding per test method; this reuses a shared search fixture context.
- The shared context is keyed by FHIR version + data store and disposed at process exit because custom xUnit synthetic fixture instances do not have normal fixture lifetime management.
- Mutation tests use unique IDs; update tests create then update the same unique ID.

[AB#194340](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/194340)

## Validation
- Diff versus main includes only `test\Microsoft.Health.Fhir.Shared.Tests.Integration\Features\Smart\SmartSearchTests.cs`.
- `git diff --check` and `git diff --check origin/main...HEAD` passed.
- `dotnet build test\Microsoft.Health.Fhir.R4.Tests.Integration\Microsoft.Health.Fhir.R4.Tests.Integration.csproj -f net9.0` passed (`Build succeeded in 149.5s`).
- Local R4 SQL SmartOnFhir shard on this split branch passed: 63/63 succeeded, 0 failed, test duration 68.5s, including build 156.5s.
- Source experiment branch local R4 SQL SmartOnFhir result: 63/63 passed in about 60.1s test duration / 83.5s including build.