### PR TITLE
Feature/in modifier

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchParameterQueryParameterExpander.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchParameterQueryParameterExpander.cs
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    public interface ISearchParameterQueryParameterExpander
+    {
+        Task<IReadOnlyList<Tuple<string, string>>> ExpandAsync(
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         private readonly ISearchOptionsFactory _searchOptionsFactory;
         private readonly IFhirDataStore _fhirDataStore;
         private readonly ILogger _logger;
+        private readonly IReadOnlyCollection<ISearchParameterQueryParameterExpander> _queryParameterExpanders;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SearchService"/> class.
@@ -36,6 +37,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// <param name="fhirDataStore">The data store</param>
         /// <param name="logger">Logger</param>
         protected SearchService(ISearchOptionsFactory searchOptionsFactory, IFhirDataStore fhirDataStore, ILogger logger)
+            : this(searchOptionsFactory, fhirDataStore, logger, Array.Empty<ISearchParameterQueryParameterExpander>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchService"/> class.
+        /// </summary>
+        /// <param name="searchOptionsFactory">The search options factory.</param>
+        /// <param name="fhirDataStore">The data store</param>
+        /// <param name="logger">Logger</param>
+        /// <param name="queryParameterExpanders">Search query parameter expanders.</param>
+        protected SearchService(
+            ISearchOptionsFactory searchOptionsFactory,
+            IFhirDataStore fhirDataStore,
+            ILogger logger,
+            IEnumerable<ISearchParameterQueryParameterExpander> queryParameterExpanders)
         {
             EnsureArg.IsNotNull(searchOptionsFactory, nameof(searchOptionsFactory));
             EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
@@ -44,6 +61,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             _searchOptionsFactory = searchOptionsFactory;
             _fhirDataStore = fhirDataStore;
             _logger = logger;
+            _queryParameterExpanders = queryParameterExpanders?.ToArray() ?? Array.Empty<ISearchParameterQueryParameterExpander>();
         }
 
         public async Task TryLogEvent(string process, string status, string text, DateTime? startDate, CancellationToken cancellationToken)
@@ -61,6 +79,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bool onlyIds = false,
             bool isIncludesOperation = false)
         {
+            queryParameters = await ExpandQueryParametersAsync(resourceType, queryParameters, cancellationToken);
             SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation, resourceVersionTypes, onlyIds, isIncludesOperation);
 
             // Execute the actual search.
@@ -77,6 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bool isAsyncOperation = false,
             bool useSmartCompartmentDefinition = false)
         {
+            queryParameters = await ExpandQueryParametersAsync(resourceType, queryParameters, cancellationToken);
             SearchOptions searchOptions = _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, queryParameters, isAsyncOperation, useSmartCompartmentDefinition);
 
             // Execute the actual search.
@@ -285,6 +305,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public abstract Task<SearchResult> SearchAsync(
             SearchOptions searchOptions,
             CancellationToken cancellationToken);
+
+        private async Task<IReadOnlyList<Tuple<string, string>>> ExpandQueryParametersAsync(
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            CancellationToken cancellationToken)
+        {
+            foreach (ISearchParameterQueryParameterExpander expander in _queryParameterExpanders)
+            {
+                queryParameters = await expander.ExpandAsync(resourceType, queryParameters, cancellationToken);
+            }
+
+            return queryParameters;
+        }
 
         protected abstract Task<SearchResult> SearchForReindexInternalAsync(
             SearchOptions searchOptions,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -54,8 +54,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             ICosmosDbCollectionPhysicalPartitionInfo physicalPartitionInfo,
             CompartmentSearchRewriter compartmentSearchRewriter,
             SmartCompartmentSearchRewriter smartCompartmentSearchRewriter,
+            IEnumerable<ISearchParameterQueryParameterExpander> queryParameterExpanders,
             ILogger<FhirCosmosSearchService> logger)
-            : base(searchOptionsFactory, fhirDataStore, logger)
+            : base(searchOptionsFactory, fhirDataStore, logger, queryParameterExpanders)
         {
             EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
             EnsureArg.IsNotNull(queryBuilder, nameof(queryBuilder));

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.AddSingleton<ISearchParameterExpressionParser, SearchParameterExpressionParser>();
             services.AddSingleton<IExpressionParser, ExpressionParser>();
+            services.AddSingleton<ISearchParameterQueryParameterExpander, SearchParameterValueSetExpander>();
             services.AddSingleton<ISearchOptionsFactory, SearchOptionsFactory>();
             services.AddSingleton<IReferenceToElementResolver, LightweightReferenceToElementResolver>();
             services.AddTransient<ExpressionAccessControl>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameterValueSetExpanderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameterValueSetExpanderTests.cs
@@ -1,0 +1,115 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+using SearchParamType = Microsoft.Health.Fhir.ValueSets.SearchParamType;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SearchParameterValueSetExpanderTests
+    {
+        private readonly ITerminologyServiceProxy _terminologyServiceProxy = Substitute.For<ITerminologyServiceProxy>();
+        private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
+        private readonly SearchParameterValueSetExpander _expander;
+
+        public SearchParameterValueSetExpanderTests()
+        {
+            _expander = new SearchParameterValueSetExpander(
+                _terminologyServiceProxy,
+                () => _searchParameterDefinitionManager);
+        }
+
+        [Fact]
+        public async Task GivenTokenInModifier_WhenExpanding_ThenValueSetExpansionIsConvertedToTokenSearch()
+        {
+            const string valueSetUrl = "http://example.org/fhir/ValueSet/medications";
+            var searchParameter = CreateSearchParameter(SearchParamType.Token);
+            ConfigureSearchParameter("Medication", "code", searchParameter);
+
+            _terminologyServiceProxy.ExpandAsync(
+                Arg.Any<IReadOnlyList<Tuple<string, string>>>(),
+                null,
+                Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(new ValueSet
+                {
+                    Expansion = new ValueSet.ExpansionComponent
+                    {
+                        Contains = new List<ValueSet.ContainsComponent>
+                        {
+                            new ValueSet.ContainsComponent { System = "http://rx.example", Code = "a" },
+                            new ValueSet.ContainsComponent { System = "http://rx.example", Code = "b" },
+                        },
+                    },
+                }.ToResourceElement()));
+
+            IReadOnlyList<Tuple<string, string>> result = await _expander.ExpandAsync(
+                "Medication",
+                new[] { Tuple.Create("code:in", valueSetUrl) },
+                CancellationToken.None);
+
+            Tuple<string, string> expanded = Assert.Single(result);
+            Assert.Equal("code", expanded.Item1);
+            Assert.Equal("http://rx.example|a,http://rx.example|b", expanded.Item2);
+
+            await _terminologyServiceProxy.Received(1).ExpandAsync(
+                Arg.Is<IReadOnlyList<Tuple<string, string>>>(x => x.Single().Item1 == TerminologyOperationParameterNames.Expand.Url && x.Single().Item2 == valueSetUrl),
+                null,
+                Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenNonTokenInModifier_WhenExpanding_ThenQueryParameterIsNotChanged()
+        {
+            var queryParameter = Tuple.Create("name:in", "http://example.org/fhir/ValueSet/names");
+            ConfigureSearchParameter("Patient", "name", CreateSearchParameter(SearchParamType.String));
+
+            IReadOnlyList<Tuple<string, string>> result = await _expander.ExpandAsync(
+                "Patient",
+                new[] { queryParameter },
+                CancellationToken.None);
+
+            Assert.Same(queryParameter, Assert.Single(result));
+            await _terminologyServiceProxy.DidNotReceiveWithAnyArgs().ExpandAsync(default, default, default);
+        }
+
+        private void ConfigureSearchParameter(string resourceType, string code, SearchParameterInfo searchParameter)
+        {
+            _searchParameterDefinitionManager
+                .TryGetSearchParameter(resourceType, code, out Arg.Any<SearchParameterInfo>())
+                .Returns(x =>
+                {
+                    x[2] = searchParameter;
+                    return true;
+                });
+        }
+
+        private static SearchParameterInfo CreateSearchParameter(SearchParamType searchParamType)
+        {
+            return new SearchParameter
+            {
+                Name = "code",
+                Code = "code",
+                Type = Enum.Parse<Hl7.Fhir.Model.SearchParamType>(searchParamType.ToString()),
+            }.ToInfo();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
@@ -76,6 +76,31 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         }
 
         [Fact]
+        public async Task GivenSearchingWithQueryParameterExpander_WhenSearched_ThenExpandedQueryParametersAreUsed()
+        {
+            const string resourceType = "Medication";
+            var queryParameters = new[] { Tuple.Create("code:in", "http://example.org/fhir/ValueSet/medications") };
+            var expandedQueryParameters = new[] { Tuple.Create("code", "http://example.org/system|code") };
+            var queryParameterExpander = Substitute.For<ISearchParameterQueryParameterExpander>();
+            queryParameterExpander.ExpandAsync(resourceType, queryParameters, Arg.Any<CancellationToken>()).Returns(expandedQueryParameters);
+
+            var searchService = new TestSearchService(_searchOptionsFactory, _fhirDataStore, new[] { queryParameterExpander });
+            var expectedSearchOptions = new SearchOptions();
+            _searchOptionsFactory.Create(resourceType, expandedQueryParameters).Returns(expectedSearchOptions);
+
+            var expectedSearchResult = SearchResult.Empty(_unsupportedQueryParameters);
+            searchService.SearchImplementation = options =>
+            {
+                Assert.Same(expectedSearchOptions, options);
+                return expectedSearchResult;
+            };
+
+            SearchResult actual = await searchService.SearchAsync(resourceType, queryParameters, CancellationToken.None);
+
+            Assert.Same(expectedSearchResult, actual);
+        }
+
+        [Fact]
         public async Task GivenCompartmentSearching_WhenSearched_ThenCorrectOptionIsUsedAndCorrectSearchResultsReturned()
         {
             const string compartmentType = "Patient";
@@ -198,6 +223,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             public TestSearchService(ISearchOptionsFactory searchOptionsFactory, IFhirDataStore fhirDataStore)
                 : base(searchOptionsFactory, fhirDataStore, NullLogger.Instance)
+            {
+                SearchImplementation = options => null;
+            }
+
+            public TestSearchService(
+                ISearchOptionsFactory searchOptionsFactory,
+                IFhirDataStore fhirDataStore,
+                IEnumerable<ISearchParameterQueryParameterExpander> queryParameterExpanders)
+                : base(searchOptionsFactory, fhirDataStore, NullLogger.Instance, queryParameterExpanders)
             {
                 SearchImplementation = options => null;
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -127,6 +127,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Expressions\Parsers\SearchValueExpressionBuilderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchExpressionTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchOptionsFactoryTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameterValueSetExpanderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHistoryHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchServiceTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchParameterValueSetExpander.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchParameterValueSetExpander.cs
@@ -1,0 +1,151 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.Models;
+using SearchModifierCode = Microsoft.Health.Fhir.ValueSets.SearchModifierCode;
+using SearchParamType = Microsoft.Health.Fhir.ValueSets.SearchParamType;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    public class SearchParameterValueSetExpander : ISearchParameterQueryParameterExpander
+    {
+        private const string InModifierSuffix = ":in";
+        private const string EmptyValueSetTokenSystem = "urn:microsoft:fhir:search:empty-valueset";
+        private const string EmptyValueSetTokenCode = "__empty_valueset__";
+
+        private readonly ITerminologyServiceProxy _terminologyServiceProxy;
+        private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
+
+        public SearchParameterValueSetExpander(
+            ITerminologyServiceProxy terminologyServiceProxy,
+            ISearchParameterDefinitionManager.SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver)
+        {
+            EnsureArg.IsNotNull(terminologyServiceProxy, nameof(terminologyServiceProxy));
+            EnsureArg.IsNotNull(searchParameterDefinitionManagerResolver, nameof(searchParameterDefinitionManagerResolver));
+
+            _terminologyServiceProxy = terminologyServiceProxy;
+            _searchParameterDefinitionManager = searchParameterDefinitionManagerResolver();
+        }
+
+        public async Task<IReadOnlyList<Tuple<string, string>>> ExpandAsync(
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            CancellationToken cancellationToken)
+        {
+            if (queryParameters == null || queryParameters.Count == 0)
+            {
+                return queryParameters;
+            }
+
+            List<Tuple<string, string>> expandedParameters = null;
+
+            for (int i = 0; i < queryParameters.Count; i++)
+            {
+                Tuple<string, string> queryParameter = queryParameters[i];
+                Tuple<string, string> expandedParameter = await ExpandParameterAsync(resourceType, queryParameter, cancellationToken);
+
+                if (expandedParameter != queryParameter && expandedParameters == null)
+                {
+                    expandedParameters = queryParameters.Take(i).ToList();
+                }
+
+                expandedParameters?.Add(expandedParameter);
+            }
+
+            return expandedParameters ?? queryParameters;
+        }
+
+        private async Task<Tuple<string, string>> ExpandParameterAsync(
+            string resourceType,
+            Tuple<string, string> queryParameter,
+            CancellationToken cancellationToken)
+        {
+            if (queryParameter == null ||
+                string.IsNullOrWhiteSpace(queryParameter.Item1) ||
+                string.IsNullOrWhiteSpace(queryParameter.Item2) ||
+                !queryParameter.Item1.EndsWith(InModifierSuffix, StringComparison.Ordinal))
+            {
+                return queryParameter;
+            }
+
+            string searchParameterCode = queryParameter.Item1.Substring(0, queryParameter.Item1.Length - InModifierSuffix.Length);
+            if (ExpressionParser.ContainsChainOrReverseParameter(searchParameterCode) ||
+                !_searchParameterDefinitionManager.TryGetSearchParameter(resourceType, searchParameterCode, out SearchParameterInfo searchParameter) ||
+                searchParameter.Type != SearchParamType.Token)
+            {
+                return queryParameter;
+            }
+
+            IReadOnlyList<string> valueSetUrls = queryParameter.Item2.SplitByOrSeparator();
+            var tokens = new List<TokenSearchValue>();
+
+            foreach (string valueSetUrl in valueSetUrls)
+            {
+                ValueSet expandedValueSet = await ExpandValueSetAsync(valueSetUrl, cancellationToken);
+                tokens.AddRange(GetTokenSearchValues(expandedValueSet.Expansion?.Contains));
+            }
+
+            string expandedValue = tokens.Count == 0
+                ? new TokenSearchValue(EmptyValueSetTokenSystem, EmptyValueSetTokenCode, null).ToString()
+                : string.Join(",", tokens.Select(token => token.ToString()).Distinct(StringComparer.Ordinal));
+
+            return Tuple.Create(searchParameterCode, expandedValue);
+        }
+
+        private async Task<ValueSet> ExpandValueSetAsync(string valueSetUrl, CancellationToken cancellationToken)
+        {
+            var parameters = new[]
+            {
+                Tuple.Create(TerminologyOperationParameterNames.Expand.Url, valueSetUrl),
+            };
+
+            var resource = await _terminologyServiceProxy.ExpandAsync(parameters, null, cancellationToken);
+
+            if (resource?.ToPoco() is ValueSet valueSet)
+            {
+                return valueSet;
+            }
+
+            throw new InvalidSearchOperationException(
+                string.Format(Core.Resources.ModifierNotSupported, SearchModifierCode.In.GetLiteral(), valueSetUrl));
+        }
+
+        private static IEnumerable<TokenSearchValue> GetTokenSearchValues(IEnumerable<ValueSet.ContainsComponent> contains)
+        {
+            if (contains == null)
+            {
+                yield break;
+            }
+
+            foreach (ValueSet.ContainsComponent component in contains)
+            {
+                if (!string.IsNullOrWhiteSpace(component.Code))
+                {
+                    yield return new TokenSearchValue(component.System, component.Code, null);
+                }
+
+                foreach (TokenSearchValue nestedToken in GetTokenSearchValues(component.Contains))
+                {
+                    yield return nestedToken;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
@@ -90,6 +90,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ServerProvideProfileValidation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Features\Search\RawBundleEntryComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchOptionsFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameterValueSetExpander.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHistoryHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ModelAttributeValidator.cs" />

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceTests.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                 _compressedRawResourceConverter,
                 _queryHashCalculator,
                 _queryPlanReuseChecker,
+                Array.Empty<ISearchParameterQueryParameterExpander>(),
                 NullLogger<SqlServerSearchService>.Instance);
         }
 
@@ -158,6 +159,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                     _compressedRawResourceConverter,
                     _queryHashCalculator,
                     _queryPlanReuseChecker,
+                    Array.Empty<ISearchParameterQueryParameterExpander>(),
                     NullLogger<SqlServerSearchService>.Instance);
             });
 
@@ -206,6 +208,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                     _compressedRawResourceConverter,
                     _queryHashCalculator,
                     _queryPlanReuseChecker,
+                    Array.Empty<ISearchParameterQueryParameterExpander>(),
                     NullLogger<SqlServerSearchService>.Instance);
             });
 
@@ -254,6 +257,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                     _compressedRawResourceConverter,
                     _queryHashCalculator,
                     _queryPlanReuseChecker,
+                    Array.Empty<ISearchParameterQueryParameterExpander>(),
                     NullLogger<SqlServerSearchService>.Instance);
             });
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -108,8 +108,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             ICompressedRawResourceConverter compressedRawResourceConverter,
             ISqlQueryHashCalculator queryHashCalculator,
             IQueryPlanReuseChecker queryPlanReuseChecker,
+            IEnumerable<ISearchParameterQueryParameterExpander> queryParameterExpanders,
             ILogger<SqlServerSearchService> logger)
-            : base(searchOptionsFactory, fhirDataStore, logger)
+            : base(searchOptionsFactory, fhirDataStore, logger, queryParameterExpanders)
         {
             EnsureArg.IsNotNull(sqlRootExpressionRewriter, nameof(sqlRootExpressionRewriter));
             EnsureArg.IsNotNull(chainFlatteningRewriter, nameof(chainFlatteningRewriter));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -294,6 +294,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 cosmosDbPhysicalPartitionInfo,
                 compartmentSearchRewriter,
                 smartCompartmentSearchRewriter,
+                Array.Empty<ISearchParameterQueryParameterExpander>(),
                 NullLogger<FhirCosmosSearchService>.Instance);
 
             await _searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -315,6 +315,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 new CompressedRawResourceConverter(),
                 SqlQueryHashCalculator,
                 queryPlanReuseChecker,
+                Array.Empty<ISearchParameterQueryParameterExpander>(),
                 NullLogger<SqlServerSearchService>.Instance);
 
             ISearchParameterSupportResolver searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();


### PR DESCRIPTION
## Description
Adds support for expanding token search parameters that use the FHIR `:in` modifier, for example:

`GET /Medication?code:in={valueseturl}`

The change introduces a query parameter expansion step before search option parsing. When a token search parameter uses `:in`, the server expands the referenced ValueSet through the terminology service and rewrites the search parameter into equivalent token values. Non-token parameters are left unchanged.

This supports extensional ValueSet scenarios where clients need to retrieve resources whose coded values are members of a ValueSet.

## Related issues
Addresses [#4694](https://github.com/microsoft/fhir-server/issues/4694).
[AB#85030](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85030)

## Testing
Validated locally with focused R4 unit test coverage:

```powershell
dotnet build src\Microsoft.Health.Fhir.R4.Core.UnitTests\Microsoft.Health.Fhir.R4.Core.UnitTests.csproj -f net9.0 --no-restore -m:1
```

```powershell
src\Microsoft.Health.Fhir.R4.Core.UnitTests\bin\Debug\net9.0\Microsoft.Health.Fhir.R4.Core.UnitTests.exe --filter FullyQualifiedName~SearchServiceTests.GivenSearchingWithQueryParameterExpander_WhenSearched_ThenExpandedQueryParametersAreUsed --no-progress
```

Result: passed, 1/1.

```powershell
src\Microsoft.Health.Fhir.R4.Core.UnitTests\bin\Debug\net9.0\Microsoft.Health.Fhir.R4.Core.UnitTests.exe --filter FullyQualifiedName~SearchParameterValueSetExpanderTests --no-progress
```

Result: passed, 2/2.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **New-Feature**
- Tag the PR with **Azure API for FHIR** and **Azure Healthcare APIs** because this changes common search behavior used by CosmosDB and SQL paths.
- Tag the PR with **Schema Version unchanged** because this does not add or update SQL scripts.
- No ADR included; this is a scoped search behavior addition and does not change storage schema or broader system design assumptions.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Feature