### PR TITLE
Add PR review skill, prompt, and repository instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,14 @@ Welcome to the Microsoft FHIR Server! These guidelines help provide relevant, ac
 
 ---
 
+## Pull Request Reviews
+
+- For pull request reviews, use `.github/instructions/pr-review.instructions.md` as the dedicated review workflow.
+- Focus review comments on changed code, merge-blocking correctness risks, FHIR behavior, test coverage, silent failures, and maintainability issues.
+- Do not claim that builds or tests passed unless they were actually run.
+
+---
+
 ## Project Structure
 
 Here's a high-level overview of key directories and their purposes. Consider how each component relates to typical user stories or feature implementations:

--- a/.github/instructions/pr-review.instructions.md
+++ b/.github/instructions/pr-review.instructions.md
@@ -1,0 +1,65 @@
+---
+applyTo: "**"
+---
+
+# PR review instructions
+
+When reviewing pull requests in this repository, use this focused review workflow in addition to the repository-wide Microsoft FHIR Server instructions.
+
+## Review scope
+
+- Review only the pull request diff or the explicitly requested file/range.
+- Prioritize changed behavior over unchanged surrounding code.
+- Do not request broad refactors unless they directly reduce review risk for the changed code.
+- Include file and line references for actionable findings.
+- Do not invent validation results. If a test, build, or command was not run, say so plainly.
+
+## Review facets
+
+### 1. General correctness
+
+- Check for real bugs: incorrect logic, broken FHIR semantics, concurrency issues, null handling mistakes, security regressions, data-loss risks, and backwards-incompatible behavior.
+- Verify changes follow existing architecture boundaries across API, Core, shared components, Cosmos DB, and SQL Server.
+- Confirm new behavior aligns with FHIR standards and existing Microsoft FHIR Server conventions.
+
+### 2. Tests
+
+- Evaluate behavioral coverage, not line coverage.
+- Look for missing tests around critical paths, edge cases, negative cases, async or concurrency behavior, persistence behavior, and FHIR-version-specific behavior.
+- Prefer xUnit tests that use Arrange-Act-Assert and NSubstitute for external dependencies.
+- Request E2E tests only when the change affects externally observable API behavior or integration flows.
+
+### 3. Error handling and silent failures
+
+- Flag catch blocks, fallbacks, default values, retries, or null-handling that could hide failures.
+- Verify errors are surfaced, logged, or propagated according to existing repository patterns.
+- Treat broad catches, empty catches, swallowed exceptions, and success-shaped fallbacks as high-risk unless clearly justified.
+
+### 4. Comments and documentation
+
+- Check that new or changed comments accurately describe the code.
+- Flag comments that restate obvious code, contradict implementation, or are likely to rot.
+- For public API or public members, verify XML documentation expectations from repository instructions.
+
+### 5. Type design
+
+- Review new or changed types for clear invariants, explicit state, and minimal invalid states.
+- Prefer domain-specific types and existing helpers over loosely typed strings, dictionaries, or unnecessary casts.
+- Check that public APIs are understandable without reading implementation internals.
+
+### 6. Simplification
+
+- After correctness, identify unnecessary complexity, duplication, clever control flow, or over-generalized abstractions.
+- Suggest simplifications only when they preserve behavior and reduce maintenance risk.
+
+## Output expectations
+
+Report only findings that matter for merge readiness. Group findings by severity:
+
+- Critical: bugs, security issues, data loss, broken FHIR behavior, or changes likely to fail production.
+- Important: missing required tests, risky error handling, significant maintainability problems, or architecture violations.
+- Minor: low-risk cleanup that would improve clarity.
+- Positive observations: specific strengths in the changed code.
+- Validation notes: commands reviewed or actually run; write "Not run" for anything not executed.
+
+If no high-confidence findings exist, say that the review found no merge-blocking issues and mention the main areas checked.

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,0 +1,49 @@
+---
+mode: 'agent'
+description: 'Review the current pull request or diff using the repository PR review workflow adapted from the PR review toolkit'
+
+---
+
+# PR Review
+
+Review the current pull request, branch diff, or explicitly provided range using `.github/instructions/pr-review.instructions.md`.
+
+## Process
+
+1. Determine the review scope.
+   - If a PR is available, review the PR diff.
+   - If no PR is available, review the current branch diff against the appropriate base branch.
+   - If the user supplied files or a range, review only that scope.
+2. Inspect changed files before commenting.
+3. Apply the review facets from `.github/instructions/pr-review.instructions.md`:
+   - General correctness.
+   - Tests.
+   - Error handling and silent failures.
+   - Comments and documentation.
+   - Type design.
+   - Simplification.
+4. Focus on findings that matter for merge readiness.
+5. Report findings with file and line references when possible.
+
+## Output format
+
+```markdown
+## PR review summary
+
+### Critical
+- [file:line] Finding, impact, and suggested fix.
+
+### Important
+- [file:line] Finding, impact, and suggested fix.
+
+### Minor
+- [file:line] Finding, impact, and suggested fix.
+
+### Positive observations
+- Specific strengths in the changed code.
+
+### Validation notes
+- Commands reviewed or run. Say "Not run" for anything not executed.
+```
+
+If no high-confidence issues are found, say that no merge-blocking issues were found and summarize which review facets were checked.

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ ipch/
 # Visual Studio Code C# Dev Kit cache files
 *.lscache
 
+# Local git worktrees
+.worktrees/
+
 # TFS 2012 Local Workspace
 $tf/
 


### PR DESCRIPTION
## Summary

Adapts the upstream PR review toolkit concept for GitHub Copilot in this repository.

- **.github/instructions/pr-review.instructions.md** (`applyTo: "**"`): a focused PR review workflow for Copilot code review and the cloud agent, covering general correctness, tests, error handling / silent failures, comments & docs, type design, and simplification, with severity-grouped output.
- **.github/copilot-instructions.md**: a short `Pull Request Reviews` section pointing reviews at the dedicated instruction file.
- **.github/prompts/pr-review.prompt.md**: a reusable manual `mode: agent` prompt for on-demand PR/diff reviews.
- **.gitignore**: ignore the local `.worktrees/` directory.

A matching local Copilot CLI skill (`~/.copilot/skills/pr-review`) was also created outside the repo and is not part of this PR.

## Why

Lets PR review requests — including Copilot code review in the web — follow a consistent, high-signal review workflow tuned for the FHIR server.

## Testing

Documentation/instructions only; no product code changes. Verified file presence, frontmatter, and a clean placeholder scan. Not run: build/tests (not applicable).