### PR TITLE
Enable MTP Test Retry in Pipelines

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -81,6 +81,8 @@ stages:
       name: '$(DefaultWindowsPool)'
       demands:
         - ImageOverride -equals $(DefaultWindowsImage)
+    variables:
+      AllowPtrToDetectTestRunRetryFiles: true
     steps:
     - template: ./jobs/build.yml
       parameters:
@@ -91,6 +93,8 @@ stages:
     pool:
       name: '$(DefaultLinuxPool)'
       vmImage: '$(LinuxVmImage)'
+    variables:
+      AllowPtrToDetectTestRunRetryFiles: true
     steps:
     - template: ./jobs/build.yml
       parameters:

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -35,7 +35,7 @@ steps:
     inputs:
       command: test
       projects: '**/*UnitTests/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --no-build -f ${{parameters.targetBuildFramework}} -- --retry-failed-tests 3'
+      arguments: '--configuration $(buildConfiguration) --no-build -f ${{parameters.targetBuildFramework}} -- --retry-failed-tests 3 --report-trx'
       testRunTitle: 'Unit Tests'
 
 - ${{ if eq(parameters.codeCoverage, 'true') }}:

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -93,6 +93,5 @@ steps:
       testResultsFiles: '$(Agent.TempDirectory)/testresults/**/*.trx'
       mergeTestResults: true
       testRunTitle: '${{ parameters.version }} ${{parameters.appServiceType}}${{ parameters.testRunTitleSuffix }}'
-      # TODO: Re-enable when https://github.com/microsoft/testfx/issues/7167 is fixed
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
     condition: succeededOrFailed()

--- a/build/jobs/run-cosmos-tests.yml
+++ b/build/jobs/run-cosmos-tests.yml
@@ -18,6 +18,8 @@ jobs:
   pool:
     name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
+  variables:
+    AllowPtrToDetectTestRunRetryFiles: true
   steps:
   - checkout: self
     fetchDepth: 1
@@ -92,8 +94,7 @@ jobs:
       testResultsFiles: '$(Agent.TempDirectory)/coverage/**/*.trx'
       mergeTestResults: true
       testRunTitle: '${{ parameters.version }} Cosmos Integration Tests'
-      # TODO: Re-enable when https://github.com/microsoft/testfx/issues/7167 is fixed
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
     condition: succeededOrFailed()
 
   - task: reportgenerator@5
@@ -117,6 +118,8 @@ jobs:
   pool:
     name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
+  variables:
+    AllowPtrToDetectTestRunRetryFiles: true
   steps:
   - template: e2e-setup.yml
   - template: e2e-tests.yml
@@ -133,6 +136,8 @@ jobs:
     pool:
       name: '$(SharedLinuxPool)'
       vmImage: '$(LinuxVmImage)'
+    variables:
+      AllowPtrToDetectTestRunRetryFiles: true
     steps:
     - template: e2e-setup.yml
     - template: e2e-tests.yml

--- a/build/jobs/run-cosmos-tests.yml
+++ b/build/jobs/run-cosmos-tests.yml
@@ -77,6 +77,9 @@ jobs:
       projects: '$(Pipeline.Workspace)/source/test/**/*${{ parameters.version }}.Tests.Integration.csproj'
       arguments: '--configuration $(buildConfiguration) --no-build -f $(defaultBuildFramework) -- --filter "FullyQualifiedName!~SqlServer" --retry-failed-tests 3 --coverage --coverage-output-format cobertura --coverage-settings "$(System.DefaultWorkingDirectory)/CodeCoverage.Mtp.settings.xml" --report-trx'
       testRunTitle: '${{ parameters.version }} Cosmos Integration Tests'
+      # Disable the task's built-in (non-retry-aware) result publishing so the
+      # explicit retry-aware PublishTestResults@2 task below is the sole publisher.
+      publishTestResults: false
     env:
       'CosmosDb__Host': $(CosmosDb--Host)
       'FhirServer__ResourceManager__DataStoreResourceId': '$(DataStoreResourceId)'

--- a/build/jobs/run-export-tests.yml
+++ b/build/jobs/run-export-tests.yml
@@ -14,6 +14,8 @@ jobs:
   pool:
     name: '$(DefaultLinuxPool)'
     vmImage: '$(LinuxVmImage)'
+  variables:
+    AllowPtrToDetectTestRunRetryFiles: true
   steps:
   - template: e2e-setup.yml
   - template: e2e-tests-extract.yml
@@ -145,8 +147,7 @@ jobs:
       testResultsFiles: '$(Agent.TempDirectory)/testresults/**/*.trx'
       mergeTestResults: true
       testRunTitle: 'Export ${{ parameters.version }} CosmosDB'
-      # TODO: Re-enable when https://github.com/microsoft/testfx/issues/7167 is fixed
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
     condition: succeededOrFailed()
 
 - job: 'sqlE2eTests'
@@ -154,6 +155,8 @@ jobs:
   pool:
     name: '$(DefaultLinuxPool)'
     vmImage: '$(LinuxVmImage)'
+  variables:
+    AllowPtrToDetectTestRunRetryFiles: true
   steps:
   - template: e2e-setup.yml
   - template: e2e-tests-extract.yml
@@ -285,7 +288,6 @@ jobs:
       testResultsFiles: '$(Agent.TempDirectory)/testresults/**/*.trx'
       mergeTestResults: true
       testRunTitle: 'Export ${{ parameters.version }} SQL'
-      # TODO: Re-enable when https://github.com/microsoft/testfx/issues/7167 is fixed
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
     condition: succeededOrFailed()
       

--- a/build/jobs/run-sql-tests.yml
+++ b/build/jobs/run-sql-tests.yml
@@ -23,6 +23,8 @@ jobs:
   pool:
     name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
+  variables:
+    AllowPtrToDetectTestRunRetryFiles: true
   steps:
   - checkout: self
     fetchDepth: 1
@@ -82,8 +84,7 @@ jobs:
       testResultsFiles: '$(Agent.TempDirectory)/coverage/**/*.trx'
       mergeTestResults: true
       testRunTitle: '${{ parameters.version }} SQL Integration Tests'
-      # TODO: Re-enable when https://github.com/microsoft/testfx/issues/7167 is fixed
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
     condition: succeededOrFailed()
 
   - task: reportgenerator@5
@@ -107,6 +108,8 @@ jobs:
   pool:
     name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
+  variables:
+    AllowPtrToDetectTestRunRetryFiles: true
   steps:
   - template: e2e-setup.yml
   - template: e2e-tests.yml
@@ -123,6 +126,8 @@ jobs:
     pool:
       name: '$(SharedLinuxPool)'
       vmImage: '$(LinuxVmImage)'
+    variables:
+      AllowPtrToDetectTestRunRetryFiles: true
     steps:
     - template: e2e-setup.yml
     - template: e2e-tests.yml
@@ -140,6 +145,8 @@ jobs:
     pool:
       name: '$(SharedLinuxPool)'
       vmImage: '$(LinuxVmImage)'
+    variables:
+      AllowPtrToDetectTestRunRetryFiles: true
     steps:
     - template: e2e-setup.yml
     - template: e2e-tests.yml

--- a/build/jobs/run-sql-tests.yml
+++ b/build/jobs/run-sql-tests.yml
@@ -69,6 +69,9 @@ jobs:
       projects: '$(Pipeline.Workspace)/source/test/**/*${{ parameters.version }}.Tests.Integration.csproj'
       arguments: '--configuration $(buildConfiguration) --no-build -f $(defaultBuildFramework) -- --filter "FullyQualifiedName!~CosmosDb" --retry-failed-tests 3 --coverage --coverage-output-format cobertura --coverage-settings "$(System.DefaultWorkingDirectory)/CodeCoverage.Mtp.settings.xml" --report-trx'
       testRunTitle: '${{ parameters.version }} SQL Integration Tests'
+      # Disable the task's built-in (non-retry-aware) result publishing so the
+      # explicit retry-aware PublishTestResults@2 task below is the sole publisher.
+      publishTestResults: false
     env:
       'SqlServer:ConnectionString': 'Server=tcp:${{ parameters.integrationSqlServerName }}.database.windows.net,1433;Initial Catalog=master;Persist Security Info=False;Authentication=ActiveDirectoryWorkloadIdentity;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;User Id=$(AZURESUBSCRIPTION_CLIENT_ID);'
       platformOptions__resultDirectory: '$(Agent.TempDirectory)/coverage'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -42,6 +42,8 @@ stages:
       name: '$(DefaultWindowsPool)'
       demands:
         - ImageOverride -equals $(DefaultWindowsImage)
+    variables:
+      AllowPtrToDetectTestRunRetryFiles: true
     steps:
     - template: ./jobs/build.yml
       parameters:
@@ -52,6 +54,8 @@ stages:
     pool:
       name: '$(DefaultLinuxPool)'
       vmImage: '$(LinuxVmImage)'
+    variables:
+      AllowPtrToDetectTestRunRetryFiles: true
     steps:
     - template: ./jobs/build.yml
       parameters:


### PR DESCRIPTION
## Description

Enables the [Microsoft Testing Platform Azure retry feature](https://devblogs.microsoft.com/dotnet/microsoft-testing-platform-azure-retry/) on all test jobs, now that Linux support has been fixed in the upstream Azure Pipelines infrastructure

[AB#194340](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/194340)

## Testing
You can now see tests as "Passed on Rerun" in Azure DevOps
<img width="2550" height="1488" alt="CleanShot 2026-06-01 at 08 26 05@2x" src="https://github.com/user-attachments/assets/be012c8f-f33a-4a3d-bf86-239d5415fb3b" />

