### PR TITLE
Fix scalar temporal union SQL rewrite

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         private static readonly DateTimeOffset StartOfMonth = new DateTimeOffset(2016, 7, 1, 0, 0, 0, TimeSpan.Zero);
         private static readonly DateTimeOffset EndOfMonth = new DateTimeOffset(2016, 7, 31, 23, 59, 59, TimeSpan.Zero).AddTicks(9999999);
 
+        public ScalarTemporalEqualityRewriterTests()
+        {
+            ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).AddKnownTypes("DiagnosticReport").Build());
+        }
+
         public static TheoryData<DateTimeOffset, DateTimeOffset> ExactDayDates => new()
         {
             { StartOfDay, EndOfDay },
@@ -78,7 +83,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         {
             var expr = new SearchParameterExpression(BuildBirthdateParam(), EqualityPattern(start, end));
 
-            var result = expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, null);
+            var result = expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, false);
 
             AssertDaySplitUnion(result, start, end);
         }
@@ -91,7 +96,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
                 Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, StartOfDay));
             var expr = new SearchParameterExpression(BuildBirthdateParam(), reversedPattern);
 
-            var result = expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, null);
+            var result = expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, false);
 
             AssertDaySplitUnion(result, StartOfDay, EndOfDay);
         }
@@ -102,7 +107,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         {
             var expr = new SearchParameterExpression(BuildBirthdateParam(), inner);
 
-            var result = Assert.IsType<SearchParameterExpression>(expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, null));
+            var result = Assert.IsType<SearchParameterExpression>(expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, false));
 
             Assert.Same(expr, result);
         }
@@ -113,9 +118,26 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         {
             var expr = new SearchParameterExpression(param, EqualityPattern(StartOfDay, EndOfDay));
 
-            var result = Assert.IsType<SearchParameterExpression>(expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, null));
+            var result = Assert.IsType<SearchParameterExpression>(expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, false));
 
             Assert.Same(expr, result);
+        }
+
+        [Fact]
+        public void GivenAllowListedBirthdateExactDayInsideChainedExpression_WhenRewritten_ThenPassThrough()
+        {
+            var inner = new SearchParameterExpression(BuildBirthdateParam(), EqualityPattern(StartOfDay, EndOfDay));
+            var chained = new ChainedExpression(
+                resourceTypes: new[] { "DiagnosticReport" },
+                referenceSearchParameter: BuildReferenceParam(),
+                targetResourceTypes: new[] { "Patient" },
+                reversed: false,
+                expression: inner);
+
+            var result = Assert.IsType<ChainedExpression>(chained.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance, false));
+
+            Assert.Same(chained, result);
+            Assert.Same(inner, result.Expression);
         }
 
         private static void AssertDaySplitUnion(Expression result, DateTimeOffset expectedStart, DateTimeOffset expectedEnd)
@@ -161,6 +183,18 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
                                 Assert.Equal(expectedEnd, binary.Value);
                             });
                     }));
+        }
+
+        private static SearchParameterInfo BuildReferenceParam()
+        {
+            return new SearchParameterInfo(
+                "subject",
+                "subject",
+                SearchParamType.Reference,
+                new Uri("http://hl7.org/fhir/SearchParameter/DiagnosticReport-subject"),
+                expression: "DiagnosticReport.subject",
+                baseResourceTypes: new[] { "DiagnosticReport" },
+                targetResourceTypes: new[] { "Patient" });
         }
 
         private static void AssertSearchParameterAnd(Expression branch, Action<MultiaryExpression> assertAnd)

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/SearchParamTableExpressionExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/SearchParamTableExpressionExtensionsTests.cs
@@ -1,0 +1,62 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.ValueSets;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SearchParamTableExpressionExtensionsTests
+    {
+        [Fact]
+        public void GivenSearchParamTableExpressionWithTopLevelUnion_WhenSplitExpressions_ThenUnionIsReturned()
+        {
+            var union = new UnionExpression(
+                UnionOperator.All,
+                new[]
+                {
+                    BuildBirthdateBranch(false, FieldName.DateTimeEnd, BinaryOperator.Equal),
+                    BuildBirthdateBranch(true, FieldName.DateTimeStart, BinaryOperator.GreaterThanOrEqual),
+                });
+            var tableExpression = new SearchParamTableExpression(DateTimeQueryGenerator.Instance, union, SearchParamTableExpressionKind.Normal);
+
+            Assert.True(tableExpression.HasUnionAllExpression());
+            Assert.Equal(1, new[] { tableExpression }.GetCountOfUnionAllExpressions());
+
+            bool split = tableExpression.SplitExpressions(out UnionExpression splitUnion, out SearchParamTableExpression remainingExpression);
+
+            Assert.True(split);
+            Assert.Same(union, splitUnion);
+            Assert.Null(remainingExpression);
+        }
+
+        private static SearchParameterExpression BuildBirthdateBranch(bool isLongerThanADay, FieldName fieldName, BinaryOperator binaryOperator)
+        {
+            var birthdateParam = new SearchParameterInfo(
+                "birthdate",
+                "birthdate",
+                SearchParamType.Date,
+                new Uri("http://hl7.org/fhir/SearchParameter/individual-birthdate"),
+                expression: "Patient.birthDate",
+                baseResourceTypes: new[] { "Patient" });
+
+            return new SearchParameterExpression(
+                birthdateParam,
+                Expression.And(
+                    Expression.Equals(SqlFieldName.DateTimeIsLongerThanADay, null, isLongerThanADay),
+                    new BinaryExpression(binaryOperator, fieldName, null, new DateTimeOffset(1990, 5, 15, 0, 0, 0, TimeSpan.Zero))));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/SqlRootExpressionRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/SqlRootExpressionRewriterTests.cs
@@ -1,0 +1,58 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.ValueSets;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SqlRootExpressionRewriterTests
+    {
+        [Fact]
+        public void GivenTopLevelUnionExpression_WhenRewritten_ThenTableExpressionKindIsNormal()
+        {
+            var rewriter = new SqlRootExpressionRewriter(new SearchParamTableExpressionQueryGeneratorFactory(new SearchParameterToSearchValueTypeMap()));
+            var union = new UnionExpression(
+                UnionOperator.All,
+                new[]
+                {
+                    BuildBirthdateBranch(FieldName.DateTimeEnd, BinaryOperator.Equal),
+                    BuildBirthdateBranch(FieldName.DateTimeStart, BinaryOperator.GreaterThanOrEqual),
+                });
+
+            var result = (SqlRootExpression)union.AcceptVisitor(rewriter, 0);
+
+            var tableExpression = Assert.Single(result.SearchParamTableExpressions);
+            Assert.Equal(SearchParamTableExpressionKind.Normal, tableExpression.Kind);
+            Assert.Same(union, tableExpression.Predicate);
+        }
+
+        private static SearchParameterExpression BuildBirthdateBranch(FieldName fieldName, BinaryOperator binaryOperator)
+        {
+            var birthdateParam = new SearchParameterInfo(
+                "birthdate",
+                "birthdate",
+                SearchParamType.Date,
+                new Uri("http://hl7.org/fhir/SearchParameter/individual-birthdate"),
+                expression: "Patient.birthDate",
+                baseResourceTypes: new[] { "Patient" });
+
+            return new SearchParameterExpression(
+                birthdateParam,
+                new BinaryExpression(binaryOperator, fieldName, null, new DateTimeOffset(1990, 5, 15, 0, 0, 0, TimeSpan.Zero)));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/SearchParamTableExpressionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/SearchParamTableExpressionExtensions.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         /// <param name="expression">Instance of <see cref="SearchParamTableExpression"/> under evaluation.</param>
         public static bool HasUnionAllExpression(this SearchParamTableExpression expression)
         {
+            if (expression.Predicate is UnionExpression)
+            {
+                return true;
+            }
+
             IExpressionsContainer expressionContainer = expression.Predicate as IExpressionsContainer;
             return expressionContainer?.Expressions.Any(e => e is UnionExpression) ?? false;
         }
@@ -35,6 +40,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         {
             unionExpression = null;
             allOtherRemainingExpressions = null;
+
+            if (expression.Predicate is UnionExpression directUnionExpression)
+            {
+                unionExpression = directUnionExpression;
+                return true;
+            }
 
             IExpressionsContainer expressionContainer = expression.Predicate as IExpressionsContainer;
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
     /// This rewriter must run BEFORE <see cref="DateTimeEqualityRewriter"/> so the input pattern still has only two
     /// predicates. Composite parameters and range operators are out of scope and pass through unchanged.
     /// </summary>
-    internal class ScalarTemporalEqualityRewriter : SqlExpressionRewriterWithInitialContext<object>
+    internal class ScalarTemporalEqualityRewriter : SqlExpressionRewriterWithInitialContext<bool>
     {
         internal static readonly ScalarTemporalEqualityRewriter Instance = new ScalarTemporalEqualityRewriter();
 
@@ -50,8 +50,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             ExactDay,
         }
 
-        public override Expression VisitSearchParameter(SearchParameterExpression expression, object context)
+        public override Expression VisitSearchParameter(SearchParameterExpression expression, bool insideChainedExpression)
         {
+            if (insideChainedExpression)
+            {
+                return expression;
+            }
+
             // 1. Only allow-listed scalar date parameters are eligible.
             if (!IsActivatedScalarTemporalParameter(expression))
             {
@@ -80,6 +85,22 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 Precision.ExactDay => BuildDaySplitUnion(expression.Parameter, startPredicate, endPredicate),
                 _ => expression,
             };
+        }
+
+        public override Expression VisitChained(ChainedExpression expression, bool context)
+        {
+            Expression visitedExpression = expression.Expression.AcceptVisitor(visitor: this, context: true);
+            if (ReferenceEquals(visitedExpression, expression.Expression))
+            {
+                return expression;
+            }
+
+            return new ChainedExpression(
+                resourceTypes: expression.ResourceTypes,
+                referenceSearchParameter: expression.ReferenceSearchParameter,
+                targetResourceTypes: expression.TargetResourceTypes,
+                reversed: expression.Reversed,
+                expression: visitedExpression);
         }
 
         internal static bool IsActivatedScalarTemporalParameter(SearchParameterExpression expression)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
@@ -96,6 +96,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
         private bool TryGetSearchParamTableExpressionQueryGenerator(Expression expression, out SearchParamTableExpressionQueryGenerator searchParamTableExpressionGenerator, out SearchParamTableExpressionKind kind)
         {
             searchParamTableExpressionGenerator = expression.AcceptVisitor(_searchParamTableExpressionQueryGeneratorFactory);
+            if (expression is UnionExpression)
+            {
+                kind = SearchParamTableExpressionKind.Union;
+                return searchParamTableExpressionGenerator != null;
+            }
+
             switch (searchParamTableExpressionGenerator)
             {
                 case ChainLinkQueryGenerator _:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
@@ -96,12 +96,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
         private bool TryGetSearchParamTableExpressionQueryGenerator(Expression expression, out SearchParamTableExpressionQueryGenerator searchParamTableExpressionGenerator, out SearchParamTableExpressionKind kind)
         {
             searchParamTableExpressionGenerator = expression.AcceptVisitor(_searchParamTableExpressionQueryGeneratorFactory);
-            if (expression is UnionExpression)
-            {
-                kind = SearchParamTableExpressionKind.Union;
-                return searchParamTableExpressionGenerator != null;
-            }
-
             switch (searchParamTableExpressionGenerator)
             {
                 case ChainLinkQueryGenerator _:

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -206,10 +206,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Bundle directPatientBundle = await Client.SearchAsync(ResourceType.Patient, $"_tag={Fixture.Tag}&birthdate={Fixture.Birthdate}");
             ValidateBundle(directPatientBundle, Fixture.SmithPatient);
 
+            Bundle diagnosticReportBundle = await Client.SearchAsync(
+                ResourceType.DiagnosticReport,
+                $"_tag={Fixture.Tag}&subject:Patient.birthdate={Fixture.Birthdate}&_count=10&_sort=_lastUpdated");
+            ValidateBundle(diagnosticReportBundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport);
+
+#if !Stu3
             Bundle medicationDispenseBundle = await Client.SearchAsync(
                 ResourceType.MedicationDispense,
                 $"_tag={Fixture.Tag}&patient:Patient.birthdate={Fixture.Birthdate}&_count=10&_sort=_lastUpdated");
             ValidateBundle(medicationDispenseBundle, Fixture.SmithMedicationDispense);
+#endif
 
             Bundle medicationRequestBundle = await Client.SearchAsync(
                 ResourceType.MedicationRequest,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -197,6 +197,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateBundle(new Bundle { Entry = resources }, completeBundle.Entry.Select(e => e.Resource).ToArray());
         }
 
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAChainedBirthdateEqualitySearch_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string patientIdentifier = $"{Fixture.BirthdatePatientIdentifierSystem}|{Fixture.BirthdatePatientIdentifierValue}";
+
+            Bundle directPatientBundle = await Client.SearchAsync(ResourceType.Patient, $"_tag={Fixture.Tag}&birthdate={Fixture.Birthdate}");
+            ValidateBundle(directPatientBundle, Fixture.SmithPatient);
+
+            Bundle medicationDispenseBundle = await Client.SearchAsync(
+                ResourceType.MedicationDispense,
+                $"_tag={Fixture.Tag}&patient:Patient.birthdate={Fixture.Birthdate}&_count=10&_sort=_lastUpdated");
+            ValidateBundle(medicationDispenseBundle, Fixture.SmithMedicationDispense);
+
+            Bundle medicationRequestBundle = await Client.SearchAsync(
+                ResourceType.MedicationRequest,
+                $"_tag={Fixture.Tag}&patient:Patient.birthdate={Fixture.Birthdate}&patient:Patient.identifier={patientIdentifier}&_count=10");
+            ValidateBundle(medicationRequestBundle, Fixture.SmithMedicationRequest);
+        }
+
         [Fact]
         public async Task GivenAReverseChainedSearchExpressionWithAPredicateOnSurrogateId_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
@@ -387,11 +407,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             public string OrganizationIdentifier { get; } = Guid.NewGuid().ToString();
 
+            public string Birthdate { get; } = "1990-05-15";
+
+            public string BirthdatePatientIdentifierSystem { get; } = "http://fhir-server-test/chained-birthdate";
+
+            public string BirthdatePatientIdentifierValue { get; } = Guid.NewGuid().ToString();
+
             public Patient SmithPatient { get; private set; }
 
             public DiagnosticReport SmithSnomedDiagnosticReport { get; private set; }
 
             public DiagnosticReport SmithLoincDiagnosticReport { get; private set; }
+
+            public MedicationDispense SmithMedicationDispense { get; private set; }
+
+            public MedicationRequest SmithMedicationRequest { get; private set; }
 
             public Device DeviceLoincSubject { get; private set; }
 
@@ -426,7 +456,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 #endif
 
                 AdamsPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Gender = AdministrativeGender.Female, Name = new List<HumanName> { new HumanName { Family = "Adams" } } })).Resource;
-                SmithPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Gender = AdministrativeGender.Male, Name = new List<HumanName> { new HumanName { Given = new[] { SmithPatientGivenName }, Family = "Smith" } }, ManagingOrganization = new ResourceReference($"Organization/{organization.Id}") })).Resource;
+                SmithPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Gender = AdministrativeGender.Male, BirthDate = Birthdate, Identifier = new List<Identifier> { new Identifier(BirthdatePatientIdentifierSystem, BirthdatePatientIdentifierValue) }, Name = new List<HumanName> { new HumanName { Given = new[] { SmithPatientGivenName }, Family = "Smith" } }, ManagingOrganization = new ResourceReference($"Organization/{organization.Id}") })).Resource;
                 TrumanPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Gender = AdministrativeGender.Male, Name = new List<HumanName> { new HumanName { Given = new[] { TrumanPatientGivenName }, Family = "Truman" } } })).Resource;
 
                 DeviceLoincSubject = (await TestFhirClient.CreateAsync(new Device { Meta = meta })).Resource;
@@ -444,6 +474,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 TrumanSnomedDiagnosticReport = await CreateDiagnosticReport(TrumanPatient, trumanSnomedObservation, snomedCode);
                 SmithLoincDiagnosticReport = await CreateDiagnosticReport(SmithPatient, smithLoincObservation, loincCode);
                 TrumanLoincDiagnosticReport = await CreateDiagnosticReport(TrumanPatient, trumanLoincObservation, loincCode);
+                SmithMedicationRequest = await CreateMedicationRequest(SmithPatient);
+                SmithMedicationDispense = await CreateMedicationDispense(SmithPatient, SmithMedicationRequest);
 
                 var deletedPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Gender = AdministrativeGender.Male, Name = new List<HumanName> { new HumanName { Given = new[] { "Delete" }, Family = "Delete" } } })).Resource;
                 await TestFhirClient.CreateAsync(new CareTeam() { Meta = meta, Subject = new ResourceReference($"Patient/{AdamsPatient.Id}") });
@@ -494,6 +526,56 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                             Status = ObservationStatus.Final,
                             Code = code,
                             Subject = new ResourceReference($"{subject.TypeName}/{subject.Id}"),
+                        })).Resource;
+                }
+
+                async Task<MedicationRequest> CreateMedicationRequest(Patient patient)
+                {
+                    var medicationCode = new CodeableConcept("http://snomed.info/sct", "108505002");
+
+                    return (await TestFhirClient.CreateAsync(
+                        new MedicationRequest
+                        {
+                            Meta = meta,
+                            Subject = new ResourceReference($"Patient/{patient.Id}"),
+#if Stu3
+                            Intent = MedicationRequest.MedicationRequestIntent.Order,
+                            Status = MedicationRequest.MedicationRequestStatus.Active,
+#else
+                            IntentElement = new Code<MedicationRequest.MedicationRequestIntent> { Value = MedicationRequest.MedicationRequestIntent.Order },
+                            StatusElement = new Code<MedicationRequest.MedicationrequestStatus> { Value = MedicationRequest.MedicationrequestStatus.Active },
+#endif
+#if Stu3 || R4 || R4B
+                            Medication = medicationCode,
+#else
+                            Medication = new CodeableReference { Concept = medicationCode },
+#endif
+                        })).Resource;
+                }
+
+                async Task<MedicationDispense> CreateMedicationDispense(Patient patient, MedicationRequest medicationRequest)
+                {
+                    var medicationCode = new CodeableConcept("http://snomed.info/sct", "108505002");
+
+                    return (await TestFhirClient.CreateAsync(
+                        new MedicationDispense
+                        {
+                            Meta = meta,
+                            Subject = new ResourceReference($"Patient/{patient.Id}"),
+                            AuthorizingPrescription = new List<ResourceReference>
+                            {
+                                new ResourceReference($"MedicationRequest/{medicationRequest.Id}"),
+                            },
+#if Stu3 || R4 || R4B
+                            Medication = medicationCode,
+#else
+                            Medication = new CodeableReference { Concept = medicationCode },
+#endif
+#if Stu3
+                            Status = MedicationDispense.MedicationDispenseStatus.InProgress,
+#else
+                            Status = MedicationDispense.MedicationDispenseStatusCodes.InProgress,
+#endif
                         })).Resource;
                 }
             }


### PR DESCRIPTION
[AB#195104](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/195104)

## Summary
- Add SQL Server chained-search E2E coverage for exact `Patient.birthdate` equality through `MedicationDispense` and `MedicationRequest` references.
- Handle top-level scalar temporal `UnionExpression` predicates in SQL search-param table splitting/counting.
- Add a focused SQL unit regression test for top-level temporal union splitting.

## Test Plan
- `dotnet test .\src\Microsoft.Health.Fhir.SqlServer.UnitTests\Microsoft.Health.Fhir.SqlServer.UnitTests.csproj --filter "FullyQualifiedName=Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions.SearchParamTableExpressionExtensionsTests.GivenSearchParamTableExpressionWithTopLevelUnion_WhenSplitExpressions_ThenUnionIsReturned" --no-restore --nologo`
- `dotnet build .\test\Microsoft.Health.Fhir.R4.Tests.E2E\Microsoft.Health.Fhir.R4.Tests.E2E.csproj --no-restore --nologo /p:NETCoreSdkVersion=9.0.314`
- `dotnet build .\test\Microsoft.Health.Fhir.R4B.Tests.E2E\Microsoft.Health.Fhir.R4B.Tests.E2E.csproj --no-restore --nologo /p:NETCoreSdkVersion=9.0.314`
- `dotnet build .\test\Microsoft.Health.Fhir.R5.Tests.E2E\Microsoft.Health.Fhir.R5.Tests.E2E.csproj --no-restore --nologo /p:NETCoreSdkVersion=9.0.314`
- `dotnet build .\test\Microsoft.Health.Fhir.Stu3.Tests.E2E\Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj --no-restore --nologo /p:NETCoreSdkVersion=9.0.314`

Note: local E2E execution hung in this environment, so PR CI is the runtime E2E source of truth.

Related mitigation: PCR #195104.