### PR TITLE
Enlist transactions enabled only for Sequential Transactions

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/MergeOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/MergeOptions.cs
@@ -8,18 +8,38 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
     public sealed class MergeOptions
     {
         /// <summary>
-        /// C# transactions are not desired for majority of workloads and, if required, should be set explicitly
+        /// Merge options for SQL operations.
         /// </summary>
-        public MergeOptions(bool enlistTransaction = false, bool ensureAtomicOperations = false)
+        /// <remarks>
+        /// A few combinations for merge options:
+        ///     Standalone POST/PUT/DELETE/PATCH operations:
+        ///     - enlistTransaction = false, isBundleTransaction = false
+        ///     Import:
+        ///     - enlistTransaction = false, isBundleTransaction = false
+        ///     Sequential batches:
+        ///     - enlistTransaction = false, isBundleTransaction = false
+        ///     Sequential transactions (rely on C# transactions):
+        ///     - enlistTransaction = true, isBundleTransaction = true
+        ///     Parallel batches:
+        ///     - enlistTransaction = false, isBundleTransaction = false
+        ///     Parallel transactions (rely on SQL transactions):
+        ///     - enlistTransaction = false, isBundleTransaction = true
+        /// </remarks>
+        public MergeOptions(bool enlistTransaction = false, bool isBundleTransaction = false)
         {
             EnlistInTransaction = enlistTransaction;
-            EnsureAtomicOperations = ensureAtomicOperations;
+            IsBundleTransaction = isBundleTransaction;
         }
 
         public static MergeOptions Default { get; private set; } = new MergeOptions();
 
+        /// <summary>
+        /// Indicates whether to enlist in a C# transaction.
+        /// This should only be set to true for sequential transaction bundles, as they rely on C# transactions.
+        /// Standalone operations and parallel bundle transactions should not enlist transactions, as they should rely on SQL transactions.
+        /// </summary>
         public bool EnlistInTransaction { get; private set; }
 
-        public bool EnsureAtomicOperations { get; private set;  }
+        public bool IsBundleTransaction { get; private set;  }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
         private static readonly BundleResourceContextComparer _contextComparer = new BundleResourceContextComparer();
 
         private readonly int _maxExecutionTimeInSeconds;
-        private readonly bool _ensureAtomicOperations = false;
+        private readonly bool _isBundleTransaction = false;
 
         /// <summary>
         /// List of resource to be sent to the data layer.
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
             _dataStore = null;
 
             _maxExecutionTimeInSeconds = maxExecutionTimeInSeconds;
-            _ensureAtomicOperations = type == BundleOrchestratorOperationType.Transaction;
+            _isBundleTransaction = type == BundleOrchestratorOperationType.Transaction;
         }
 
         public Guid Id { get; private set; }
@@ -399,8 +399,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
 
                     // Bundle Orchestrator operations will not enlist to C# transactions.
                     // The database will be responsible for handling it internally.
-                    // For Transaction, atomicity will be ensured based on the 'ensureAtomicOperations' flag.
-                    MergeOptions mergeOptions = new MergeOptions(enlistTransaction: false, ensureAtomicOperations: _ensureAtomicOperations);
+                    // For Transaction, atomicity will be ensured based on the 'isBundleTransaction' flag.
+                    MergeOptions mergeOptions = new MergeOptions(enlistTransaction: false, isBundleTransaction: _isBundleTransaction);
 
                     // 2 - Merge all resources in the database.
                     MergeOutcome mergeOutcome = await _dataStore.MergeAsync(_resources.Values.ToList(), mergeOptions, cancellationToken);

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
             // Act & Assert
             await Assert.ThrowsAsync<ResourceConflictException>(
-                () => dataStore.MergeAsync(resources, new MergeOptions(enlistTransaction: true, ensureAtomicOperations: true), cts.Token));
+                () => dataStore.MergeAsync(resources, new MergeOptions(enlistTransaction: true, isBundleTransaction: true), cts.Token));
 
             await sqlRetryService.DidNotReceive()
                 .TryLogEvent("MergeAsync", "Warn", Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
@@ -270,7 +270,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
             // Act & Assert
             await Assert.ThrowsAsync<TaskCanceledException>(
-                () => dataStore.MergeAsync(resources, new MergeOptions(enlistTransaction: true, ensureAtomicOperations: false), cts.Token));
+                () => dataStore.MergeAsync(resources, new MergeOptions(enlistTransaction: true, isBundleTransaction: false), cts.Token));
 
             await sqlRetryService.Received(1)
                 .TryLogEvent("MergeAsync", "Warn", Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         mergeOptions.EnlistInTransaction,
                         retries == 0,
                         eventualConsistency: false,
-                        ensureAtomicOperations: mergeOptions.EnsureAtomicOperations,
+                        isBundleTransaction: mergeOptions.IsBundleTransaction,
                         cancellationToken); // TODO: Pass correct retries value once we start supporting retries
                     return results;
                 }
@@ -227,7 +227,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
         }
 
-        private async Task<MergeOutcome> MergeInternalAsync(IReadOnlyList<ResourceWrapperOperation> resources, bool keepLastUpdated, bool keepAllDeleted, bool enlistInTransaction, bool useReplicasForReads, bool eventualConsistency, bool ensureAtomicOperations, CancellationToken cancellationToken)
+        private async Task<MergeOutcome> MergeInternalAsync(IReadOnlyList<ResourceWrapperOperation> resources, bool keepLastUpdated, bool keepAllDeleted, bool enlistInTransaction, bool useReplicasForReads, bool eventualConsistency, bool isBundleTransaction, CancellationToken cancellationToken)
         {
             var results = new Dictionary<DataStoreOperationIdentifier, DataStoreOperationOutcome>();
             if (resources == null || resources.Count == 0)
@@ -412,9 +412,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 results.Add(resourceExt.GetIdentifier(), new DataStoreOperationOutcome(new UpsertOutcome(resource, resource.Version == InitialVersion ? SaveOutcomeType.Created : SaveOutcomeType.Updated)));
             }
 
-            // In case the operation is atomic and there are validation errors, then nothing should be persisted at the database.
+            // In case the operation is atomic (i.e., bundle transaction) and there are validation errors, then nothing should be persisted at the database.
             // Instead, the errors should be reported and ensure the operation is atomic.
-            if (ensureAtomicOperations && results.Where(r => !r.Value.IsOperationSuccessful).Any())
+            if (isBundleTransaction && results.Where(r => !r.Value.IsOperationSuccessful).Any())
             {
                 return new MergeOutcome(MergeOutcomeFinalState.CompletedWithFailures, results);
             }
@@ -876,6 +876,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 resource.BundleResourceContext != null &&
                 resource.BundleResourceContext.IsTransactionalBundle;
 
+            // For non-transaction operations, extract pending statuses now so they are merged with the resource.
+            // Transaction bundles never reach this branch with pending statuses: any transaction bundle that
+            // contains a SearchParameter resource is forced to the parallel path (handled above), where the
+            // statuses ride along with the resource through dbo.MergeResourcesAndSearchParams.
+            if (!isBundleTransaction)
+            {
+                SetAndClearPendingSearchParameterStatus(resource);
+            }
+
             if (isBundleParallelOperation)
             {
                 // Parallel operations:
@@ -890,21 +899,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             {
                 // Sequential operations:
                 // - EnlistTransaction: set to true only in sequential transaction bundles (as they rely on C# transactions).
-                // - Standalone operations should not enlist transactions (as they should rely on SQL transactions).
+                // - Standalone operations should not enlist transactions (as they rely on SQL transactions).
                 bool enlistTransaction = isBundleTransaction;
 
-                // For non-transaction operations, extract pending statuses now so they are merged with the resource.
-                // Transaction bundles never reach this branch with pending statuses: any transaction bundle that
-                // contains a SearchParameter resource is forced to the parallel path (handled above), where the
-                // statuses ride along with the resource through dbo.MergeResourcesAndSearchParams.
-                if (!isBundleTransaction)
-                {
-                    SetAndClearPendingSearchParameterStatus(resource);
-                }
-
                 MergeOptions mergeOptions = new MergeOptions(
-                    enlistTransaction: enlistTransaction,
-                    ensureAtomicOperations: isBundleTransaction);
+                    enlistTransaction: isBundleTransaction,
+                    isBundleTransaction: isBundleTransaction);
                 var mergeOutcome = await MergeAsync(new[] { resource }, mergeOptions, cancellationToken);
                 DataStoreOperationOutcome dataStoreOperationOutcome = mergeOutcome.Results.First().Value;
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -885,6 +885,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
             else
             {
+                // For non-parallel bundle operations:
+                // - EnlistTransaction is set to true only in sequential transaction bundles (as they rely on C# transactions).
+                // - Standalone operations should not enlist transactions (as they rely on SQL transactions).
+                bool enlistTransaction = isBundleTransaction;
+
                 // For non-transaction operations, extract pending statuses now so they are merged with the resource.
                 // Transaction bundles never reach this branch with pending statuses: any transaction bundle that
                 // contains a SearchParameter resource is forced to the parallel path (handled above), where the
@@ -894,8 +899,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     SetAndClearPendingSearchParameterStatus(resource);
                 }
 
-                // For regular upserts and sequential bundle operations, enlistTransaction is set to true.
-                MergeOptions mergeOptions = new MergeOptions(enlistTransaction: true, ensureAtomicOperations: isBundleTransaction);
+                MergeOptions mergeOptions = new MergeOptions(
+                    enlistTransaction: enlistTransaction,
+                    ensureAtomicOperations: isBundleTransaction);
                 var mergeOutcome = await MergeAsync(new[] { resource }, mergeOptions, cancellationToken);
                 DataStoreOperationOutcome dataStoreOperationOutcome = mergeOutcome.Results.First().Value;
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -878,6 +878,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             if (isBundleParallelOperation)
             {
+                // Parallel operations:
+                // - EnlistTransaction: should be always false, and rely on SQL transactions.
+
                 IBundleOrchestratorOperation bundleOperation = _bundleOrchestrator.GetOperation(resource.BundleResourceContext.BundleOperationId);
                 SetAndClearPendingSearchParameterStatus(resource);
 
@@ -885,9 +888,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
             else
             {
-                // For non-parallel bundle operations:
-                // - EnlistTransaction is set to true only in sequential transaction bundles (as they rely on C# transactions).
-                // - Standalone operations should not enlist transactions (as they rely on SQL transactions).
+                // Sequential operations:
+                // - EnlistTransaction: set to true only in sequential transaction bundles (as they rely on C# transactions).
+                // - Standalone operations should not enlist transactions (as they should rely on SQL transactions).
                 bool enlistTransaction = isBundleTransaction;
 
                 // For non-transaction operations, extract pending statuses now so they are merged with the resource.

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -898,9 +898,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             else
             {
                 // Sequential operations:
-                // - EnlistTransaction: set to true only in sequential transaction bundles (as they rely on C# transactions).
-                // - Standalone operations should not enlist transactions (as they rely on SQL transactions).
-                bool enlistTransaction = isBundleTransaction;
+                // - EnlistTransaction: set to true only in sequential transaction bundles (as they rely on C# transactions). Standalone operations should not enlist transactions (as they rely on SQL transactions).
 
                 MergeOptions mergeOptions = new MergeOptions(
                     enlistTransaction: isBundleTransaction,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -801,7 +801,17 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 
                 {
                     using (ITransactionScope transactionScope = _fixture.TransactionHandler.BeginTransaction())
                     {
-                        SaveOutcome saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
+                        ResourceElement resource = Samples.GetJsonSample("Weight");
+                        UpsertResourceRequest upsertResource = new UpsertResourceRequest(
+                           resource,
+                           new BundleResourceContext(
+                               Bundle.BundleType.Transaction,
+                               BundleProcessingLogic.Sequential,
+                               Bundle.HTTPVerb.PUT,
+                               null,
+                               Guid.Empty));
+
+                        SaveOutcome saveResult = await Mediator.UpsertResourceAsync(upsertResource);
                         createdId = saveResult.RawResourceElement.Id;
 
                         Assert.NotEqual(string.Empty, createdId);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -31,6 +31,7 @@ using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Messages.Create;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
@@ -758,13 +759,27 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+        [Trait(Traits.Category, Categories.BundleTransaction)]
         public async Task GivenATransactionHandler_WhenATransactionIsNotCommitted_ThenNothingShouldBeCreated()
         {
+            // In this test, after a C# transaction is created and never commit, it's expected that the resource will not exist.
+            // For the use of C# transactions, operations should enlist in transactions. And it'll only work as expected for transaction sequential bundles.
+
             string createdId = string.Empty;
 
             using (_ = _fixture.TransactionHandler.BeginTransaction())
             {
-                SaveOutcome saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
+                ResourceElement resource = Samples.GetJsonSample("Weight");
+                UpsertResourceRequest upsertResource = new UpsertResourceRequest(
+                    resource,
+                    new BundleResourceContext(
+                        Bundle.BundleType.Transaction,
+                        BundleProcessingLogic.Sequential,
+                        Bundle.HTTPVerb.PUT,
+                        null,
+                        Guid.Empty));
+
+                SaveOutcome saveResult = await Mediator.UpsertResourceAsync(upsertResource);
                 createdId = saveResult.RawResourceElement.Id;
 
                 Assert.NotEqual(string.Empty, createdId);


### PR DESCRIPTION
## Description
In this PR, I'm setting "_enlistTransaction_" to **false** for most all operations, except by Sequential Bundle Transactions. 

During last week, it was noticed that deadlocks were not retried in standalone operations as they were set to enlist in transaction. By setting that to false, it'll now: (1) be included as part of SQL transaction in MergeResources; (2) retry deadlock errors if any. 

With these changes we should make standalone operations more stable and resilient to sporadic deadlocks (considered as retriable). 

## Related issues
Addresses [AB#195581](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/195581).

## Testing
- Tested through local validations. 

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
