### PR TITLE
Fix copy

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Conformance/Models/ListedCapabilityStatementTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Conformance/Models/ListedCapabilityStatementTests.cs
@@ -373,6 +373,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance.Models
             await Task.WhenAll(cloneTask, modifyTask);
 
             // Assert
+            // If this step fails the excpetions will be logged to the test output
+            // This can look like this step threw an exception, but it is just reporting an exception that happened in the clone or modify tasks
             Assert.Empty(exceptions);
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 using Newtonsoft.Json;
@@ -109,21 +110,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
         /// </summary>
         /// <typeparam name="T">Generic data type being copied.</typeparam>
         /// <param name="origin">Origin.</param>
-        /// <param name="destiny">Destiny.</param>
-        private static void SafeCopyTo<T>(ICollection<T> origin, ICollection<T> destiny)
+        /// <param name="destination">Destination.</param>
+        private static void SafeCopyTo<T>(ICollection<T> origin, ICollection<T> destination)
         {
             if (origin == null)
             {
-                destiny = null;
+                destination = null;
                 return;
             }
 
-            T[] temp = new T[origin.Count];
-            origin.CopyTo(temp, 0);
+            T[] temp = origin.ToArray();
 
             foreach (T item in temp)
             {
-                destiny.Add(item);
+                destination.Add(item);
             }
         }
     }


### PR DESCRIPTION
## Description
Makes the SafeCopyTo method more resilient. 

## Related issues
Addresses [Bug 195638](https://microsofthealth.visualstudio.com/Health/_workitems/edit/195638)

## Testing
Existing unit test

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
