### PR TITLE
Fix CapabilityStatement conformance for resources

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -407,15 +407,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             // Remove resource entries with no interactions to ensure FHIR conformance.
             // In STU3, CapabilityStatement.rest.resource.interaction has min cardinality 1,
             // so resources without interactions (e.g. Parameters) must be excluded.
-            foreach (var restComponent in _statement.Rest)
+            if (_modelInfoProvider.Version == FhirSpecification.Stu3)
             {
-                var emptyResources = restComponent.Resource
-                    .Where(r => r.Interaction == null || r.Interaction.Count == 0)
-                    .ToList();
-
-                foreach (var resource in emptyResources)
+                foreach (var restComponent in _statement.Rest)
                 {
-                    restComponent.Resource.Remove(resource);
+                    var emptyResources = restComponent.Resource
+                        .Where(r => r.Interaction == null || r.Interaction.Count == 0)
+                        .ToList();
+
+                    foreach (var resource in emptyResources)
+                    {
+                        restComponent.Resource.Remove(resource);
+                    }
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -418,7 +418,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                     restComponent.Resource.Remove(resource);
                 }
             }
-            
+
             // To build a CapabilityStatement we use a custom JsonConverter that serializes
             // the ListedCapabilityStatement into a CapabilityStatement poco
             var json = JsonConvert.SerializeObject(_statement, new JsonSerializerSettings

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -404,6 +404,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         public ITypedElement Build()
         {
+            // Remove resource entries with no interactions to ensure FHIR conformance.
+            // In STU3, CapabilityStatement.rest.resource.interaction has min cardinality 1,
+            // so resources without interactions (e.g. Parameters) must be excluded.
+            foreach (var restComponent in _statement.Rest)
+            {
+                var emptyResources = restComponent.Resource
+                    .Where(r => r.Interaction == null || r.Interaction.Count == 0)
+                    .ToList();
+
+                foreach (var resource in emptyResources)
+                {
+                    restComponent.Resource.Remove(resource);
+                }
+            }
+            
             // To build a CapabilityStatement we use a custom JsonConverter that serializes
             // the ListedCapabilityStatement into a CapabilityStatement poco
             var json = JsonConvert.SerializeObject(_statement, new JsonSerializerSettings


### PR DESCRIPTION
## Summary

Fixes #5394. External PR #5473

In STU3, `CapabilityStatement.rest.resource.interaction` has a **minimum cardinality of 1** ([spec](https://www.hl7.org/fhir/STU3/capabilitystatement.html)). Resources like `Parameters` that are explicitly excluded from interaction population (line 303-307) were still appearing in the resource list with an empty interaction array, causing FHIR-conformant parsers (e.g., Firely SDK 6.x with strict validation) to reject the CapabilityStatement.

## Changes

- In `CapabilityStatementBuilder.Build()`, added a cleanup step that removes resource entries with no interactions before serialization
- This ensures the output CapabilityStatement conforms to the FHIR standard across all versions

## Why this approach

Rather than modifying how `Parameters` is handled specifically, this cleanup catches *any* resource that ends up with zero interactions — making it robust against future edge cases. The comment explains the STU3 cardinality requirement for maintainability.

## Related issues
[AB#191808](https://dev.azure.com/microsofthealth/Health/_workitems/edit/191808)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
