### PR TITLE
Disable $includes for iterative includes

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             IncludesOperationSupported = other.IncludesOperationSupported;
             IsAsyncOperation = other.IsAsyncOperation;
             SkipAppendIntersectionWithPredecessor = other.SkipAppendIntersectionWithPredecessor;
+            ContainsIterativeInclude = other.ContainsIterativeInclude;
         }
 
         /// <summary>
@@ -185,6 +186,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// Specifically used for smart request with ANDed query parameters multiary operation inside the union of all allowed scopes
         /// </summary>
         public bool SkipAppendIntersectionWithPredecessor { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the search contains iterative includes.
+        /// </summary>
+        public bool ContainsIterativeInclude { get; set; }
 
         /// <summary>
         /// Performs a shallow clone of this instance

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1944,7 +1944,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include result was truncated. Iterative include results can not be paged though, please narrow your search..
+        ///   Looks up a localized string similar to Include result was truncated. Iterative include results cannot be paged though, please narrow your search..
         /// </summary>
         internal static string TruncatedIncludeMessageForIterativeInclude {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -1940,6 +1940,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string TruncatedIncludeMessageForIncludes {
             get {
                 return ResourceManager.GetString("TruncatedIncludeMessageForIncludes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include result was truncated. Iterative include results can not be paged though, please narrow your search..
+        /// </summary>
+        internal static string TruncatedIncludeMessageForIterativeInclude {
+            get {
+                return ResourceManager.GetString("TruncatedIncludeMessageForIterativeInclude", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -880,6 +880,6 @@
     <value>Optimistic concurrency conflict detected while writing custom search parameter(s). Make sure that custom search parameters are not written in parallel. Consider sequential writes or a bundle.</value>
   </data>
   <data name="TruncatedIncludeMessageForIterativeInclude" xml:space="preserve">
-    <value>Include result was truncated. Iterative include results can not be paged though, please narrow your search.</value>
+    <value>Include result was truncated. Iterative include results cannot be paged though, please narrow your search.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -879,4 +879,7 @@
   <data name="SearchParameterConcurrencyConflict" xml:space="preserve">
     <value>Optimistic concurrency conflict detected while writing custom search parameter(s). Make sure that custom search parameters are not written in parallel. Consider sequential writes or a bundle.</value>
   </data>
+  <data name="TruncatedIncludeMessageForIterativeInclude" xml:space="preserve">
+    <value>Include result was truncated. Iterative include results can not be paged though, please narrow your search.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -444,6 +444,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (includeRevincludeSearchExpressions.Any())
             {
                 searchExpressions.AddRange(includeRevincludeSearchExpressions);
+
+                if (includeRevincludeSearchExpressions.Any(expression => expression.Iterate))
+                {
+                    searchOptions.ContainsIterativeInclude = true;
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(compartmentType))

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -764,7 +764,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                     && newContinuationType.HasValue
                                     && newContinuationId.HasValue
                                     && matchedResourceSurrogateIdStart.HasValue
-                                    && (isResultPartial || includedResources.Count > clonedSearchOptions.IncludeCount))
+                                    && (isResultPartial || includedResources.Count > clonedSearchOptions.IncludeCount)
+                                    && !clonedSearchOptions.ContainsIterativeInclude)
                                 {
                                     clonedSearchOptions.IncludesContinuationToken = new IncludesContinuationToken(
                                         new object[]
@@ -791,7 +792,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                         new OperationOutcomeIssue(
                                             OperationOutcomeConstants.IssueSeverity.Warning,
                                             OperationOutcomeConstants.IssueType.Incomplete,
-                                            clonedSearchOptions.IncludesOperationSupported ? Core.Resources.TruncatedIncludeMessageForIncludes : Core.Resources.TruncatedIncludeMessage));
+                                            clonedSearchOptions.IncludesOperationSupported ? (clonedSearchOptions.ContainsIterativeInclude ? Core.Resources.TruncatedIncludeMessageForIterativeInclude : Core.Resources.TruncatedIncludeMessageForIncludes) : Core.Resources.TruncatedIncludeMessage));
                                 }
 
                                 // If this is a sort query, lets keep track of whether we actually searched for sort values.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
@@ -168,7 +168,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             var relatedResources = new List<Resource>();
 
             var response = await Client.SearchAsync(searchUrl);
-            searchUrl = response.Resource.NextLink?.AbsoluteUri;
 
             matchedResources.AddRange(response.Resource.Entry
                     .Where(x => x.Search.Mode == SearchEntryMode.Match)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Test.Utilities;
 using Xunit;
+using static Hl7.Fhir.Model.Bundle;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
@@ -155,6 +156,40 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     includesCount.Value,
                     pages);
             }
+        }
+
+        [Fact]
+        public async Task GivenIterativeIncludes_WhenThereAreMultiplePagesOfIncludedResources_ThenWarningIsReturned()
+        {
+            Skip.IfNot(_fixture.TestFhirServer.Metadata.SupportsOperation("includes"), "$includes not enabled on this server");
+            var query = TagQuery("_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:subject&_includesCount=2");
+            var searchUrl = $"{Server.BaseAddress}{KnownResourceTypes.MedicationDispense}?{query}";
+            var matchedResources = new List<Resource>();
+            var relatedResources = new List<Resource>();
+
+            var response = await Client.SearchAsync(searchUrl);
+            searchUrl = response.Resource.NextLink?.AbsoluteUri;
+
+            matchedResources.AddRange(response.Resource.Entry
+                    .Where(x => x.Search.Mode == SearchEntryMode.Match)
+                    .Select(x => x.Resource)
+                    .ToList());
+
+            relatedResources.AddRange(response.Resource.Entry
+                .Where(x => x.Search.Mode == SearchEntryMode.Include)
+                .Select(x => x.Resource)
+                .ToList());
+
+            var operationOutcome = response.Resource.Entry
+                .Where(x => x.Resource.TypeName.Equals(KnownResourceTypes.OperationOutcome, StringComparison.OrdinalIgnoreCase))
+                .Select(x => x.Resource)
+                .Cast<OperationOutcome>()
+                .FirstOrDefault();
+
+            Assert.False(response.Resource.Link?.Any(x => x.Relation.Equals("related", StringComparison.Ordinal)));
+            Assert.Equal(6, relatedResources.Count); // includes has a bug where it returns _includesCount + 1 resources instead of _includesCount resources and it counts iterative includes seperately
+            Assert.Equal(10, matchedResources.Count);
+            Assert.NotNull(operationOutcome);
         }
 
         private void ValidateRelatedResources(


### PR DESCRIPTION
## Description
$includes never supported iterative includes, but it currently throws a 500 when a search with iterative includes exceeds the max includes count. This change prevents that 500 and returns a warning instead.

## Related issues
Addresses [Bug 194365](https://microsofthealth.visualstudio.com/Health/_workitems/edit/194365)

## Testing
New E2E test

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
