### PR TITLE
Fix iterative include test

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
@@ -186,7 +186,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 .FirstOrDefault();
 
             Assert.False(response.Resource.Link?.Any(x => x.Relation.Equals("related", StringComparison.Ordinal)));
-            Assert.Equal(6, relatedResources.Count); // includes has a bug where it returns _includesCount + 1 resources instead of _includesCount resources and it counts iterative includes seperately
+            Assert.True(relatedResources.Count >= 4 && relatedResources.Count <= 6, "The number of included resources is wrong"); // includes has a bug where it returns _includesCount + 1 resources instead of _includesCount resources and it counts iterative includes seperately. The test data also has some patients being reused, so depending on the order the test data is entered in the number of resources returned can vary.
+            Assert.Contains(relatedResources, resource => resource.TypeName.Equals(KnownResourceTypes.MedicationRequest, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(relatedResources, resource => resource.TypeName.Equals(KnownResourceTypes.Patient, StringComparison.OrdinalIgnoreCase));
             Assert.Equal(10, matchedResources.Count);
             Assert.NotNull(operationOutcome);
         }


### PR DESCRIPTION
## Description
Fixing a flaky test

## Related issues
Addresses [Bug 194365](https://microsofthealth.visualstudio.com/Health/_workitems/edit/194365)

## Testing
Existing E2E test

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
