### PR TITLE
Keep DOB temporal unions as a single SQL union

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/DateTimeEqualityRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/DateTimeEqualityRewriterTests.cs
@@ -5,7 +5,9 @@
 
 using System;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.ValueSets;
 using Microsoft.Health.Test.Utilities;
 using Xunit;
 
@@ -130,6 +132,38 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
 
             Assert.Same(inputExpression, rewrittenExpression);
+        }
+
+        [Fact]
+        public void GivenNoSplitUnion_WhenDateTimeRewriterRewritesBranches_NoSplitMarkerIsPreserved()
+        {
+            var birthdate = new SearchParameterInfo(
+                "birthdate",
+                "birthdate",
+                SearchParamType.Date,
+                new Uri("http://hl7.org/fhir/SearchParameter/individual-birthdate"),
+                expression: "Patient.birthDate",
+                baseResourceTypes: new[] { "Patient" });
+
+            var start = new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var end = start.AddDays(1).AddTicks(-1);
+
+            var shortBranch = new SearchParameterExpression(
+                birthdate,
+                Expression.Equals(FieldName.DateTimeEnd, null, end));
+
+            var longBranch = new SearchParameterExpression(
+                birthdate,
+                Expression.And(
+                    Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, start),
+                    Expression.LessThanOrEqual(FieldName.DateTimeEnd, null, end)));
+
+            var union = Expression.Union(UnionOperator.All, new Expression[] { shortBranch, longBranch });
+            union.DoNotSplitIntoSeparateCtes = true;
+
+            var rewritten = Assert.IsType<UnionExpression>(union.AcceptVisitor(DateTimeEqualityRewriter.Instance));
+
+            Assert.True(rewritten.DoNotSplitIntoSeparateCtes);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Expressions/UnionExpressionTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Expressions/UnionExpressionTests.cs
@@ -49,5 +49,20 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
                 UnionExpression unionExpressionFail2 = new UnionExpression(UnionOperator.All, new Expression[] { multiaryExpression1 });
             });
         }
+
+        [Fact]
+        public void GivenUnionExpression_WhenCreated_ThenNoSplitMarkerDefaultsToFalseAndCanBeEnabled()
+        {
+            StringExpression expression1 = new StringExpression(StringOperator.Equals, FieldName.String, componentIndex: 0, value: "rush", ignoreCase: true);
+            StringExpression expression2 = new StringExpression(StringOperator.Equals, FieldName.String, componentIndex: 0, value: "2112", ignoreCase: true);
+
+            UnionExpression unionExpression = new UnionExpression(UnionOperator.All, new Expression[] { expression1, expression2 });
+
+            Assert.False(unionExpression.DoNotSplitIntoSeparateCtes);
+
+            unionExpression.DoNotSplitIntoSeparateCtes = true;
+
+            Assert.True(unionExpression.DoNotSplitIntoSeparateCtes);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Expressions/UnionExpressionTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Expressions/UnionExpressionTests.cs
@@ -64,5 +64,28 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
 
             Assert.True(unionExpression.DoNotSplitIntoSeparateCtes);
         }
+
+        [Fact]
+        public void GivenUnionExpressionWithNoSplitMarker_WhenRewritten_ThenMarkerIsPreserved()
+        {
+            StringExpression expression1 = new StringExpression(StringOperator.Equals, FieldName.String, componentIndex: 0, value: "rush", ignoreCase: true);
+            StringExpression expression2 = new StringExpression(StringOperator.Equals, FieldName.String, componentIndex: 0, value: "2112", ignoreCase: true);
+            UnionExpression unionExpression = new UnionExpression(UnionOperator.All, new Expression[] { expression1, expression2 })
+            {
+                DoNotSplitIntoSeparateCtes = true,
+            };
+
+            var result = Assert.IsType<UnionExpression>(unionExpression.AcceptVisitor(new StringNodeRewriter(), null));
+
+            Assert.True(result.DoNotSplitIntoSeparateCtes);
+        }
+
+        private sealed class StringNodeRewriter : ExpressionRewriter<object>
+        {
+            public override Expression VisitString(StringExpression expression, object context)
+            {
+                return new StringExpression(expression.StringOperator, expression.FieldName, expression.ComponentIndex, expression.Value, expression.IgnoreCase);
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
@@ -80,7 +80,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         public virtual Expression VisitUnion(UnionExpression expression, TContext context)
         {
             IReadOnlyList<Expression> rewrittenExpressions = VisitArray(expression.Expressions, context);
-            return ReferenceEquals(rewrittenExpressions, expression.Expressions) ? expression : new UnionExpression(expression.Operator, rewrittenExpressions);
+            if (ReferenceEquals(rewrittenExpressions, expression.Expressions))
+            {
+                return expression;
+            }
+
+            return new UnionExpression(expression.Operator, rewrittenExpressions)
+            {
+                DoNotSplitIntoSeparateCtes = expression.DoNotSplitIntoSeparateCtes,
+            };
         }
 
         public virtual Expression VisitString(StringExpression expression, TContext context)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/UnionExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/UnionExpression.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public IReadOnlyList<Expression> Expressions { get; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this union must remain in-place and not be split into separate SQL CTE branches.
+        /// </summary>
+        public bool DoNotSplitIntoSeparateCtes { get; set; }
+
         public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
         {
             EnsureArg.IsNotNull(visitor, nameof(visitor));

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         {
             var union = Assert.IsType<UnionExpression>(result);
             Assert.Equal(UnionOperator.All, union.Operator);
+            Assert.True(union.DoNotSplitIntoSeparateCtes);
             Assert.Collection(
                 union.Expressions,
                 shortBranch => AssertSearchParameterAnd(

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/SearchParamTableExpressionExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/SearchParamTableExpressionExtensionsTests.cs
@@ -1,0 +1,186 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.ValueSets;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SearchParamTableExpressionExtensionsTests
+    {
+        private static readonly SearchParameterInfo BirthdateParam = new SearchParameterInfo(
+            "birthdate",
+            "birthdate",
+            SearchParamType.Date,
+            new Uri("http://hl7.org/fhir/SearchParameter/individual-birthdate"),
+            expression: "Patient.birthDate",
+            baseResourceTypes: new[] { "Patient" });
+
+        private static readonly SearchParameterInfo NameParam = new SearchParameterInfo(
+            "name",
+            "name",
+            SearchParamType.String,
+            new Uri("http://hl7.org/fhir/SearchParameter/individual-name"),
+            expression: "Patient.name",
+            baseResourceTypes: new[] { "Patient" });
+
+        public static TheoryData<Expression, bool> UnionDetectionCases => new()
+        {
+            { Expression.And(BuildBareUnion()), true },
+            { Expression.And(BuildSmartV2Union(), new SearchParameterExpression(NameParam, Expression.Equals(FieldName.TokenCode, null, "Smith"))), true },
+            { new SearchParameterExpression(NameParam, Expression.Equals(FieldName.TokenCode, null, "Smith")), false },
+        };
+
+        private static UnionExpression BuildBareUnion()
+        {
+            var endOfDay = new DateTimeOffset(2016, 7, 6, 23, 59, 59, TimeSpan.Zero);
+            var startOfDay = new DateTimeOffset(2016, 7, 6, 0, 0, 0, TimeSpan.Zero);
+            var shortBranch = new SearchParameterExpression(BirthdateParam, Expression.Equals(FieldName.DateTimeEnd, null, endOfDay));
+            var longBranch = new SearchParameterExpression(BirthdateParam, Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, startOfDay));
+            return Expression.Union(UnionOperator.All, new Expression[] { shortBranch, longBranch });
+        }
+
+        private static UnionExpression BuildSmartV2Union()
+        {
+            var branch = new SearchParameterExpression(NameParam, Expression.Equals(FieldName.TokenCode, null, "Smith"));
+            return Expression.Union(UnionOperator.All, new Expression[] { branch });
+        }
+
+        [Theory]
+        [MemberData(nameof(UnionDetectionCases))]
+        public void HasUnionAllExpression_DetectsBareAndNestedUnions(Expression predicate, bool expected)
+        {
+            var tableExpr = new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                predicate,
+                SearchParamTableExpressionKind.Normal);
+
+            Assert.Equal(expected, tableExpr.HasUnionAllExpression());
+        }
+
+        [Fact]
+        public void SplitExpressions_WhenPredicateContainsSingleUnionChild_ReturnsTrueWithUnionAndNullRemainder()
+        {
+            var union = BuildBareUnion();
+            var tableExpr = new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                Expression.And(union),
+                SearchParamTableExpressionKind.Normal);
+
+            bool result = tableExpr.SplitExpressions(out UnionExpression outUnion, out SearchParamTableExpression outRemainder);
+
+            Assert.True(result);
+            Assert.Same(union, outUnion);
+            Assert.Null(outRemainder);
+        }
+
+        [Fact]
+        public void SplitExpressions_WhenUnionIsMarkedAsNoSplit_ReturnsFalse()
+        {
+            var union = BuildBareUnion();
+            union.DoNotSplitIntoSeparateCtes = true;
+
+            var tableExpr = new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                Expression.And(union),
+                SearchParamTableExpressionKind.Normal);
+
+            bool result = tableExpr.SplitExpressions(out UnionExpression outUnion, out SearchParamTableExpression outRemainder);
+
+            Assert.False(result);
+            Assert.Null(outUnion);
+            Assert.Null(outRemainder);
+        }
+
+        [Fact]
+        public void SplitExpressions_WhenUnionNestedInMultiaryWithSiblings_ReturnsTrueWithUnionAndRemainder()
+        {
+            var union = BuildSmartV2Union();
+            var otherExpr = new SearchParameterExpression(NameParam, Expression.Equals(FieldName.TokenCode, null, "Smith"));
+            var multiary = Expression.And(union, otherExpr);
+
+            var tableExpr = new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                multiary,
+                SearchParamTableExpressionKind.Normal);
+
+            bool result = tableExpr.SplitExpressions(out UnionExpression outUnion, out SearchParamTableExpression outRemainder);
+
+            Assert.True(result);
+            Assert.Same(union, outUnion);
+            Assert.NotNull(outRemainder);
+            var remainderAnd = Assert.IsType<MultiaryExpression>(outRemainder.Predicate);
+            Assert.DoesNotContain(remainderAnd.Expressions, e => e is UnionExpression);
+        }
+
+        [Fact]
+        public void SplitExpressions_WhenPredicateIsPlainSearchParameter_ReturnsFalse()
+        {
+            var predicate = new SearchParameterExpression(NameParam, Expression.Equals(FieldName.TokenCode, null, "Smith"));
+            var tableExpr = new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                predicate,
+                SearchParamTableExpressionKind.Normal);
+
+            bool result = tableExpr.SplitExpressions(out UnionExpression outUnion, out SearchParamTableExpression outRemainder);
+
+            Assert.False(result);
+            Assert.Null(outUnion);
+            Assert.Null(outRemainder);
+        }
+
+        [Fact]
+        public void SortExpressionsByQueryLogic_WhenRegularUnionPrecedesConcatenationPair_ThenUnionMovesFirstAndPairStaysAdjacent()
+        {
+            var leadingNormal = BuildNormalTableExpression("leading");
+            var regularUnion = new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                Expression.And(BuildBareUnion()),
+                SearchParamTableExpressionKind.Normal);
+            var normalSibling = BuildNormalTableExpression("sibling-normal");
+            var concatenationSibling = new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                new SearchParameterExpression(NameParam, Expression.Equals(FieldName.TokenCode, null, "sibling-concat")),
+                SearchParamTableExpressionKind.Concatenation);
+            var trailingNormal = BuildNormalTableExpression("trailing");
+
+            var input = new List<SearchParamTableExpression>
+            {
+                leadingNormal,
+                regularUnion,
+                normalSibling,
+                concatenationSibling,
+                trailingNormal,
+            };
+
+            IReadOnlyList<SearchParamTableExpression> sorted = input.SortExpressionsByQueryLogic();
+
+            Assert.Same(regularUnion, sorted[0]);
+            Assert.Same(leadingNormal, sorted[1]);
+            Assert.Same(normalSibling, sorted[2]);
+            Assert.Same(concatenationSibling, sorted[3]);
+            Assert.Same(trailingNormal, sorted[4]);
+            Assert.Equal(SearchParamTableExpressionKind.Concatenation, sorted[3].Kind);
+        }
+
+        private static SearchParamTableExpression BuildNormalTableExpression(string code)
+        {
+            return new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                new SearchParameterExpression(NameParam, Expression.Equals(FieldName.TokenCode, null, code)),
+                SearchParamTableExpressionKind.Normal);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
@@ -213,4 +213,52 @@ public class SqlQueryGeneratorTests
         _fhirModel.Received(1).TryGetResourceTypeId("Patient", out Arg.Any<short>());
         _fhirModel.Received(1).TryGetResourceTypeId("Practitioner", out Arg.Any<short>());
     }
+
+    [Fact]
+    public void GivenNoSplitUnionPredicate_WhenSqlGenerated_ThenSingleCteUsesUnionAllBetweenBranches()
+    {
+        var birthdateParam = new SearchParameterInfo(
+            "birthdate",
+            "birthdate",
+            SearchParamType.Date,
+            new Uri("http://hl7.org/fhir/SearchParameter/individual-birthdate"),
+            expression: "Patient.birthDate",
+            baseResourceTypes: new[] { "Patient" });
+
+        var startOfDay = new DateTimeOffset(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var endOfDay = startOfDay.AddDays(1).AddTicks(-1);
+
+        var shortBranch = new SearchParameterExpression(
+            birthdateParam,
+            Expression.And(
+                Expression.Equals(SqlFieldName.DateTimeIsLongerThanADay, null, false),
+                Expression.Equals(FieldName.DateTimeEnd, null, endOfDay)));
+
+        var longBranch = new SearchParameterExpression(
+            birthdateParam,
+            Expression.And(
+                Expression.Equals(SqlFieldName.DateTimeIsLongerThanADay, null, true),
+                Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, startOfDay),
+                Expression.LessThanOrEqual(FieldName.DateTimeEnd, null, endOfDay)));
+
+        var union = Expression.Union(UnionOperator.All, new Expression[] { shortBranch, longBranch });
+        union.DoNotSplitIntoSeparateCtes = true;
+        Expression predicate = Expression.And(union);
+
+        var queryGenerator = predicate.AcceptVisitor(_queryGeneratorFactory, null);
+        SqlRootExpression sqlExpression = new([new(queryGenerator, predicate, SearchParamTableExpressionKind.Normal)], new List<SearchParameterExpressionBase>());
+        SearchOptions searchOptions = new()
+        {
+            Sort = [],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+
+        Assert.Contains("UNION ALL", generatedSql);
+        Assert.DoesNotContain(" OR (SearchParamId = 690", generatedSql);
+        Assert.DoesNotContain("EndDateTime = @p0 SearchParamId", generatedSql);
+    }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
@@ -260,5 +260,13 @@ public class SqlQueryGeneratorTests
         Assert.Contains("UNION ALL", generatedSql);
         Assert.DoesNotContain(" OR (SearchParamId = 690", generatedSql);
         Assert.DoesNotContain("EndDateTime = @p0 SearchParamId", generatedSql);
+
+        // The no-split union must be a single CTE with both branches inlined via UNION ALL.
+        // It must NOT be re-aggregated from per-branch CTEs (the old "SELECT * FROM cteN UNION ALL SELECT * FROM cteM" shape).
+        Assert.DoesNotContain("SELECT * FROM cte", generatedSql);
+
+        // Both branches emit a complete "SELECT ... AS Sid1" projection inside the single union CTE.
+        int branchSelectCount = generatedSql.Split("AS Sid1").Length - 1;
+        Assert.True(branchSelectCount >= 2, $"Expected at least 2 inlined branch SELECTs, found {branchSelectCount} in: {generatedSql}");
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/SearchParamTableExpressionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/SearchParamTableExpressionExtensions.cs
@@ -44,6 +44,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
 
                 if (tempUnionAllExpression != null)
                 {
+                    if (tempUnionAllExpression.DoNotSplitIntoSeparateCtes)
+                    {
+                        return false;
+                    }
+
                     IReadOnlyList<Expression> allOtherExpression = expressionContainer.Expressions.Where(e => e != tempUnionAllExpression).ToList();
 
                     if (allOtherExpression.Any())

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -638,6 +638,48 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         {
             var specialCaseTableName = searchParamTableExpression.QueryGenerator.Table;
 
+            if (searchParamTableExpression.ChainLevel == 0 &&
+                !IsInSortMode(context) &&
+                TryGetNoSplitUnionPredicate(searchParamTableExpression.Predicate, out UnionExpression noSplitUnion, out Expression remainderPredicate))
+            {
+                for (int branchIndex = 0; branchIndex < noSplitUnion.Expressions.Count; branchIndex++)
+                {
+                    if (branchIndex > 0)
+                    {
+                        StringBuilder.AppendLine();
+                        StringBuilder.Append("UNION ALL");
+                        StringBuilder.AppendLine();
+                    }
+
+                    StringBuilder.Append("SELECT ")
+                        .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T1, ")
+                        .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1")
+                        .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
+
+                    if (UseAppendWithJoin() && !context.SkipAppendIntersectionWithPredecessor)
+                    {
+                        AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
+                    }
+
+                    using (var delimited = StringBuilder.BeginDelimitedWhereClause())
+                    {
+                        AppendHistoryClause(delimited, context.ResourceVersionTypes, searchParamTableExpression, null, specialCaseTableName);
+
+                        if (!UseAppendWithJoin() && !context.SkipAppendIntersectionWithPredecessor)
+                        {
+                            AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
+                        }
+
+                        Expression branchPredicate = CombinePredicates(noSplitUnion.Expressions[branchIndex], remainderPredicate);
+                        delimited.BeginDelimitedElement();
+                        CheckForIdentifierSearchParams(branchPredicate);
+                        branchPredicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
+                    }
+                }
+
+                return;
+            }
+
             if (searchParamTableExpression.ChainLevel == 0)
             {
                 int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex();
@@ -726,6 +768,53 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     searchParamTableExpression.Predicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
                 }
             }
+        }
+
+        private static bool TryGetNoSplitUnionPredicate(Expression predicate, out UnionExpression unionExpression, out Expression remainderPredicate)
+        {
+            unionExpression = null;
+            remainderPredicate = null;
+
+            if (predicate is UnionExpression directUnion && directUnion.DoNotSplitIntoSeparateCtes)
+            {
+                unionExpression = directUnion;
+                return true;
+            }
+
+            if (predicate is MultiaryExpression andExpression && andExpression.MultiaryOperation == MultiaryOperator.And)
+            {
+                UnionExpression selectedUnionExpression = andExpression.Expressions
+                    .OfType<UnionExpression>()
+                    .SingleOrDefault(u => u.DoNotSplitIntoSeparateCtes);
+
+                if (selectedUnionExpression != null)
+                {
+                    unionExpression = selectedUnionExpression;
+                    List<Expression> remainderExpressions = andExpression.Expressions.Where(e => !ReferenceEquals(e, selectedUnionExpression)).ToList();
+                    if (remainderExpressions.Count == 1)
+                    {
+                        remainderPredicate = remainderExpressions[0];
+                    }
+                    else if (remainderExpressions.Count > 1)
+                    {
+                        remainderPredicate = Expression.And(remainderExpressions);
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static Expression CombinePredicates(Expression branchPredicate, Expression remainderPredicate)
+        {
+            if (remainderPredicate == null)
+            {
+                return branchPredicate;
+            }
+
+            return Expression.And(branchPredicate, remainderPredicate);
         }
 
         private void HandleTableKindAll(SearchParamTableExpression searchParamTableExpression, SearchOptions context)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -651,32 +651,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.AppendLine();
                     }
 
-                    StringBuilder.Append("SELECT ")
-                        .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T1, ")
-                        .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1")
-                        .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
-
-                    if (UseAppendWithJoin() && !context.SkipAppendIntersectionWithPredecessor)
-                    {
-                        AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
-                    }
-
-                    using (var delimited = StringBuilder.BeginDelimitedWhereClause())
-                    {
-                        AppendHistoryClause(delimited, context.ResourceVersionTypes, searchParamTableExpression, null, specialCaseTableName);
-
-                        if (!UseAppendWithJoin() && !context.SkipAppendIntersectionWithPredecessor)
-                        {
-                            AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
-                        }
-
-                        Expression branchPredicate = CombinePredicates(noSplitUnion.Expressions[branchIndex], remainderPredicate);
-                        delimited.BeginDelimitedElement();
-                        CheckForIdentifierSearchParams(branchPredicate);
-                        branchPredicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
-                    }
+                    Expression branchPredicate = CombinePredicates(noSplitUnion.Expressions[branchIndex], remainderPredicate);
+                    AppendChainLevelZeroNonSortNormalQuery(searchParamTableExpression, context, specialCaseTableName, branchPredicate);
                 }
 
+                return;
+            }
+
+            if (searchParamTableExpression.ChainLevel == 0 && !IsInSortMode(context))
+            {
+                AppendChainLevelZeroNonSortNormalQuery(searchParamTableExpression, context, specialCaseTableName, searchParamTableExpression.Predicate);
                 return;
             }
 
@@ -766,6 +750,40 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     delimited.BeginDelimitedElement();
                     CheckForIdentifierSearchParams(searchParamTableExpression.Predicate);
                     searchParamTableExpression.Predicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
+                }
+            }
+        }
+
+        private void AppendChainLevelZeroNonSortNormalQuery(
+            SearchParamTableExpression searchParamTableExpression,
+            SearchOptions context,
+            string specialCaseTableName,
+            Expression predicate)
+        {
+            StringBuilder.Append("SELECT ")
+                .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T1, ")
+                .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1")
+                .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
+
+            if (UseAppendWithJoin() && !context.SkipAppendIntersectionWithPredecessor)
+            {
+                AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
+            }
+
+            using (var delimited = StringBuilder.BeginDelimitedWhereClause())
+            {
+                AppendHistoryClause(delimited, context.ResourceVersionTypes, searchParamTableExpression, null, specialCaseTableName);
+
+                if (!UseAppendWithJoin() && !context.SkipAppendIntersectionWithPredecessor)
+                {
+                    AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
+                }
+
+                if (predicate != null)
+                {
+                    delimited.BeginDelimitedElement();
+                    CheckForIdentifierSearchParams(predicate);
+                    predicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -574,64 +574,75 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void HandleParamTableUnion(SearchParamTableExpression searchParamTableExpression, SearchOptions context)
         {
-            var specialCaseTableName = searchParamTableExpression.QueryGenerator.Table;
             StringBuilder.Append(TableExpressionName(++_tableExpressionCounter)).AppendLine(" AS").AppendLine("(");
 
             using (StringBuilder.Indent())
             {
-                StringBuilder.Append("SELECT ")
-                    .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T1, ")
-                    .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1");
-
-                var searchParameterExpressionPredicate = searchParamTableExpression.Predicate as SearchParameterExpression;
-
-                // handle special case where we want to Union a specific resource to the results
-                if (searchParameterExpressionPredicate != null &&
-                    searchParameterExpressionPredicate.Parameter.ColumnLocation().HasFlag(SearchParameterColumnLocation.ResourceTable))
-                {
-                    specialCaseTableName = VLatest.Resource;
-                    StringBuilder.Append("FROM ").AppendLine(specialCaseTableName);
-                }
-                else
-                {
-                    // For Smart union expression, searchParamTableExpression.Predicate could be a multiary expression and not SearchParameterExpression
-                    // To retrieve the main compartment resource we are building the Multiary expression with ResourceTypeId AND ResourceId (SearchParameterExpression)
-                    // Check if its a Multiary expression, if yes then check the internal expressions are SearchParameterExpression of parameter _type and _id
-                    // If yes then we can set the specialCaseTableName to Resource table and not to searchParamTableExpression.QueryGenerator.Table which will mostly be a ReferenceSearchParamTable
-                    if (searchParamTableExpression.Predicate is MultiaryExpression multiaryExpression)
-                    {
-                        bool allAreResourceTypeOrId = multiaryExpression.Expressions.All(e =>
-                            e is SearchParameterExpression spe &&
-                            (spe.Parameter.Name == SearchParameterNames.ResourceType || spe.Parameter.Name == SearchParameterNames.Id));
-
-                        if (allAreResourceTypeOrId)
-                        {
-                            specialCaseTableName = VLatest.Resource;
-                        }
-                    }
-
-                    StringBuilder.Append("FROM ").AppendLine(specialCaseTableName);
-                }
-
-                using (var delimited = StringBuilder.BeginDelimitedWhereClause())
-                {
-                    // Apply History and Delete clause when querying from Resource table in case of compartment unions
-                    AppendHistoryClause(delimited, context.ResourceVersionTypes, searchParamTableExpression, null, specialCaseTableName);
-
-                    if (specialCaseTableName.Equals(VLatest.Resource))
-                    {
-                        AppendDeletedClause(delimited, context.ResourceVersionTypes);
-                    }
-
-                    if (searchParamTableExpression.Predicate != null && !(searchParamTableExpression.Predicate is CompartmentSearchExpression))
-                    {
-                        delimited.BeginDelimitedElement();
-                        searchParamTableExpression.Predicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
-                    }
-                }
+                AppendUnionBranchSelectBody(searchParamTableExpression, context);
             }
 
             StringBuilder.AppendLine("),");
+        }
+
+        /// <summary>
+        /// Emits a single union-branch projection (<c>SELECT ... FROM ... WHERE ...</c>) without any surrounding CTE wrapper.
+        /// Shared by <see cref="HandleParamTableUnion"/>, which wraps each branch in its own CTE, and by the no-split union
+        /// path in <see cref="HandleTableKindNormal"/>, which inlines the branches into a single CTE separated by <c>UNION ALL</c>.
+        /// </summary>
+        private void AppendUnionBranchSelectBody(SearchParamTableExpression searchParamTableExpression, SearchOptions context)
+        {
+            var specialCaseTableName = searchParamTableExpression.QueryGenerator.Table;
+
+            StringBuilder.Append("SELECT ")
+                .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T1, ")
+                .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1");
+
+            var searchParameterExpressionPredicate = searchParamTableExpression.Predicate as SearchParameterExpression;
+
+            // handle special case where we want to Union a specific resource to the results
+            if (searchParameterExpressionPredicate != null &&
+                searchParameterExpressionPredicate.Parameter.ColumnLocation().HasFlag(SearchParameterColumnLocation.ResourceTable))
+            {
+                specialCaseTableName = VLatest.Resource;
+                StringBuilder.Append("FROM ").AppendLine(specialCaseTableName);
+            }
+            else
+            {
+                // For Smart union expression, searchParamTableExpression.Predicate could be a multiary expression and not SearchParameterExpression
+                // To retrieve the main compartment resource we are building the Multiary expression with ResourceTypeId AND ResourceId (SearchParameterExpression)
+                // Check if its a Multiary expression, if yes then check the internal expressions are SearchParameterExpression of parameter _type and _id
+                // If yes then we can set the specialCaseTableName to Resource table and not to searchParamTableExpression.QueryGenerator.Table which will mostly be a ReferenceSearchParamTable
+                if (searchParamTableExpression.Predicate is MultiaryExpression multiaryExpression)
+                {
+                    bool allAreResourceTypeOrId = multiaryExpression.Expressions.All(e =>
+                        e is SearchParameterExpression spe &&
+                        (spe.Parameter.Name == SearchParameterNames.ResourceType || spe.Parameter.Name == SearchParameterNames.Id));
+
+                    if (allAreResourceTypeOrId)
+                    {
+                        specialCaseTableName = VLatest.Resource;
+                    }
+                }
+
+                StringBuilder.Append("FROM ").AppendLine(specialCaseTableName);
+            }
+
+            using (var delimited = StringBuilder.BeginDelimitedWhereClause())
+            {
+                // Apply History and Delete clause when querying from Resource table in case of compartment unions
+                AppendHistoryClause(delimited, context.ResourceVersionTypes, searchParamTableExpression, null, specialCaseTableName);
+
+                if (specialCaseTableName.Equals(VLatest.Resource))
+                {
+                    AppendDeletedClause(delimited, context.ResourceVersionTypes);
+                }
+
+                if (searchParamTableExpression.Predicate != null && !(searchParamTableExpression.Predicate is CompartmentSearchExpression))
+                {
+                    delimited.BeginDelimitedElement();
+                    searchParamTableExpression.Predicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
+                }
+            }
         }
 
         private void HandleTableKindNormal(SearchParamTableExpression searchParamTableExpression, SearchOptions context)
@@ -651,8 +662,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.AppendLine();
                     }
 
+                    // Fold the remainder predicate (for example the ResourceType filter) into each branch and reuse the
+                    // exact same union-branch projection that HandleParamTableUnion uses, so the branches are produced by
+                    // a single shared code path. The branches are emitted directly into the current CTE separated by
+                    // UNION ALL instead of each getting its own CTE.
                     Expression branchPredicate = CombinePredicates(noSplitUnion.Expressions[branchIndex], remainderPredicate);
-                    AppendChainLevelZeroNonSortNormalQuery(searchParamTableExpression, context, specialCaseTableName, branchPredicate);
+                    var branchTableExpression = new SearchParamTableExpression(
+                        searchParamTableExpression.QueryGenerator,
+                        branchPredicate,
+                        SearchParamTableExpressionKind.Union);
+
+                    AppendUnionBranchSelectBody(branchTableExpression, context);
                 }
 
                 return;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -196,7 +196,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     startPredicate,
                     endPredicate));
 
-            return Expression.Union(UnionOperator.All, new Expression[] { shortBranch, longBranch });
+            UnionExpression union = Expression.Union(UnionOperator.All, new Expression[] { shortBranch, longBranch });
+            union.DoNotSplitIntoSeparateCtes = true;
+            return union;
         }
 
         private static bool IsStartGe(BinaryExpression be) =>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -50,17 +50,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             ExactDay,
         }
 
-        public override Expression VisitChained(ChainedExpression expression, bool context)
-        {
-            Expression visitedExpression = expression.Expression.AcceptVisitor(this, context: true);
-            if (ReferenceEquals(visitedExpression, expression.Expression))
-            {
-                return expression;
-            }
-
-            return new ChainedExpression(expression.ResourceTypes, expression.ReferenceSearchParameter, expression.TargetResourceTypes, expression.Reversed, visitedExpression);
-        }
-
         public override Expression VisitSearchParameter(SearchParameterExpression expression, bool context)
         {
             if (context)
@@ -96,6 +85,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 Precision.ExactDay => BuildDaySplitUnion(expression.Parameter, startPredicate, endPredicate),
                 _ => expression,
             };
+        }
+
+        public override Expression VisitChained(ChainedExpression expression, bool context)
+        {
+            return expression;
         }
 
         internal static bool IsActivatedScalarTemporalParameter(SearchParameterExpression expression)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -96,6 +96,70 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport);
         }
 
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAChainedSearchExpressionOverBirthdateMonthPrecision_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&subject:Patient.birthdate=1990-05";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport, Fixture.TrumanSnomedDiagnosticReport, Fixture.TrumanLoincDiagnosticReport);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAChainedSearchExpressionOverBirthdateDayWithAdditionalCriteriaOnTheSameTarget_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&subject:Patient.birthdate={Fixture.SmithPatientBirthDate}&subject:Patient.family=Smith";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAChainedExactDayBirthdateWithBaseResourceSortAndSecondChainedPredicate_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string tag = Guid.NewGuid().ToString();
+            var meta = new Meta { Tag = new List<Coding> { new Coding("testTag", tag) } };
+            const string exactDay = "1951-06-08";
+
+            Patient matchingPatient = (await Client.CreateAsync(
+                new Patient { Meta = meta, BirthDate = exactDay, Name = new List<HumanName> { new HumanName { Family = "Smith" } } })).Resource;
+            Patient wrongFamilyPatient = (await Client.CreateAsync(
+                new Patient { Meta = meta, BirthDate = exactDay, Name = new List<HumanName> { new HumanName { Family = "Jones" } } })).Resource;
+            Patient wrongDayPatient = (await Client.CreateAsync(
+                new Patient { Meta = meta, BirthDate = "1951-06-09", Name = new List<HumanName> { new HumanName { Family = "Smith" } } })).Resource;
+
+            var code = new CodeableConcept("http://loinc.org", "4548-4");
+
+            Observation matchA = await CreateObservationWithEffective(matchingPatient, "2021-03-03");
+            Observation matchB = await CreateObservationWithEffective(matchingPatient, "2021-01-01");
+            await CreateObservationWithEffective(wrongFamilyPatient, "2021-02-02");
+            await CreateObservationWithEffective(wrongDayPatient, "2021-04-04");
+
+            string query = $"_tag={tag}&subject:Patient.birthdate={exactDay}&subject:Patient.family=Smith&_sort=-date&_count=100";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Observation, query);
+
+            ValidateBundle(bundle, matchA, matchB);
+
+            async Task<Observation> CreateObservationWithEffective(Patient patient, string effective)
+            {
+                return (await Client.CreateAsync(
+                    new Observation
+                    {
+                        Meta = meta,
+                        Status = ObservationStatus.Final,
+                        Code = code,
+                        Subject = new ResourceReference($"Patient/{patient.Id}"),
+                        Effective = new FhirDateTime(effective),
+                    })).Resource;
+            }
+        }
+
         [Fact]
         public async Task GivenAChainedSearchExpressionOverASimpleParameter_WhenSearchedWithPaging_ThenCorrectBundleShouldBeReturned()
         {
@@ -143,6 +207,86 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             ValidateBundle(bundle, Fixture.TrumanPatient);
         }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GivenAReverseChainSearchExpressionCombinedWithAnExactDayBirthdate_WhenSearched_ThenCorrectBundleShouldBeReturned(bool includeAccurateTotal)
+        {
+            string query = $"_tag={Fixture.Tag}&birthdate={Fixture.SmithPatientBirthDate}&_has:Observation:patient:code={Fixture.SnomedCode}";
+            if (includeAccurateTotal)
+            {
+                query += "&_total=accurate";
+            }
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
+
+            if (includeAccurateTotal)
+            {
+                Assert.Equal(1, bundle.Total.GetValueOrDefault());
+            }
+
+            ValidateBundle(bundle, Fixture.SmithPatient);
+        }
+
+#if !Stu3
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAReverseChainSearchExpressionOverImagingStudyStartedCombinedWithAnExactDayBirthdateAndTag_WhenSearchedWithPost_ThenCorrectBundleShouldBeReturned()
+        {
+            string tenantTagCode = Guid.NewGuid().ToString("N");
+            var tenantMeta = new Meta
+            {
+                Tag = new List<Coding>
+                {
+                    new Coding(Fixture.TenantTagSystem, tenantTagCode),
+                },
+            };
+
+            Patient imagingStudyExactDayPatient = (await Client.CreateAsync(
+                new Patient
+                {
+                    Meta = tenantMeta,
+                    BirthDate = Fixture.ImagingStudyPatientBirthDate,
+                })).Resource;
+
+            Patient imagingStudyMonthPrecisionPatient = (await Client.CreateAsync(
+                new Patient
+                {
+                    Meta = tenantMeta,
+                    BirthDate = Fixture.ImagingStudyMonthPrecisionPatientBirthDate,
+                })).Resource;
+
+            await Client.CreateAsync(
+                new ImagingStudy
+                {
+                    Meta = tenantMeta,
+                    Status = ImagingStudy.ImagingStudyStatus.Available,
+                    Subject = new ResourceReference($"Patient/{imagingStudyExactDayPatient.Id}"),
+                    Started = Fixture.ImagingStudyStarted,
+                });
+
+            await Client.CreateAsync(
+                new ImagingStudy
+                {
+                    Meta = tenantMeta,
+                    Status = ImagingStudy.ImagingStudyStatus.Available,
+                    Subject = new ResourceReference($"Patient/{imagingStudyMonthPrecisionPatient.Id}"),
+                    Started = Fixture.ImagingStudyStarted,
+                });
+
+            Bundle bundle = await Client.SearchPostAsync(
+                ResourceType.Patient.ToString(),
+                null,
+                default,
+                ("_has:ImagingStudy:patient:started", Fixture.ImagingStudyStarted),
+                ("birthdate", Fixture.ImagingStudyPatientBirthDate),
+                ("_tag", $"{Fixture.TenantTagSystem}|{tenantTagCode}"));
+
+            ValidateBundle(bundle, imagingStudyExactDayPatient, imagingStudyMonthPrecisionPatient);
+        }
+#endif
 
         [Fact]
         public async Task GivenAReverseChainSearchExpressionWithMultipleTargetTypes_WhenSearched_ThenCorrectBundleShouldBeReturned()
@@ -399,6 +543,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             public string OrganizationCity { get; } = Guid.NewGuid().ToString();
 
             public string OrganizationIdentifier { get; } = Guid.NewGuid().ToString();
+
+#if !Stu3
+            public string TenantTagSystem { get; } = "urn:tenantId";
+
+            public string ImagingStudyPatientBirthDate { get; } = "2018-06-06";
+
+            public string ImagingStudyMonthPrecisionPatientBirthDate { get; } = "2018-06";
+
+            public string ImagingStudyStarted { get; } = "2018-02-02T05:00:00.000";
+#endif
 
             public Patient SmithPatient { get; private set; }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -298,10 +298,161 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
         }
 
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByMultiValueOr_ThenUnionOfPerValueOverlapSetsIsReturned()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03,2001-12-31&_tag={tag}");
+
+            ValidateBundle(bundle, matrix.Year2000, matrix.March2000, matrix.March03, matrix.Year2001, matrix.December2001, matrix.December31_2001);
+            AssertNoDuplicateEntries(bundle);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByNotEquals_ThenOnlyTheExactDayValueIsExcluded()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=ne2000-03-03&_tag={tag}&_total=accurate&_count=100");
+
+            Assert.Equal(11, bundle.Total.GetValueOrDefault());
+            ValidateBundle(
+                bundle,
+                matrix.Year2000,
+                matrix.March2000,
+                matrix.December31_1999,
+                matrix.April01_2000,
+                matrix.December2000,
+                matrix.March31_2000,
+                matrix.Year2001,
+                matrix.November30_2001,
+                matrix.December2001,
+                matrix.December31_2001,
+                matrix.January01_2002);
+            AssertNoDuplicateEntries(bundle);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenDayEqualitySearchedWithTotal_ThenCountIsAccurateAndEntriesAreNotDuplicated()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_tag={tag}&_total=accurate");
+
+            Assert.Equal(3, bundle.Total.GetValueOrDefault());
+            ValidateBundle(bundle, matrix.Year2000, matrix.March2000, matrix.March03);
+            AssertNoDuplicateEntries(bundle);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenDayEqualitySearchedWithSort_ThenResultsAreOrderedByBirthdateWithoutDuplicates()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_sort=birthdate&_tag={tag}");
+
+            AssertNoDuplicateEntries(bundle);
+            Assert.Equal(
+                new[] { matrix.Year2000.Id, matrix.March2000.Id, matrix.March03.Id },
+                bundle.Entry.Select(e => e.Resource.Id).ToArray());
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithLeapDayBirthdates_WhenSearchedByDay_ThenCorrectBundleShouldBeReturned()
+        {
+            string tag = Guid.NewGuid().ToString();
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientBirthDate(p, "2020", tag),
+                p => SetPatientBirthDate(p, "2020-02", tag),
+                p => SetPatientBirthDate(p, "2020-02-28", tag),
+                p => SetPatientBirthDate(p, "2020-02-29", tag),
+                p => SetPatientBirthDate(p, "2020-03-01", tag));
+            Patient year2020 = patients[0];
+            Patient february2020 = patients[1];
+            Patient february28 = patients[2];
+            Patient february29 = patients[3];
+            Patient march01 = patients[4];
+
+            Bundle leapDayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2020-02-29&_tag={tag}");
+            ValidateBundle(leapDayBundle, year2020, february2020, february29);
+
+            Bundle feb28Bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2020-02-28&_tag={tag}");
+            ValidateBundle(feb28Bundle, year2020, february2020, february28);
+
+            Bundle march01Bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2020-03-01&_tag={tag}");
+            ValidateBundle(march01Bundle, year2020, march01);
+        }
+
+        private async Task<PartialBirthdateMatrix> CreatePartialBirthdateMatrixAsync(string tag)
+        {
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientBirthDate(p, "2000", tag),
+                p => SetPatientBirthDate(p, "2000-03", tag),
+                p => SetPatientBirthDate(p, "2000-03-03", tag),
+                p => SetPatientBirthDate(p, "1999-12-31", tag),
+                p => SetPatientBirthDate(p, "2000-04-01", tag),
+                p => SetPatientBirthDate(p, "2000-12", tag),
+                p => SetPatientBirthDate(p, "2000-03-31", tag),
+                p => SetPatientBirthDate(p, "2001", tag),
+                p => SetPatientBirthDate(p, "2001-11-30", tag),
+                p => SetPatientBirthDate(p, "2001-12", tag),
+                p => SetPatientBirthDate(p, "2001-12-31", tag),
+                p => SetPatientBirthDate(p, "2002-01-01", tag));
+
+            return new PartialBirthdateMatrix(
+                Year2000: patients[0],
+                March2000: patients[1],
+                March03: patients[2],
+                December31_1999: patients[3],
+                April01_2000: patients[4],
+                December2000: patients[5],
+                March31_2000: patients[6],
+                Year2001: patients[7],
+                November30_2001: patients[8],
+                December2001: patients[9],
+                December31_2001: patients[10],
+                January01_2002: patients[11]);
+        }
+
+        private static void AssertNoDuplicateEntries(Bundle bundle)
+        {
+            List<string> ids = bundle.Entry.Select(e => e.Resource.Id).ToList();
+            Assert.Equal(ids.Count, ids.Distinct().Count());
+        }
+
         private static void SetPatientBirthDate(Patient patient, string birthDate, string tag)
         {
             patient.Meta = new Meta { Tag = new List<Coding> { new Coding(null, tag) } };
             patient.BirthDate = birthDate;
         }
+
+        private sealed record PartialBirthdateMatrix(
+            Patient Year2000,
+            Patient March2000,
+            Patient March03,
+            Patient December31_1999,
+            Patient April01_2000,
+            Patient December2000,
+            Patient March31_2000,
+            Patient Year2001,
+            Patient November30_2001,
+            Patient December2001,
+            Patient December31_2001,
+            Patient January01_2002);
     }
 }


### PR DESCRIPTION
## Description
This change marks the day-split union emitted by `ScalarTemporalEqualityRewriter` for exact birthdate equality so SQL expression splitting does not break it into multiple CTE branches. Keeping that union intact reduces query-shape complexity while preserving existing short-date and long-date branch behavior.

It also adds regression coverage for union split/no-split decisions and ports DOB-focused date/chaining E2E scenarios from `mikaelweave/fix-temporal-rewriter-union-handling`.

## Related issues
N/A

## Testing
- `dotnet test src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj -c Release -f net9.0`
- `dotnet test src/Microsoft.Health.Fhir.SqlServer.UnitTests/Microsoft.Health.Fhir.SqlServer.UnitTests.csproj -c Release -f net9.0`

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch