### PR TITLE
Fix temporal rewriter ignoring chained searches

### DIFF
--- a/docs/arch/adr-2605-scalar-temporal-equality-rewriter.md
+++ b/docs/arch/adr-2605-scalar-temporal-equality-rewriter.md
@@ -1,4 +1,4 @@
-# Scalar Temporal Equality Rewriter for Birthdate
+# ADR-2605: Scalar Temporal Equality Rewriter for Birthdate
 
 ## Context
 
@@ -8,6 +8,8 @@ The table carries a filtered index intended for the rare wide rows:
 `IX_SearchParamId_StartDateTime_EndDateTime_INCLUDE_IsMin_IsMax_WHERE_IsLongerThanADay_1`. For `IsLongerThanADay = 0` there is no filtered index — the common short rows are served by the general `IX_SearchParamId_StartDateTime_EndDateTime_INCLUDE_IsLongerThanADay_IsMin_IsMax`. The previous SQL generated creates a two-predicate form which doesn't build SQL the planner can use to target either index. This means it picks a generic seek on the clustered index which is far less efficient than using the non-clustered indexes on our indexes we have.
 
 The FHIR containment semantics for partial-date equality are separately tracked by AB#191826 and intentionally left untouched here.
+
+Later validation found that emitting the birthdate rewrite as a `UnionExpression` also requires SQL generation to preserve CTE predecessor semantics for top-level `Normal` + `Concatenation` date-range pairs.
 
 ## Decision
 
@@ -24,12 +26,16 @@ All other shapes — month/year precision, approximate (`ap`), single-sided rang
 
 There is also discussion on if the data returned by this query is matching the FHIR spec. In this change we are only keeping current behavior. If we change our date range return values in the future we can simply remove the second (union) part of the rewrite query easily.
 
+SQL generation supports this union shape only at the **top level of a non-chained query**. When the query also contains a chained or reverse-chained (`_has`) expression, a day-split union — whether nested inside the chain or sitting beside it as a top-level sibling — produces SQL the chained generator joins incorrectly: the union aggregate ends up restricted on the chain SOURCE columns instead of the chain TARGET, returning zero rows. To keep the change small and confine the union to where it is well understood, the rewriter is therefore **skipped for the entire query whenever the expression tree contains any chained or reverse-chained expression** (detected before chain flattening in `ScalarTemporalEqualityRewriter.Rewrite`). Such searches fall back to the standard two-predicate datetime-range filter — correct results, just without the `IsLongerThanADay` union optimization in the presence of a chain (this matches the behavior that existed before the rewriter). A narrower guard that only skipped birthdates *nested inside* a chain was insufficient, because a top-level birthdate beside a reverse `_has` chain still triggered the broken union path.
+
 ## Status
 
- Accepted
+Accepted
 
 ## Consequences
 
 - Day-precision birthdate equality consistently picks the intended filtered/specific indexes per branch instead of a generic plan over the mixed population, reducing logical reads on `dbo.DateTimeSearchParam` for the dominant workload.
+- The SQL generator keeps CTE predecessor resolution tied to generated CTE order, so a top-level union expansion does not make a following `Concatenation` predicate join the wrong predecessor.
+- Any exact-day birthdate search whose query also contains a chained or reverse-chained (`_has`) expression is intentionally skipped — including when the birthdate is a top-level sibling of the chain — and falls back to the standard datetime-range predicate; it returns correct results without the union optimization. This keeps the union shape limited to top-level, non-chained queries and avoids the extra SQL-generation machinery a chain-adjacent union would require. Regression covered by E2E `ChainingSearchTests.GivenAReverseChainSearchExpressionCombinedWithAnExactDayBirthdate`.
 - The long branch becomes dead once AB#191826 lands; at that point the union collapses to the short branch and this ADR should be revisited.
 - The allow-list (currently `individual-birthdate`) limits blast radius. Extending the optimization to additional scalar date parameters is a follow-up that requires confirming the same single-element storage assumption.

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ResourceColumnPredicatePushdownRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ResourceColumnPredicatePushdownRewriterTests.cs
@@ -141,5 +141,91 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             Assert.Equal(inputExpression.SearchParamTableExpressions[0].ChainLevel, visitedExpression.SearchParamTableExpressions[0].ChainLevel);
             Assert.Same(inputExpression.SearchParamTableExpressions[1], visitedExpression.SearchParamTableExpressions[1]);
         }
+
+        [Fact]
+        public void GivenTopLevelUnionWithExtractableResourceColumnExpression_WhenRewritten_ResourceColumnDistributedIntoEachUnionBranch()
+        {
+            // The exact-day birthdate rewrite produces a top-level UNION ALL leaf. The common resource predicate
+            // (_type / ResourceTypeId) must be folded into EACH union branch rather than wrapping the whole union,
+            // so SplitExpressions does not later peel it back out into a separate ResourceTypeId-grounding CTE.
+            var branch1 = new SearchParameterExpression(new SearchParameterInfo("birthdate", "birthdate"), Expression.Equals(FieldName.String, null, "branch1"));
+            var branch2 = new SearchParameterExpression(new SearchParameterInfo("birthdate", "birthdate"), Expression.Equals(FieldName.String, null, "branch2"));
+            UnionExpression union = Expression.Union(UnionOperator.All, new Expression[] { branch1, branch2 });
+
+            var resourceTypeExpression = new SearchParameterExpression(
+                new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceType),
+                Expression.Equals(FieldName.String, null, "Patient"));
+
+            var inputExpression = new SqlRootExpression(
+                new List<SearchParamTableExpression>
+                {
+                    new SearchParamTableExpression(null, union, SearchParamTableExpressionKind.Normal),
+                },
+                new List<SearchParameterExpressionBase> { resourceTypeExpression });
+
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(ResourceColumnPredicatePushdownRewriter.Instance);
+
+            // The predicate stays a bare UnionExpression (no And wrapper that would force a grounding CTE) ...
+            var rewrittenUnion = Assert.IsType<UnionExpression>(visitedExpression.SearchParamTableExpressions[0].Predicate);
+            Assert.Equal(union.Operator, rewrittenUnion.Operator);
+            Assert.Equal(2, rewrittenUnion.Expressions.Count);
+
+            // ... with the resource predicate ANDed into every branch.
+            Assert.Equal(Expression.And(branch1, resourceTypeExpression).ToString(), rewrittenUnion.Expressions[0].ToString());
+            Assert.Equal(Expression.And(branch2, resourceTypeExpression).ToString(), rewrittenUnion.Expressions[1].ToString());
+        }
+
+        [Fact]
+        public void GivenTopLevelSmartV2UnionWithExtractableResourceColumnExpression_WhenRewritten_ResourceColumnWrapsUnionWithoutDistribution()
+        {
+            // SMART v2 scope unions keep their original And(Union, resource) shape so their established SQL is
+            // unchanged. Option A's branch distribution must not touch them.
+            var branch1 = new SearchParameterExpression(new SearchParameterInfo("birthdate", "birthdate"), Expression.Equals(FieldName.String, null, "branch1"));
+            var branch2 = new SearchParameterExpression(new SearchParameterInfo("birthdate", "birthdate"), Expression.Equals(FieldName.String, null, "branch2"));
+            UnionExpression union = Expression.Union(UnionOperator.All, new Expression[] { branch1, branch2 });
+            union.IsSmartV2UnionExpressionForScopesSearchParameters = true;
+
+            var resourceTypeExpression = new SearchParameterExpression(
+                new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceType),
+                Expression.Equals(FieldName.String, null, "Patient"));
+
+            var inputExpression = new SqlRootExpression(
+                new List<SearchParamTableExpression>
+                {
+                    new SearchParamTableExpression(null, union, SearchParamTableExpressionKind.Normal),
+                },
+                new List<SearchParameterExpressionBase> { resourceTypeExpression });
+
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(ResourceColumnPredicatePushdownRewriter.Instance);
+
+            Assert.Equal(
+                Expression.And(union, resourceTypeExpression).ToString(),
+                visitedExpression.SearchParamTableExpressions[0].Predicate.ToString());
+        }
+
+        [Fact]
+        public void GivenChainNestedUnionWithExtractableResourceColumnExpression_WhenRewritten_UnionTableExpressionIsUnchanged()
+        {
+            // A chain-nested union (Normal, ChainLevel > 0) must NOT be distributed - the chained-union SQL path
+            // owns that shape. Option A is scoped to top-level (ChainLevel 0) unions only.
+            var branch1 = new SearchParameterExpression(new SearchParameterInfo("birthdate", "birthdate"), Expression.Equals(FieldName.String, null, "branch1"));
+            var branch2 = new SearchParameterExpression(new SearchParameterInfo("birthdate", "birthdate"), Expression.Equals(FieldName.String, null, "branch2"));
+            UnionExpression union = Expression.Union(UnionOperator.All, new Expression[] { branch1, branch2 });
+
+            var unionTableExpression = new SearchParamTableExpression(null, union, SearchParamTableExpressionKind.Normal, chainLevel: 1);
+
+            var inputExpression = new SqlRootExpression(
+                new List<SearchParamTableExpression> { unionTableExpression },
+                new List<SearchParameterExpressionBase>
+                {
+                    new SearchParameterExpression(
+                        new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceType),
+                        Expression.Equals(FieldName.String, null, "Patient")),
+                });
+
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(ResourceColumnPredicatePushdownRewriter.Instance);
+
+            Assert.Same(unionTableExpression, visitedExpression.SearchParamTableExpressions[0]);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
@@ -81,13 +81,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
                 targetResourceTypes: new[] { "Patient" });
         }
 
-        private static ChainedExpression BuildChainedExpression(Expression inner)
+        private static ChainedExpression BuildChainedExpression(Expression inner, bool reversed = false)
         {
             var expression = (ChainedExpression)RuntimeHelpers.GetUninitializedObject(typeof(ChainedExpression));
             SetBackingField(expression, nameof(ChainedExpression.ResourceTypes), new[] { "Observation" });
             SetBackingField(expression, nameof(ChainedExpression.ReferenceSearchParameter), BuildReferenceParam());
             SetBackingField(expression, nameof(ChainedExpression.TargetResourceTypes), new[] { "Patient" });
-            SetBackingField(expression, nameof(ChainedExpression.Reversed), false);
+            SetBackingField(expression, nameof(ChainedExpression.Reversed), reversed);
             SetBackingField(expression, nameof(ChainedExpression.Expression), inner);
             return expression;
         }
@@ -136,6 +136,44 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             var result = Assert.IsType<ChainedExpression>(expr.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance));
 
             Assert.Same(inner, result.Expression);
+        }
+
+        [Fact]
+        public void GivenTopLevelBirthdateExactDayBesideForwardChain_WhenRewritten_ThenPassThroughWithoutUnion()
+        {
+            // The failing-shape: an eligible top-level birthdate equality sitting BESIDE a chain (not nested in it).
+            var birthdate = new SearchParameterExpression(BuildBirthdateParam(), EqualityPattern(StartOfDay, EndOfDay));
+            var chain = BuildChainedExpression(Expression.GreaterThan(FieldName.DateTimeStart, null, EndOfDay), reversed: false);
+            var tree = Expression.And(birthdate, chain);
+
+            var result = ScalarTemporalEqualityRewriter.Rewrite(tree);
+
+            // Any chain in the tree makes the whole query ineligible: nothing is rewritten, no UNION is produced.
+            Assert.Same(tree, result);
+        }
+
+        [Fact]
+        public void GivenTopLevelBirthdateExactDayBesideReverseChain_WhenRewritten_ThenPassThroughWithoutUnion()
+        {
+            // Reverse chains (_has) are ChainedExpression with Reversed=true; the same suppression must apply.
+            var birthdate = new SearchParameterExpression(BuildBirthdateParam(), EqualityPattern(StartOfDay, EndOfDay));
+            var reverseChain = BuildChainedExpression(Expression.GreaterThan(FieldName.DateTimeStart, null, EndOfDay), reversed: true);
+            var tree = Expression.And(birthdate, reverseChain);
+
+            var result = ScalarTemporalEqualityRewriter.Rewrite(tree);
+
+            Assert.Same(tree, result);
+        }
+
+        [Fact]
+        public void GivenAllowListedBirthdateExactDayWithoutChain_WhenRewrittenViaRewrite_ThenEmitsDaySplitUnion()
+        {
+            // No chain present, so Rewrite must still apply the day-split optimization (high-volume path preserved).
+            var expr = new SearchParameterExpression(BuildBirthdateParam(), EqualityPattern(StartOfDay, EndOfDay));
+
+            var result = ScalarTemporalEqualityRewriter.Rewrite(expr);
+
+            AssertDaySplitUnion(result, StartOfDay, EndOfDay);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/Visitors/SortRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/Visitors/SortRewriterTests.cs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.ValueSets;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions.Visitors
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SortRewriterTests
+    {
+        private static readonly SearchParameterInfo BirthdateParam = new SearchParameterInfo(
+            "birthdate",
+            "birthdate",
+            SearchParamType.Date,
+            new Uri("http://hl7.org/fhir/SearchParameter/individual-birthdate"),
+            expression: "Patient.birthDate",
+            baseResourceTypes: new[] { "Patient" });
+
+        private static readonly SearchParameterInfo NameParam = new SearchParameterInfo(
+            "name",
+            "name",
+            SearchParamType.String,
+            new Uri("http://hl7.org/fhir/SearchParameter/individual-name"),
+            expression: "Patient.name",
+            baseResourceTypes: new[] { "Patient" });
+
+        private static readonly DateTimeOffset StartOfDay = new DateTimeOffset(2016, 7, 6, 0, 0, 0, TimeSpan.Zero);
+        private static readonly DateTimeOffset EndOfDay = new DateTimeOffset(2016, 7, 6, 23, 59, 59, TimeSpan.Zero).AddTicks(9999999);
+
+        private readonly SortRewriter _rewriter;
+
+        public SortRewriterTests()
+        {
+            var map = new SearchParameterToSearchValueTypeMap();
+            var factory = new SearchParamTableExpressionQueryGeneratorFactory(map);
+            _rewriter = new SortRewriter(factory);
+        }
+
+        public static TheoryData<Expression, SortOrder, bool> SortCoverageCases => new()
+        {
+            { BuildBirthdateDaySplitUnion(), SortOrder.Ascending, true },
+            {
+                Expression.Union(
+                    UnionOperator.All,
+                    new Expression[]
+                    {
+                        new SearchParameterExpression(BirthdateParam, Expression.Equals(FieldName.DateTimeEnd, null, EndOfDay)),
+                        new SearchParameterExpression(NameParam, Expression.Equals(FieldName.String, null, "Smith")),
+                    }),
+                SortOrder.Descending,
+                false
+            },
+        };
+
+        private static SqlSearchOptions BuildSortOptions(SearchParameterInfo sortParam, SortOrder order = SortOrder.Ascending)
+        {
+            var inner = new SearchOptions
+            {
+                Sort = new List<(SearchParameterInfo, SortOrder)> { (sortParam, order) },
+                UnsupportedSearchParams = new List<Tuple<string, string>>(),
+                ResourceVersionTypes = ResourceVersionType.Latest,
+            };
+            return new SqlSearchOptions(inner);
+        }
+
+        private static UnionExpression BuildBirthdateDaySplitUnion()
+        {
+            var shortBranch = new SearchParameterExpression(
+                BirthdateParam,
+                Expression.And(
+                    Expression.Equals(SqlFieldName.DateTimeIsLongerThanADay, null, false),
+                    Expression.Equals(FieldName.DateTimeEnd, null, EndOfDay)));
+
+            var longBranch = new SearchParameterExpression(
+                BirthdateParam,
+                Expression.And(
+                    Expression.Equals(SqlFieldName.DateTimeIsLongerThanADay, null, true),
+                    Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, StartOfDay),
+                    Expression.LessThanOrEqual(FieldName.DateTimeEnd, null, EndOfDay)));
+
+            return Expression.Union(UnionOperator.All, new Expression[] { shortBranch, longBranch });
+        }
+
+        [Theory]
+        [MemberData(nameof(SortCoverageCases))]
+        public void GivenSortPredicateCoverage_WhenRewritten_ThenSortWithFilterEmittedOnlyWhenAllBranchesMatch(Expression predicate, SortOrder sortOrder, bool expectMatch)
+        {
+            var tableExpr = new SearchParamTableExpression(DateTimeQueryGenerator.Instance, predicate, SearchParamTableExpressionKind.Normal);
+            var root = SqlRootExpression.WithSearchParamTableExpressions(new List<SearchParamTableExpression> { tableExpr });
+            var options = BuildSortOptions(BirthdateParam, sortOrder);
+
+            var result = (SqlRootExpression)root.AcceptVisitor(_rewriter, options);
+
+            SearchParamTableExpressionKind expected = expectMatch ? SearchParamTableExpressionKind.SortWithFilter : SearchParamTableExpressionKind.Sort;
+            SearchParamTableExpressionKind unexpected = expectMatch ? SearchParamTableExpressionKind.Sort : SearchParamTableExpressionKind.SortWithFilter;
+
+            Assert.Equal(expectMatch, options.IsSortWithFilter);
+            Assert.Contains(result.SearchParamTableExpressions, e => e.Kind == expected);
+            Assert.DoesNotContain(result.SearchParamTableExpressions, e => e.Kind == unexpected);
+            Assert.DoesNotContain(result.SearchParamTableExpressions, e => e.Kind == SearchParamTableExpressionKind.NotExists);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
@@ -213,4 +213,206 @@ public class SqlQueryGeneratorTests
         _fhirModel.Received(1).TryGetResourceTypeId("Patient", out Arg.Any<short>());
         _fhirModel.Received(1).TryGetResourceTypeId("Practitioner", out Arg.Any<short>());
     }
+
+    [Fact]
+    public void GivenUnionFollowedByConcatenationPair_WhenSqlGenerated_ThenBothBranchesShareUnionAggregatePredecessor()
+    {
+        // Reproduces the ScalarTemporalEqualityRewriter union + ConcatenationRewriter (DateTimeBoundedRangeRewriter)
+        // interaction. The union inflates the CTE counter; the Normal/Concatenation pair that follows must both
+        // restrict against the union aggregate, not against each other.
+        SearchParamTableExpression unionTableExpression = BuildBareBirthdateUnionTableExpression();
+        (SearchParamTableExpression normal, SearchParamTableExpression concatenation) = BuildBoundedDateRangePair();
+
+        SqlRootExpression sqlExpression = new(
+            new List<SearchParamTableExpression> { unionTableExpression, normal, concatenation },
+            new List<SearchParameterExpressionBase>());
+        SearchOptions searchOptions = new()
+        {
+            Sort = [],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+        string sql = _strBuilder.ToString();
+
+        // Generation order: cte0/cte1 = union branches, cte2 = union aggregate,
+        // cte3 = Normal (long-range) sibling, cte4 = Concatenation (short-range) sibling.
+        // Both the Normal sibling and the Concatenation must restrict against the shared union
+        // aggregate (cte2). Before the fix, the Concatenation incorrectly restricted against its
+        // own sibling cte3 because the union had inflated the CTE counter.
+        Assert.Equal(2, CountOccurrences(sql, "EXISTS (SELECT * FROM cte2"));
+        Assert.DoesNotContain("EXISTS (SELECT * FROM cte3", sql);
+
+        // The Concatenation still unions in its Normal sibling (cte3) as a data source - that reference is correct.
+        Assert.Contains("SELECT * FROM cte3", sql);
+    }
+
+    [Fact]
+    public void GivenNormalFilterFollowedByConcatenationPair_WhenSqlGenerated_ThenBothBranchesShareLeadingPredecessor()
+    {
+        // Regression guard for the non-union path: a leading Normal filter followed by a Normal/Concatenation pair.
+        // The predecessor finder must resolve both pair branches to the leading filter (cte0), matching the
+        // behavior that existed before the union-aware rewrite.
+        var leadingStart = new DateTimeOffset(2010, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var leadingPredicate = new SearchParameterExpression(BuildBirthdateParam(), Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, leadingStart));
+        var leading = new SearchParamTableExpression(DateTimeQueryGenerator.Instance, leadingPredicate, SearchParamTableExpressionKind.Normal);
+        (SearchParamTableExpression normal, SearchParamTableExpression concatenation) = BuildBoundedDateRangePair();
+
+        SqlRootExpression sqlExpression = new(
+            new List<SearchParamTableExpression> { leading, normal, concatenation },
+            new List<SearchParameterExpressionBase>());
+        SearchOptions searchOptions = new()
+        {
+            Sort = [],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+        string sql = _strBuilder.ToString();
+
+        // Generation order: cte0 = leading Normal, cte1 = Normal (long-range) sibling,
+        // cte2 = Concatenation (short-range) sibling. With no union inflating the counter, both the
+        // Normal sibling and the Concatenation restrict against the shared leading predecessor (cte0).
+        Assert.Equal(2, CountOccurrences(sql, "EXISTS (SELECT * FROM cte0"));
+        Assert.DoesNotContain("EXISTS (SELECT * FROM cte1", sql);
+        Assert.Contains("SELECT * FROM cte1", sql);
+    }
+
+    [Fact]
+    public void GivenTwoConsecutiveConcatenationPairs_WhenSqlGenerated_ThenSecondPairRestrictsAgainstFirstPairResult()
+    {
+        // Stacked pairs: cte0/cte1 = first (Normal, Concatenation) pair, cte2/cte3 = second pair. The predecessor
+        // of the second pair is the second branch of the FIRST pair (cte1), exercising the case where a
+        // Concatenation's predecessor is itself a Concatenation. Both second-pair branches must resolve to cte1,
+        // never to the second pair's own Normal sibling (cte2).
+        (SearchParamTableExpression normalA, SearchParamTableExpression concatA) = BuildBoundedDateRangePair();
+        (SearchParamTableExpression normalB, SearchParamTableExpression concatB) = BuildBoundedDateRangePair();
+
+        SqlRootExpression sqlExpression = new(
+            new List<SearchParamTableExpression> { normalA, concatA, normalB, concatB },
+            new List<SearchParameterExpressionBase>());
+        SearchOptions searchOptions = new()
+        {
+            Sort = [],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+        string sql = _strBuilder.ToString();
+
+        Assert.Equal(2, CountOccurrences(sql, "EXISTS (SELECT * FROM cte1"));
+        Assert.DoesNotContain("EXISTS (SELECT * FROM cte2", sql);
+        Assert.Contains("SELECT * FROM cte2", sql); // concatB unions in its Normal sibling (cte2) as a data source
+    }
+
+    private static SearchParameterInfo BuildBirthdateParam() =>
+        new SearchParameterInfo(
+            "birthdate",
+            "birthdate",
+            SearchParamType.Date,
+            new Uri("http://hl7.org/fhir/SearchParameter/individual-birthdate"),
+            expression: "Patient.birthDate",
+            baseResourceTypes: new[] { "Patient" });
+
+    private static SearchParamTableExpression BuildBareBirthdateUnionTableExpression() =>
+        BuildBirthdateUnionTableExpression(chainLevel: 0);
+
+    private static SearchParamTableExpression BuildBirthdateUnionTableExpression(int chainLevel)
+    {
+        var startOfDay = new DateTimeOffset(2016, 7, 6, 0, 0, 0, TimeSpan.Zero);
+        var endOfDay = new DateTimeOffset(2016, 7, 6, 23, 59, 59, TimeSpan.Zero);
+        var shortBranch = new SearchParameterExpression(BuildBirthdateParam(), Expression.Equals(FieldName.DateTimeEnd, null, endOfDay));
+        var longBranch = new SearchParameterExpression(BuildBirthdateParam(), Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, startOfDay));
+        UnionExpression union = Expression.Union(UnionOperator.All, new Expression[] { shortBranch, longBranch });
+
+        return new SearchParamTableExpression(DateTimeQueryGenerator.Instance, union, SearchParamTableExpressionKind.Normal, chainLevel);
+    }
+
+    private void SetupChainModel()
+    {
+        _fhirModel.TryGetResourceTypeId("MedicationDispense", out Arg.Any<short>())
+            .Returns(x =>
+            {
+                x[1] = (short)10;
+                return true;
+            });
+        _fhirModel.TryGetResourceTypeId("Patient", out Arg.Any<short>())
+            .Returns(x =>
+            {
+                x[1] = (short)1;
+                return true;
+            });
+        _fhirModel.GetSearchParamId(Arg.Any<Uri>()).Returns((short)100);
+    }
+
+    // Produces a [Normal, Concatenation] pair from a bounded date range using the real DateTimeBoundedRangeRewriter,
+    // preserving DateTimeQueryGenerator on both expressions so the SQL generator emits predecessor restrictions.
+    private static (SearchParamTableExpression Normal, SearchParamTableExpression Concatenation) BuildBoundedDateRangePair()
+    {
+        var rangeStart = new DateTimeOffset(2024, 1, 15, 0, 0, 0, TimeSpan.Zero);
+        var rangeEnd = new DateTimeOffset(2024, 1, 16, 0, 0, 0, TimeSpan.Zero);
+        var rangeAnd = Expression.And(
+            Expression.GreaterThanOrEqual(FieldName.DateTimeEnd, null, rangeStart),
+            Expression.LessThan(FieldName.DateTimeStart, null, rangeEnd));
+        var predicate = new SearchParameterExpression(BuildBirthdateParam(), rangeAnd);
+
+        SqlRootExpression root = new(
+            new List<SearchParamTableExpression> { new(DateTimeQueryGenerator.Instance, predicate, SearchParamTableExpressionKind.Normal) },
+            new List<SearchParameterExpressionBase>());
+
+        var rewritten = (SqlRootExpression)root.AcceptVisitor(DateTimeBoundedRangeRewriter.Instance, null);
+
+        Assert.Equal(2, rewritten.SearchParamTableExpressions.Count);
+        Assert.Equal(SearchParamTableExpressionKind.Normal, rewritten.SearchParamTableExpressions[0].Kind);
+        Assert.Equal(SearchParamTableExpressionKind.Concatenation, rewritten.SearchParamTableExpressions[1].Kind);
+
+        return (rewritten.SearchParamTableExpressions[0], rewritten.SearchParamTableExpressions[1]);
+    }
+
+    [Fact]
+    public void GivenTopLevelBirthdateUnionWithResourceTypeConstraint_WhenSqlGenerated_ThenConstraintIsDistributedIntoBranchesAndNoGroundingCteIsEmitted()
+    {
+        // Option A: a top-level (ChainLevel 0) exact-day birthdate becomes a UNION ALL, and the request also carries
+        // a resource-column constraint (_type=Patient). ResourceColumnPredicatePushdownRewriter distributes that
+        // constraint INTO each union branch - Union[And(b1, _type), And(b2, _type)] - instead of wrapping the whole
+        // union - And(Union[b1, b2], _type). Distribution is valid because every branch reads the same table/partition.
+        // The payoff: each branch carries the ResourceTypeId filter directly, so SplitExpressions finds no residual
+        // resource predicate and emits NO extra dbo.Resource grounding CTE; the union aggregate is consumed directly.
+        SetupChainModel();
+
+        SearchParamTableExpression unionTableExpression = BuildBareBirthdateUnionTableExpression();
+        var resourceType = new SearchParameterExpression(
+            new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceType),
+            Expression.StringEquals(FieldName.String, null, "Patient", false));
+
+        SqlRootExpression sqlExpression = new(
+            new List<SearchParamTableExpression> { unionTableExpression },
+            new List<SearchParameterExpressionBase> { resourceType });
+
+        var pushedDown = (SqlRootExpression)sqlExpression.AcceptVisitor(ResourceColumnPredicatePushdownRewriter.Instance);
+
+        SearchOptions searchOptions = new()
+        {
+            Sort = [],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(pushedDown, searchOptions);
+        string sql = _strBuilder.ToString();
+
+        // The union is preserved...
+        Assert.Contains("UNION ALL", sql);
+
+        // ...and the resource-type constraint (Patient -> ResourceTypeId = 1 per SetupChainModel) is pushed into BOTH
+        // branches rather than a single trailing grounding CTE.
+        Assert.Equal(2, CountOccurrences(sql, "AND ResourceTypeId = 1"));
+
+        // Generation order with distribution: cte0/cte1 = branches, cte2 = union aggregate. No cte3: the redundant
+        // dbo.Resource grounding CTE that the And(union, _type) shape would have produced is eliminated, and the final
+        // SELECT joins the union aggregate (cte2) directly.
+        Assert.DoesNotContain("cte3", sql);
+        Assert.Contains("JOIN cte2 ON r.ResourceTypeId = cte2.T1 AND r.ResourceSurrogateId = cte2.Sid1", sql);
+    }
+
+    private static int CountOccurrences(string haystack, string needle) => haystack.Split(needle).Length - 1;
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/SearchParamTableExpressionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/SearchParamTableExpressionExtensions.cs
@@ -20,8 +20,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         /// <param name="expression">Instance of <see cref="SearchParamTableExpression"/> under evaluation.</param>
         public static bool HasUnionAllExpression(this SearchParamTableExpression expression)
         {
-            IExpressionsContainer expressionContainer = expression.Predicate as IExpressionsContainer;
-            return expressionContainer?.Expressions.Any(e => e is UnionExpression) ?? false;
+            // The exact-day birthdate day-split surfaces as a UNION ALL in two shapes: a bare UnionExpression
+            // sitting directly on the predicate (top-level birthdate on its own), or a UnionExpression nested
+            // inside a multi-predicate container (birthdate ANDed with other filters). Detect both.
+            return expression.Predicate is UnionExpression ||
+                (expression.Predicate is IExpressionsContainer expressionContainer &&
+                expressionContainer.Expressions.Any(e => e is UnionExpression));
         }
 
         /// <summary>
@@ -35,6 +39,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         {
             unionExpression = null;
             allOtherRemainingExpressions = null;
+
+            // Bare union: the predicate IS the UnionExpression with no ANDed siblings, so there is nothing to
+            // split out — hand the union back directly. The container path below handles the case where the
+            // union is one of several predicates combined together.
+            if (expression.Predicate is UnionExpression bareUnion)
+            {
+                unionExpression = bareUnion;
+                return true;
+            }
 
             IExpressionsContainer expressionContainer = expression.Predicate as IExpressionsContainer;
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -640,7 +640,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             if (searchParamTableExpression.ChainLevel == 0)
             {
-                int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex();
+                int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex(searchParamTableExpression);
 
                 // if this is not sort mode or if it is the first cte
                 if (!IsInSortMode(context) || predecessorIndex < 0)
@@ -678,7 +678,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T2, ")
                     .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid2")
                     .Append("FROM ").AppendLine(specialCaseTableName)
-                    .Append(_joinShift).Append("JOIN ").Append(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex()))
+                    .Append(_joinShift).Append("JOIN ").Append(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex(searchParamTableExpression)))
                     .Append(" ON ").Append(VLatest.Resource.ResourceTypeId, null).Append(" = ").Append(_firstChainAfterUnionVisited ? "T2" : "T1")
                     .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" = ").AppendLine(_firstChainAfterUnionVisited ? "Sid2" : "Sid1");
 
@@ -692,7 +692,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T2, ")
                     .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid2")
                     .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table)
-                    .Append(_joinShift).Append("JOIN ").Append(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex()))
+                    .Append(_joinShift).Append("JOIN ").Append(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex(searchParamTableExpression)))
                     .Append(" ON ").Append(VLatest.Resource.ResourceTypeId, null).Append(" = ").Append("T2")
                     .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" = ").AppendLine("Sid2");
             }
@@ -730,7 +730,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void HandleTableKindAll(SearchParamTableExpression searchParamTableExpression, SearchOptions context)
         {
-            int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex();
+            int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex(searchParamTableExpression);
 
             // In the case the query contains a UNION operator, the following CTE must join the latest Union CTE
             // where all data is aggregated.
@@ -905,7 +905,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             if (searchParamTableExpression.ChainLevel > 1)
             {
-                StringBuilder.Append(_joinShift).Append("JOIN ").Append(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex()))
+                StringBuilder.Append(_joinShift).Append("JOIN ").Append(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex(searchParamTableExpression)))
                     .Append(" ON ").Append(VLatest.Resource.ResourceTypeId, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias).Append(" = ").Append("T2")
                     .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias).Append(" = ").AppendLine("Sid2");
             }
@@ -1645,7 +1645,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void AppendIntersectionWithPredecessor(IndentedStringBuilder.DelimitedScope delimited, SearchParamTableExpression searchParamTableExpression, string tableAlias = null)
         {
-            int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex();
+            int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex(searchParamTableExpression);
 
             if (predecessorIndex >= 0)
             {
@@ -1662,7 +1662,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void AppendIntersectionWithPredecessorUsingInnerJoin(IndentedStringBuilder sb, SearchParamTableExpression searchParamTableExpression, string tableAlias = null)
         {
-            int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex();
+            int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex(searchParamTableExpression);
 
             if (predecessorIndex >= 0)
             {
@@ -1671,52 +1671,28 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 // To simplify query plan generation, if we are intersecting with the Reference search param table, we will use an inner join
                 // rather than an EXISTS clause.  We have see that this significanlty reduces the query plan generation time for
                 // complex queries
-                sb.Append(_joinShift).Append("JOIN " + TableExpressionName(predecessorIndex - 0))
+                sb.Append(_joinShift).Append("JOIN " + TableExpressionName(predecessorIndex))
                     .Append(" ON ").Append(VLatest.Resource.ResourceTypeId, tableAlias).Append(" = ").Append(intersectWithFirst ? "T1" : "T2")
                     .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, tableAlias).Append(" = ").Append(intersectWithFirst ? "Sid1" : "Sid2")
                     .AppendLine();
             }
         }
 
-        private int FindRestrictingPredecessorTableExpressionIndex()
+        private int FindRestrictingPredecessorTableExpressionIndex(SearchParamTableExpression currentExpression)
         {
-            int FindImpl(int currentIndex)
+            // Restrict against the immediately previous CTE (_tableExpressionCounter - 1). We track against
+            // _tableExpressionCounter rather than root-expression indices because unions inject extra
+            // aggregate CTEs that those logical indices don't account for.
+            //
+            // Concatenation is the exception: its own Normal sibling sits one CTE back
+            // (_tableExpressionCounter - 1), so we skip past it to reach the shared predecessor that the
+            // sibling restricts against, two CTEs back (_tableExpressionCounter - 2).
+            if (currentExpression.Kind == SearchParamTableExpressionKind.Concatenation)
             {
-                // Due to the UnionAll expressions, the number of the current index used to create new CTEs can be greater than
-                // the number of expressions in '_rootExpression.SearchParamTableExpressions'.
-                if (currentIndex >= _rootExpression.SearchParamTableExpressions.Count)
-                {
-                    return currentIndex - 1;
-                }
-
-                SearchParamTableExpression currentSearchParamTableExpression = _rootExpression.SearchParamTableExpressions[currentIndex];
-
-                // Include all the required SearchParamTableExpressionKind here
-                switch (currentSearchParamTableExpression.Kind)
-                {
-                    case SearchParamTableExpressionKind.NotExists:
-                    case SearchParamTableExpressionKind.Normal:
-                    case SearchParamTableExpressionKind.Chain:
-                    case SearchParamTableExpressionKind.Top:
-                        return currentIndex - 1;
-                    case SearchParamTableExpressionKind.Concatenation:
-                        return FindImpl(currentIndex - 1);
-                    case SearchParamTableExpressionKind.Sort:
-                    case SearchParamTableExpressionKind.SortWithFilter:
-                        return currentIndex - 1;
-                    case SearchParamTableExpressionKind.All:
-                        return currentIndex - 1;
-                    case SearchParamTableExpressionKind.Include:
-                    case SearchParamTableExpressionKind.IncludeLimit:
-                    case SearchParamTableExpressionKind.Union:
-                    case SearchParamTableExpressionKind.IncludeUnionAll:
-                        return currentIndex - 1;
-                    default:
-                        throw new ArgumentOutOfRangeException(currentSearchParamTableExpression.Kind.ToString());
-                }
+                return _tableExpressionCounter - 2;
             }
 
-            return FindImpl(_tableExpressionCounter);
+            return _tableExpressionCounter - 1;
         }
 
         private void AppendDeletedClause(in IndentedStringBuilder.DelimitedScope delimited, ResourceVersionType resourceVersionType, string tableAlias = null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ResourceColumnPredicatePushdownRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ResourceColumnPredicatePushdownRewriter.cs
@@ -86,15 +86,49 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 }
                 else
                 {
-                    Expression predicate = tableExpression.Predicate == null
-                        ? extractedCommonResourceExpressions
-                        : Expression.And(tableExpression.Predicate, extractedCommonResourceExpressions);
+                    Expression predicate;
+
+                    if (extractedCommonResourceExpressions != null
+                        && tableExpression.Predicate is UnionExpression unionPredicate
+                        && !tableExpression.HasSmartV2UnionExpression())
+                    {
+                        // A top-level UNION ALL leaf (e.g. the exact-day birthdate day-split) cannot absorb the
+                        // common resource predicate (ResourceTypeId / _id) as a sibling AND: SplitExpressions would
+                        // later peel that sibling back out into its own ResourceTypeId-grounding CTE that joins
+                        // dbo.Resource against the union aggregate. Instead, fold the resource predicate into every
+                        // branch so it lands directly in each leaf CTE (where ResourceTypeId is the partition /
+                        // clustered-index lead column) and the extra grounding CTE is never emitted. Chain-nested
+                        // unions never reach this branch (they are Normal with ChainLevel > 0 and pass through
+                        // above), so this optimization stays scoped to top-level unions.
+                        predicate = DistributeResourcePredicateIntoUnionBranches(unionPredicate, extractedCommonResourceExpressions);
+                    }
+                    else
+                    {
+                        predicate = tableExpression.Predicate == null
+                            ? extractedCommonResourceExpressions
+                            : Expression.And(tableExpression.Predicate, extractedCommonResourceExpressions);
+                    }
 
                     newTableExpressions.Add(new SearchParamTableExpression(tableExpression.QueryGenerator, predicate, tableExpression.Kind, tableExpression.ChainLevel));
                 }
             }
 
             return new SqlRootExpression(newTableExpressions, Array.Empty<SearchParameterExpressionBase>());
+        }
+
+        // Rewrites Union[b1, b2, ...] into Union[And(b1, common), And(b2, common), ...] so a common resource
+        // predicate is pushed into each branch leaf instead of wrapping the whole union (which would force a
+        // separate grounding CTE). Distributivity holds because every branch reads the same table/partition:
+        // (b1 ∪ b2) ∩ common == (b1 ∩ common) ∪ (b2 ∩ common).
+        private static UnionExpression DistributeResourcePredicateIntoUnionBranches(UnionExpression unionExpression, Expression commonResourceExpression)
+        {
+            var distributedBranches = new List<Expression>(unionExpression.Expressions.Count);
+            foreach (Expression branch in unionExpression.Expressions)
+            {
+                distributedBranches.Add(Expression.And(branch, commonResourceExpression));
+            }
+
+            return new UnionExpression(unionExpression.Operator, distributedBranches);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -50,6 +50,33 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             ExactDay,
         }
 
+        /// <summary>
+        /// Pipeline entry point. Applies the day-split rewrite, EXCEPT when the expression tree contains any
+        /// chained or reverse-chained (<c>_has</c>) expression. A day-split <see cref="UnionExpression"/> in the
+        /// presence of a chain — nested inside it or sitting beside it as a top-level sibling — generates SQL the
+        /// chained generator joins incorrectly (the union aggregate is restricted on the chain SOURCE columns
+        /// instead of the chain TARGET), returning zero rows. In that case we skip the rewrite entirely and let
+        /// the date predicate fall back to its range form, which the chained generator handles correctly. See ADR-2605.
+        /// </summary>
+        public static Expression Rewrite(Expression expression)
+        {
+            if (expression == null)
+            {
+                return null;
+            }
+
+            if (expression.AcceptVisitor(ContainsChainedExpressionVisitor.Instance, (object)null))
+            {
+                return expression;
+            }
+
+            return expression.AcceptVisitor(Instance);
+        }
+
+        // Defense-in-depth: Rewrite() already skips the whole tree when any chain is present, so in the normal
+        // pipeline this is not reached with a rewritable date nested inside a chain. If the rewriter is ever
+        // invoked directly (not via Rewrite), recursing with context=true still prevents a date param nested in
+        // a chain from being rewritten into a union.
         public override Expression VisitChained(ChainedExpression expression, bool context)
         {
             Expression visitedExpression = expression.Expression.AcceptVisitor(this, context: true);
@@ -208,5 +235,22 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
         private static bool IsUtc(DateTimeOffset value) => value.Offset == TimeSpan.Zero;
 
         private static bool IsUtcMidnight(DateTimeOffset value) => IsUtc(value) && value.TimeOfDay == TimeSpan.Zero;
+
+        /// <summary>
+        /// Returns <c>true</c> if the expression tree contains any <see cref="ChainedExpression"/>, covering both
+        /// forward chains and reverse chains (<c>_has</c>, distinguished by <see cref="ChainedExpression.Reversed"/>).
+        /// Used by <see cref="Rewrite"/> to suppress the day-split union whenever the query involves a chain.
+        /// </summary>
+        private sealed class ContainsChainedExpressionVisitor : DefaultExpressionVisitor<object, bool>
+        {
+            internal static readonly ContainsChainedExpressionVisitor Instance = new ContainsChainedExpressionVisitor();
+
+            private ContainsChainedExpressionVisitor()
+                : base((accumulated, current) => accumulated || current)
+            {
+            }
+
+            public override bool VisitChained(ChainedExpression expression, object context) => true;
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SortRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SortRewriter.cs
@@ -156,6 +156,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             return new SqlRootExpression(newTableExpressions, expression.ResourceTableExpressions);
         }
 
+        // Follows VisitSearchParameter's null contract: returning null signals "this predicate is the sort
+        // parameter" so the caller can lift it into a dedicated Sort/SortWithFilter CTE. A union qualifies
+        // only when every branch is itself the sort parameter; if any branch is something else, return the
+        // union unchanged so it stays a normal filter. Needed because the exact-day birthdate day-split can
+        // produce a bare UnionExpression the base visitor would otherwise leave unhandled.
+        public override Expression VisitUnion(UnionExpression expression, SqlSearchOptions context) =>
+            expression.Expressions.All(e => e.AcceptVisitor(this, context) == null) ? null : expression;
+
         public override Expression VisitSearchParameter(SearchParameterExpression expression, SqlSearchOptions context)
         {
             if (context.Sort.Count > 0)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -2254,7 +2254,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 .AcceptVisitor(_smartCompartmentSearchRewriter);
 
             Expression afterScalarTemporal = _fhirSqlServerConfiguration.EnableScalarTemporalEqualityRewriter
-                ? afterSmartCompartment?.AcceptVisitor(ScalarTemporalEqualityRewriter.Instance)
+                ? ScalarTemporalEqualityRewriter.Rewrite(afterSmartCompartment)
                 : afterSmartCompartment;
 
             return (SqlRootExpression)afterScalarTemporal

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -96,6 +96,73 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport);
         }
 
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAChainedSearchExpressionOverBirthdateMonthPrecision_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&subject:Patient.birthdate=1990-05";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport, Fixture.TrumanSnomedDiagnosticReport, Fixture.TrumanLoincDiagnosticReport);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAChainedSearchExpressionOverBirthdateDayWithAdditionalCriteriaOnTheSameTarget_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&subject:Patient.birthdate={Fixture.SmithPatientBirthDate}&subject:Patient.family=Smith";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAChainedExactDayBirthdateWithBaseResourceSortAndSecondChainedPredicate_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            // Matches previous error shape:
+            // MedicationDispense?patient:Patient.birthdate=<day>&_sort=-whenhandedover&patient:Patient.identifier=...
+            string tag = Guid.NewGuid().ToString();
+            var meta = new Meta { Tag = new List<Coding> { new Coding("testTag", tag) } };
+            const string exactDay = "1951-06-08";
+
+            Patient matchingPatient = (await Client.CreateAsync(
+                new Patient { Meta = meta, BirthDate = exactDay, Name = new List<HumanName> { new HumanName { Family = "Smith" } } })).Resource;
+            Patient wrongFamilyPatient = (await Client.CreateAsync(
+                new Patient { Meta = meta, BirthDate = exactDay, Name = new List<HumanName> { new HumanName { Family = "Jones" } } })).Resource;
+            Patient wrongDayPatient = (await Client.CreateAsync(
+                new Patient { Meta = meta, BirthDate = "1951-06-09", Name = new List<HumanName> { new HumanName { Family = "Smith" } } })).Resource;
+
+            var code = new CodeableConcept("http://loinc.org", "4548-4");
+
+            Observation matchA = await CreateObservationWithEffective(matchingPatient, "2021-03-03");
+            Observation matchB = await CreateObservationWithEffective(matchingPatient, "2021-01-01");
+            await CreateObservationWithEffective(wrongFamilyPatient, "2021-02-02");
+            await CreateObservationWithEffective(wrongDayPatient, "2021-04-04");
+
+            // Exact-day birthdate (UNION path) + a second chained predicate on the same target + a base-resource date sort.
+            string query = $"_tag={tag}&subject:Patient.birthdate={exactDay}&subject:Patient.family=Smith&_sort=-date&_count=100";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Observation, query);
+
+            ValidateBundle(bundle, matchA, matchB);
+
+            async Task<Observation> CreateObservationWithEffective(Patient patient, string effective)
+            {
+                return (await Client.CreateAsync(
+                    new Observation
+                    {
+                        Meta = meta,
+                        Status = ObservationStatus.Final,
+                        Code = code,
+                        Subject = new ResourceReference($"Patient/{patient.Id}"),
+                        Effective = new FhirDateTime(effective),
+                    })).Resource;
+            }
+        }
+
         [Fact]
         public async Task GivenAChainedSearchExpressionOverASimpleParameter_WhenSearchedWithPaging_ThenCorrectBundleShouldBeReturned()
         {
@@ -143,6 +210,86 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             ValidateBundle(bundle, Fixture.TrumanPatient);
         }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GivenAReverseChainSearchExpressionCombinedWithAnExactDayBirthdate_WhenSearched_ThenCorrectBundleShouldBeReturned(bool includeAccurateTotal)
+        {
+            string query = $"_tag={Fixture.Tag}&birthdate={Fixture.SmithPatientBirthDate}&_has:Observation:patient:code={Fixture.SnomedCode}";
+            if (includeAccurateTotal)
+            {
+                query += "&_total=accurate";
+            }
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
+
+            if (includeAccurateTotal)
+            {
+                Assert.Equal(1, bundle.Total.GetValueOrDefault());
+            }
+
+            ValidateBundle(bundle, Fixture.SmithPatient);
+        }
+
+#if !Stu3
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        public async Task GivenAReverseChainSearchExpressionOverImagingStudyStartedCombinedWithAnExactDayBirthdateAndTag_WhenSearchedWithPost_ThenCorrectBundleShouldBeReturned()
+        {
+            string tenantTagCode = Guid.NewGuid().ToString("N");
+            var tenantMeta = new Meta
+            {
+                Tag = new List<Coding>
+                {
+                    new Coding(Fixture.TenantTagSystem, tenantTagCode),
+                },
+            };
+
+            Patient imagingStudyExactDayPatient = (await Client.CreateAsync(
+                new Patient
+                {
+                    Meta = tenantMeta,
+                    BirthDate = Fixture.ImagingStudyPatientBirthDate,
+                })).Resource;
+
+            Patient imagingStudyMonthPrecisionPatient = (await Client.CreateAsync(
+                new Patient
+                {
+                    Meta = tenantMeta,
+                    BirthDate = Fixture.ImagingStudyMonthPrecisionPatientBirthDate,
+                })).Resource;
+
+            await Client.CreateAsync(
+                new ImagingStudy
+                {
+                    Meta = tenantMeta,
+                    Status = ImagingStudy.ImagingStudyStatus.Available,
+                    Subject = new ResourceReference($"Patient/{imagingStudyExactDayPatient.Id}"),
+                    Started = Fixture.ImagingStudyStarted,
+                });
+
+            await Client.CreateAsync(
+                new ImagingStudy
+                {
+                    Meta = tenantMeta,
+                    Status = ImagingStudy.ImagingStudyStatus.Available,
+                    Subject = new ResourceReference($"Patient/{imagingStudyMonthPrecisionPatient.Id}"),
+                    Started = Fixture.ImagingStudyStarted,
+                });
+
+            Bundle bundle = await Client.SearchPostAsync(
+                ResourceType.Patient.ToString(),
+                null,
+                default,
+                ("_has:ImagingStudy:patient:started", Fixture.ImagingStudyStarted),
+                ("birthdate", Fixture.ImagingStudyPatientBirthDate),
+                ("_tag", $"{Fixture.TenantTagSystem}|{tenantTagCode}"));
+
+            ValidateBundle(bundle, imagingStudyExactDayPatient, imagingStudyMonthPrecisionPatient);
+        }
+#endif
 
         [Fact]
         public async Task GivenAReverseChainSearchExpressionWithMultipleTargetTypes_WhenSearched_ThenCorrectBundleShouldBeReturned()
@@ -399,6 +546,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             public string OrganizationCity { get; } = Guid.NewGuid().ToString();
 
             public string OrganizationIdentifier { get; } = Guid.NewGuid().ToString();
+
+#if !Stu3
+            public string TenantTagSystem { get; } = "urn:tenantId";
+
+            public string ImagingStudyPatientBirthDate { get; } = "2018-06-06";
+
+            public string ImagingStudyMonthPrecisionPatientBirthDate { get; } = "2018-06";
+
+            public string ImagingStudyStarted { get; } = "2018-02-02T05:00:00.000";
+#endif
 
             public Patient SmithPatient { get; private set; }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -298,10 +298,161 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
         }
 
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByMultiValueOr_ThenUnionOfPerValueOverlapSetsIsReturned()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03,2001-12-31&_tag={tag}");
+
+            ValidateBundle(bundle, matrix.Year2000, matrix.March2000, matrix.March03, matrix.Year2001, matrix.December2001, matrix.December31_2001);
+            AssertNoDuplicateEntries(bundle);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByNotEquals_ThenOnlyTheExactDayValueIsExcluded()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=ne2000-03-03&_tag={tag}&_total=accurate&_count=100");
+
+            Assert.Equal(11, bundle.Total.GetValueOrDefault());
+            ValidateBundle(
+                bundle,
+                matrix.Year2000,
+                matrix.March2000,
+                matrix.December31_1999,
+                matrix.April01_2000,
+                matrix.December2000,
+                matrix.March31_2000,
+                matrix.Year2001,
+                matrix.November30_2001,
+                matrix.December2001,
+                matrix.December31_2001,
+                matrix.January01_2002);
+            AssertNoDuplicateEntries(bundle);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenDayEqualitySearchedWithTotal_ThenCountIsAccurateAndEntriesAreNotDuplicated()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_tag={tag}&_total=accurate");
+
+            Assert.Equal(3, bundle.Total.GetValueOrDefault());
+            ValidateBundle(bundle, matrix.Year2000, matrix.March2000, matrix.March03);
+            AssertNoDuplicateEntries(bundle);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenDayEqualitySearchedWithSort_ThenResultsAreOrderedByBirthdateWithoutDuplicates()
+        {
+            string tag = Guid.NewGuid().ToString();
+            PartialBirthdateMatrix matrix = await CreatePartialBirthdateMatrixAsync(tag);
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_sort=birthdate&_tag={tag}");
+
+            AssertNoDuplicateEntries(bundle);
+            Assert.Equal(
+                new[] { matrix.Year2000.Id, matrix.March2000.Id, matrix.March03.Id },
+                bundle.Entry.Select(e => e.Resource.Id).ToArray());
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithLeapDayBirthdates_WhenSearchedByDay_ThenCorrectBundleShouldBeReturned()
+        {
+            string tag = Guid.NewGuid().ToString();
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientBirthDate(p, "2020", tag),
+                p => SetPatientBirthDate(p, "2020-02", tag),
+                p => SetPatientBirthDate(p, "2020-02-28", tag),
+                p => SetPatientBirthDate(p, "2020-02-29", tag),
+                p => SetPatientBirthDate(p, "2020-03-01", tag));
+            Patient year2020 = patients[0];
+            Patient february2020 = patients[1];
+            Patient february28 = patients[2];
+            Patient february29 = patients[3];
+            Patient march01 = patients[4];
+
+            Bundle leapDayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2020-02-29&_tag={tag}");
+            ValidateBundle(leapDayBundle, year2020, february2020, february29);
+
+            Bundle feb28Bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2020-02-28&_tag={tag}");
+            ValidateBundle(feb28Bundle, year2020, february2020, february28);
+
+            Bundle march01Bundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2020-03-01&_tag={tag}");
+            ValidateBundle(march01Bundle, year2020, march01);
+        }
+
+        private async System.Threading.Tasks.Task<PartialBirthdateMatrix> CreatePartialBirthdateMatrixAsync(string tag)
+        {
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientBirthDate(p, "2000", tag),
+                p => SetPatientBirthDate(p, "2000-03", tag),
+                p => SetPatientBirthDate(p, "2000-03-03", tag),
+                p => SetPatientBirthDate(p, "1999-12-31", tag),
+                p => SetPatientBirthDate(p, "2000-04-01", tag),
+                p => SetPatientBirthDate(p, "2000-12", tag),
+                p => SetPatientBirthDate(p, "2000-03-31", tag),
+                p => SetPatientBirthDate(p, "2001", tag),
+                p => SetPatientBirthDate(p, "2001-11-30", tag),
+                p => SetPatientBirthDate(p, "2001-12", tag),
+                p => SetPatientBirthDate(p, "2001-12-31", tag),
+                p => SetPatientBirthDate(p, "2002-01-01", tag));
+
+            return new PartialBirthdateMatrix(
+                Year2000: patients[0],
+                March2000: patients[1],
+                March03: patients[2],
+                December31_1999: patients[3],
+                April01_2000: patients[4],
+                December2000: patients[5],
+                March31_2000: patients[6],
+                Year2001: patients[7],
+                November30_2001: patients[8],
+                December2001: patients[9],
+                December31_2001: patients[10],
+                January01_2002: patients[11]);
+        }
+
+        private static void AssertNoDuplicateEntries(Bundle bundle)
+        {
+            List<string> ids = bundle.Entry.Select(e => e.Resource.Id).ToList();
+            Assert.Equal(ids.Count, ids.Distinct().Count());
+        }
+
         private static void SetPatientBirthDate(Patient patient, string birthDate, string tag)
         {
             patient.Meta = new Meta { Tag = new List<Coding> { new Coding(null, tag) } };
             patient.BirthDate = birthDate;
         }
+
+        private sealed record PartialBirthdateMatrix(
+            Patient Year2000,
+            Patient March2000,
+            Patient March03,
+            Patient December31_1999,
+            Patient April01_2000,
+            Patient December2000,
+            Patient March31_2000,
+            Patient Year2001,
+            Patient November30_2001,
+            Patient December2001,
+            Patient December31_2001,
+            Patient January01_2002);
     }
 }


### PR DESCRIPTION
## Summary

Fixes issuse with the Date of Birth query optimization mainly with observed regressions around chaining and sort in search.

This is a **smaller alternative to #5641**. It fixes the same bug — exact-day birthdate equality (e.g. `birthdate=1980-01-01`) being rewritten by `ScalarTemporalEqualityRewriter` into a `UNION ALL` that broke **chained / reverse-chained** searches (they returned 0 rows) — but with far less production code.

### The two approaches

- **#5641** keeps the rewriter active inside chained expressions and teaches `SqlQueryGenerator` how to correctly lower a *chain-nested* union (chain-aware union branches, predecessor pinning on the chain target, etc.). That's ~178 changed lines in `SqlQueryGenerator.cs` alone.
- **This PR** instead **restores the original guard** that simply *skips* the rewriter inside chained expressions. If chained searches never produce a union, the chain-specific union machinery becomes dead code and is removed. Chained exact-day birthdate falls back to the normal datetime-range predicate — **correct results**, just without the `IsLongerThanADay` union perf optimization in the chained context (exactly how it behaved before the rewriter existed).

## Test Plan
- Added unit and E2E Tests
- Found test cases by analyzing production query patterns

[AB#195112](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/195112)
