### PR TITLE
Return HTTP 400 (not 500) for mixed SMART v1/v2 scopes

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -6,18 +6,21 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EnsureThat;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -34,9 +37,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
     {
         private readonly RequestDelegate _next;
         private readonly ILogger<SmartClinicalScopesMiddleware> _logger;
-
-        // Hard-coded to minimize allocations when writing the error response, mirroring ThrottlingMiddleware.
-        private const string BadRequestContentType = "application/json; charset=utf-8";
 
         // Regex based on SMART on FHIR clinical scopes v1.0 and v2.0
         // v1: http://hl7.org/fhir/smart-app-launch/1.0.0/scopes-and-launch-context/index.html#clinical-scope-syntax
@@ -212,11 +212,27 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                         // If both SMART v1 and v2 access levels are present the scopes are ambiguous and not allowed.
                         // This middleware runs before MVC, so a thrown FhirException would not be mapped to a 400 by
                         // OperationOutcomeExceptionFilterAttribute (an MVC action filter) and would instead surface as
-                        // a generic 500. Write a 400 OperationOutcome directly and short-circuit the pipeline instead.
+                        // a generic 500. Execute a 400 OperationOutcome result through the normal FHIR error flow
+                        // (the same path BaseExceptionMiddleware uses) and short-circuit the pipeline instead.
                         if (smartV1AccessLevelUsed && smartV2AccessLevelUsed)
                         {
                             _logger.LogInformation("Mixed SMART v1 and v2 scopes detected. Returning a 400 Bad Request.");
-                            await WriteBadRequestOperationOutcomeAsync(context, Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed);
+
+                            var operationOutcome = new OperationOutcome
+                            {
+                                Id = fhirRequestContext.CorrelationId,
+                                Issue = new List<OperationOutcome.IssueComponent>
+                                {
+                                    new OperationOutcome.IssueComponent
+                                    {
+                                        Severity = OperationOutcome.IssueSeverity.Error,
+                                        Code = OperationOutcome.IssueType.Invalid,
+                                        Diagnostics = Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed,
+                                    },
+                                },
+                            };
+
+                            await ExecuteResultAsync(context, new OperationOutcomeResult(operationOutcome, HttpStatusCode.BadRequest));
                             return;
                         }
 
@@ -307,27 +323,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
         }
 
         /// <summary>
-        /// Writes a FHIR <c>OperationOutcome</c> with an HTTP 400 status code directly to the response and
-        /// short-circuits the pipeline. Used for failures detected in middleware (before MVC), where a thrown
-        /// <c>FhirException</c> would otherwise be mapped to a 500 because the MVC OperationOutcome exception
-        /// filter never runs for middleware-thrown exceptions.
+        /// Executes a FHIR action result (e.g. an <see cref="OperationOutcomeResult"/>) through the standard MVC
+        /// result pipeline. This reuses the FHIR output formatters and content negotiation so errors detected in
+        /// middleware are written exactly like errors raised in the normal request flow. Marked virtual so unit
+        /// tests can intercept it, mirroring <c>BaseExceptionMiddleware</c>.
         /// </summary>
-        private static async Task WriteBadRequestOperationOutcomeAsync(HttpContext context, string diagnostics)
+        protected internal virtual async Task ExecuteResultAsync(HttpContext context, IActionResult result)
         {
-            ReadOnlyMemory<byte> body = CreateBadRequestBody(diagnostics);
-
-            context.Response.StatusCode = StatusCodes.Status400BadRequest;
-            context.Response.ContentType = BadRequestContentType;
-            context.Response.ContentLength = body.Length;
-
-            await context.Response.Body.WriteAsync(body);
-        }
-
-        private static ReadOnlyMemory<byte> CreateBadRequestBody(string diagnostics)
-        {
-            // JSON-encode the diagnostics so any special characters in the message are escaped safely.
-            string encodedDiagnostics = JsonEncodedText.Encode(diagnostics).ToString();
-            return Encoding.UTF8.GetBytes($@"{{""resourceType"":""OperationOutcome"",""issue"":[{{""severity"":""error"",""code"":""invalid"",""diagnostics"":""{encodedDiagnostics}""}}]}}").AsMemory();
+            await result.ExecuteResultAsync(new ActionContext { HttpContext = context });
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -33,6 +34,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
     {
         private readonly RequestDelegate _next;
         private readonly ILogger<SmartClinicalScopesMiddleware> _logger;
+
+        // Hard-coded to minimize allocations when writing the error response, mirroring ThrottlingMiddleware.
+        private const string BadRequestContentType = "application/json; charset=utf-8";
 
         // Regex based on SMART on FHIR clinical scopes v1.0 and v2.0
         // v1: http://hl7.org/fhir/smart-app-launch/1.0.0/scopes-and-launch-context/index.html#clinical-scope-syntax
@@ -205,10 +209,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                             smartV2AccessLevelUsed = true;
                         }
 
-                        // If both types are detected, throw an error.
+                        // If both SMART v1 and v2 access levels are present the scopes are ambiguous and not allowed.
+                        // This middleware runs before MVC, so a thrown FhirException would not be mapped to a 400 by
+                        // OperationOutcomeExceptionFilterAttribute (an MVC action filter) and would instead surface as
+                        // a generic 500. Write a 400 OperationOutcome directly and short-circuit the pipeline instead.
                         if (smartV1AccessLevelUsed && smartV2AccessLevelUsed)
                         {
-                            throw new BadHttpRequestException(string.Format(Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed));
+                            _logger.LogInformation("Mixed SMART v1 and v2 scopes detected. Returning a 400 Bad Request.");
+                            await WriteBadRequestOperationOutcomeAsync(context, Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed);
+                            return;
                         }
 
                         fhirRequestContext.AccessControlContext.ClinicalScopes.Add(match.Value);
@@ -295,6 +304,30 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
             // Call the next delegate/middleware in the pipeline
             await _next(context);
+        }
+
+        /// <summary>
+        /// Writes a FHIR <c>OperationOutcome</c> with an HTTP 400 status code directly to the response and
+        /// short-circuits the pipeline. Used for failures detected in middleware (before MVC), where a thrown
+        /// <c>FhirException</c> would otherwise be mapped to a 500 because the MVC OperationOutcome exception
+        /// filter never runs for middleware-thrown exceptions.
+        /// </summary>
+        private static async Task WriteBadRequestOperationOutcomeAsync(HttpContext context, string diagnostics)
+        {
+            ReadOnlyMemory<byte> body = CreateBadRequestBody(diagnostics);
+
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            context.Response.ContentType = BadRequestContentType;
+            context.Response.ContentLength = body.Length;
+
+            await context.Response.Body.WriteAsync(body);
+        }
+
+        private static ReadOnlyMemory<byte> CreateBadRequestBody(string diagnostics)
+        {
+            // JSON-encode the diagnostics so any special characters in the message are escaped safely.
+            string encodedDiagnostics = JsonEncodedText.Encode(diagnostics).ToString();
+            return Encoding.UTF8.GetBytes($@"{{""resourceType"":""OperationOutcome"",""issue"":[{{""severity"":""error"",""code"":""invalid"",""diagnostics"":""{encodedDiagnostics}""}}]}}").AsMemory();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -164,10 +164,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
         [Theory]
         [MemberData(nameof(GetMixedTestScopes))]
-        public async Task GivenMixedSmartScope_WhenInvoked_ThenBadRequestIsThrown(string scopes)
+        public async Task GivenMixedSmartScope_WhenInvoked_ThenBadRequestIsReturned(string scopes)
         {
-            HttpContext httpContext = new DefaultHttpContext();
-
             var fhirConfiguration = new FhirServerConfiguration();
             fhirConfiguration.Security.Enabled = true;
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
@@ -179,6 +177,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                // Use a fresh context with a readable body stream per iteration since the middleware writes the response directly.
+                HttpContext httpContext = new DefaultHttpContext();
+                httpContext.Response.Body = new MemoryStream();
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
                 var fhirRequestContext = new DefaultFhirRequestContext();
@@ -194,8 +196,16 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+
+                // The middleware must short-circuit with a 400 OperationOutcome rather than throwing (which would surface as a 500).
+                Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+
+                httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+                string body = await new StreamReader(httpContext.Response.Body).ReadToEndAsync();
+                Assert.Contains("OperationOutcome", body, StringComparison.Ordinal);
+                Assert.Contains("\"code\":\"invalid\"", body, StringComparison.Ordinal);
+                Assert.Contains(Microsoft.Health.Fhir.Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed, body, StringComparison.Ordinal);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -6,11 +6,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -18,6 +21,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Smart;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features;
@@ -177,9 +181,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
-                // Use a fresh context with a readable body stream per iteration since the middleware writes the response directly.
                 HttpContext httpContext = new DefaultHttpContext();
-                httpContext.Response.Body = new MemoryStream();
 
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
@@ -196,16 +198,24 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                // Intercept the result execution so the test does not depend on the full MVC formatter pipeline,
+                // mirroring how BaseExceptionMiddlewareTests verifies the OperationOutcomeResult that is produced.
+                var middleware = Substitute.ForPartsOf<SmartClinicalScopesMiddleware>((RequestDelegate)(innerContext => Task.CompletedTask), _logger);
+                middleware.ExecuteResultAsync(Arg.Any<HttpContext>(), Arg.Any<IActionResult>()).Returns(Task.CompletedTask);
 
-                // The middleware must short-circuit with a 400 OperationOutcome rather than throwing (which would surface as a 500).
-                Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+                await middleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
 
-                httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
-                string body = await new StreamReader(httpContext.Response.Body).ReadToEndAsync();
-                Assert.Contains("OperationOutcome", body, StringComparison.Ordinal);
-                Assert.Contains("\"code\":\"invalid\"", body, StringComparison.Ordinal);
-                Assert.Contains(Microsoft.Health.Fhir.Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed, body, StringComparison.Ordinal);
+                // The middleware must short-circuit through the normal FHIR error flow with a 400 OperationOutcome
+                // rather than throwing (which would surface as a 500).
+                await middleware
+                    .Received(1)
+                    .ExecuteResultAsync(
+                        Arg.Any<HttpContext>(),
+                        Arg.Is<OperationOutcomeResult>(x =>
+                            x.StatusCode == HttpStatusCode.BadRequest &&
+                            x.Result.Issue[0].Severity == OperationOutcome.IssueSeverity.Error &&
+                            x.Result.Issue[0].Code == OperationOutcome.IssueType.Invalid &&
+                            x.Result.Issue[0].Diagnostics == Microsoft.Health.Fhir.Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed));
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/SmartClinicalScopesValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/SmartClinicalScopesValidationTests.cs
@@ -1,0 +1,93 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Smart.Tests.E2E
+{
+    /// <summary>
+    /// E2E tests validating SMART clinical scope handling in <c>SmartClinicalScopesMiddleware</c>.
+    /// </summary>
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Authorization)]
+    [Trait(Traits.Category, Categories.SmartOnFhir)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
+    public class SmartClinicalScopesValidationTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        private readonly HttpClient _httpClient;
+        private readonly Uri _tokenUri;
+        private readonly Uri _baseAddress;
+
+        public SmartClinicalScopesValidationTests(HttpIntegrationTestFixture fixture)
+        {
+            _httpClient = fixture.TestFhirClient.HttpClient;
+            _tokenUri = fixture.TestFhirServer.TokenUri;
+            _baseAddress = fixture.TestFhirServer.BaseAddress;
+        }
+
+        [Fact]
+        public async Task GivenMixedSmartV1AndV2Scopes_WhenRequestingFhirResource_ThenBadRequestIsReturned()
+        {
+            // Only meaningful when security (and the dev token endpoint) is enabled.
+            Skip.If(_tokenUri == null, "Security is not enabled on this test server.");
+
+            // A token that contains both a SMART v1 scope (.read) and a SMART v2 granular scope (.rs)
+            // for the same resource type. The middleware must reject this combination with HTTP 400.
+            const string mixedScope = "patient/Patient.read patient/Patient.rs";
+
+            string accessToken = await GetAccessTokenWithScopeAsync(TestApplications.SmartUserClient, mixedScope);
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_baseAddress, "Patient"));
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(request);
+
+            string body = await response.Content.ReadAsStringAsync();
+
+            Assert.True(
+                response.StatusCode == HttpStatusCode.BadRequest,
+                $"Expected 400 BadRequest for mixed SMART scopes but got {(int)response.StatusCode} {response.StatusCode}. Response: {body}");
+
+            Assert.Contains("OperationOutcome", body, StringComparison.Ordinal);
+            Assert.Contains("\"code\":\"invalid\"", body, StringComparison.Ordinal);
+        }
+
+        private async Task<string> GetAccessTokenWithScopeAsync(TestApplication testApplication, string scope)
+        {
+            var tokenRequest = new Dictionary<string, string>
+            {
+                { "grant_type", testApplication.GrantType },
+                { "client_id", testApplication.ClientId },
+                { "client_secret", testApplication.ClientSecret },
+                { "scope", scope },
+                { "resource", AuthenticationSettings.Resource },
+            };
+
+            using var content = new FormUrlEncodedContent(tokenRequest);
+
+            using HttpResponseMessage response = await _httpClient.PostAsync(_tokenUri, content);
+            string responseJson = await response.Content.ReadAsStringAsync();
+
+            Assert.True(
+                response.IsSuccessStatusCode,
+                $"Failed to acquire token for scope '{scope}'. Status {(int)response.StatusCode}. Response: {responseJson}");
+
+            var tokenResponse = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(responseJson);
+            return tokenResponse["access_token"].GetString();
+        }
+    }
+}


### PR DESCRIPTION
## Problem (ICM)

A request whose token mixes **SMART v1** scopes (e.g. `patient/Observation.read`) and **SMART v2** granular scopes (e.g. `patient/Observation.rs`) returned **HTTP 500** instead of **400**.

## Root cause

`SmartClinicalScopesMiddleware` detected the mixed-scope case and threw `BadHttpRequestException`. However, the middleware runs in the ASP.NET pipeline **before MVC**. The `FhirException` → 400 mapping (`OperationOutcomeExceptionFilterAttribute`) is an MVC action filter, so it never runs for exceptions thrown from middleware. The exception was instead caught by `UseExceptionHandler("/CustomError")` / `BaseExceptionMiddleware`, both of which default to **500**.

The originally-proposed fix (swapping `BadHttpRequestException` → `BadRequestException`) does **not** fix this — any exception type thrown from the middleware still surfaces as a 500.

## Fix

Write a `400 Bad Request` `OperationOutcome` response directly from the middleware and short-circuit the pipeline (return without calling `_next`), mirroring the existing pattern in `ThrottlingMiddleware`. The body is a FHIR `OperationOutcome` with `severity: error`, `code: invalid`, and the existing `MixedSMARTV1AndV2ScopesAreNotAllowed` message.

## Tests

- **Unit** (`SmartClinicalScopesMiddlewareTests`): updated the mixed-scope theory to assert the middleware now returns `400` with an `OperationOutcome` body (`"code":"invalid"` + the message), instead of throwing.
- **E2E** (`SmartClinicalScopesValidationTests`): acquires a real token for `SmartUserClient` with a mixed scope (`patient/Patient.read patient/Patient.rs`) from the dev token endpoint, issues a FHIR request, and asserts `400 BadRequest` with an `OperationOutcome`. Skips when security is not enabled on the test server.

## Verification

- `Microsoft.Health.Fhir.Api` builds clean (net8.0 + net9.0).
- SMART middleware unit tests pass (R4, net8.0 + net9.0).
- E2E project compiles (both DLLs emitted; the only build error in my local env is the pinned-SDK post-build check, unrelated to this change).

## Follow-up (out of ICM scope)

Two sibling `BadHttpRequestException` throws in the same middleware for the `fhirUser` claim cases have the identical latent 500 behavior. Left unchanged to keep this PR focused on the ICM; worth a follow-up.