### PR TITLE
Ensure conditional delete requires delete data action

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/Authorization/AuthorizationServiceExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/Authorization/AuthorizationServiceExtensionsTests.cs
@@ -260,6 +260,46 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security.Authorization
         }
 
         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GivenSearchOnlyPermission_WhenCheckingConditionalDeleteAccess_ThenAccessIsDenied(bool hardDelete)
+        {
+            var service = Substitute.For<IAuthorizationService<DataActions>>();
+            service.CheckAccess(
+                Arg.Any<DataActions>(),
+                Arg.Any<CancellationToken>())
+                .Returns(DataActions.Search);
+
+            var result = await service.CheckConditionalDeleteAccess(
+                CancellationToken.None,
+                hardDelete,
+                true,
+                false);
+
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GivenNoPermissionsAndGranularDisabled_WhenCheckingConditionalDeleteAccess_ThenAccessIsDenied(bool hardDelete)
+        {
+            var service = Substitute.For<IAuthorizationService<DataActions>>();
+            service.CheckAccess(
+                Arg.Any<DataActions>(),
+                Arg.Any<CancellationToken>())
+                .Returns(DataActions.None);
+
+            var result = await service.CheckConditionalDeleteAccess(
+                CancellationToken.None,
+                hardDelete,
+                false,
+                false);
+
+            Assert.False(result);
+        }
+
+        [Theory]
         [InlineData(true, true, DataActions.Read | DataActions.Write | DataActions.Search | DataActions.Update, DataActions.Read | DataActions.Write | DataActions.Search | DataActions.Update)]
         [InlineData(false, true, DataActions.Read | DataActions.Write, DataActions.Read | DataActions.Write)]
         [InlineData(true, true, DataActions.Read | DataActions.Write | DataActions.Search | DataActions.Update, DataActions.Read | DataActions.Write)]

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/AuthorizationServiceExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/AuthorizationServiceExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'create' permission (SMART v2) or legacy 'write' permission (SMART v1/backward compatibility).</remarks>
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'readById' permission (SMART v2) or legacy 'read' permission (SMART v1/backward compatibility).</remarks>
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'update' permission (SMART v2) or legacy 'write' + 'read' permission (SMART v1/backward compatibility).</remarks>
@@ -119,7 +119,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>
@@ -150,7 +150,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'update' permission (SMART v2) or legacy 'write' permission (SMART v1/backward compatibility).</remarks>
@@ -175,7 +175,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'update' + 'create' permission (SMART v2) or legacy 'write' permission (SMART v1/backward compatibility).</remarks>
@@ -200,7 +200,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'create' + 'search' permission (SMART v2) or legacy 'write' + 'read' permission (SMART v1/backward compatibility).</remarks>
@@ -213,10 +213,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             EnsureArg.IsNotNull(service, nameof(service));
 
             var actions = DataActions.Read | DataActions.Write;
-            var gradular = includeGranular ? DataActions.Search | DataActions.Create : DataActions.None;
+            var granular = includeGranular ? DataActions.Search | DataActions.Create : DataActions.None;
             return service.CheckAccess(
-                actions | gradular,
-                x => (x & actions) == actions || (x & gradular) == gradular,
+                actions | granular,
+                x => (x & actions) == actions || (x & granular) == granular,
                 throwException,
                 cancellationToken);
         }
@@ -227,7 +227,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="hardDelete">The value indicating whether it is soft or hard delete.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'search' + 'delete' permission (SMART v2) or legacy 'delete' + 'read' permission (SMART v1/backward compatibility).</remarks>
@@ -241,10 +241,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             EnsureArg.IsNotNull(service, nameof(service));
 
             var actions = DataActions.Delete | DataActions.Read | (hardDelete ? DataActions.HardDelete : DataActions.None);
-            var gradular = includeGranular ? DataActions.Search : DataActions.None;
+            var granular = includeGranular
+                ? DataActions.Search | DataActions.Delete | (hardDelete ? DataActions.HardDelete : DataActions.None)
+                : DataActions.None;
             return service.CheckAccess(
-                actions | gradular,
-                x => (x & actions) == actions || (x & gradular) == gradular,
+                actions | granular,
+                x => (x & actions) == actions
+                     || (granular != DataActions.None && (x & granular) == granular),
                 throwException,
                 cancellationToken);
         }
@@ -254,7 +257,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'search' + 'update' permission (SMART v2) or legacy 'write' + 'read' permission (SMART v1/backward compatibility).</remarks>
@@ -267,10 +270,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             EnsureArg.IsNotNull(service, nameof(service));
 
             var actions = DataActions.Read | DataActions.Write;
-            var gradular = includeGranular ? DataActions.Search | DataActions.Update : DataActions.None;
+            var granular = includeGranular ? DataActions.Search | DataActions.Update : DataActions.None;
             return service.CheckAccess(
-                actions | gradular,
-                x => (x & actions) == actions || (x & gradular) == gradular,
+                actions | granular,
+                x => (x & actions) == actions || (x & granular) == granular,
                 throwException,
                 cancellationToken);
         }
@@ -280,7 +283,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// </summary>
         /// <param name="service">The authorization service.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="includeGranular">The value indicating whether to include gradular permissions in a request.</param>
+        /// <param name="includeGranular">The value indicating whether to include granular permissions in a request.</param>
         /// <param name="throwException">The value indicating whether to throw an unauthorized exception when requested permissions aren't granted.</param>
         /// <returns>A boolean indicating if access is granted.</returns>
         /// <remarks>The method checks for granular 'search' + 'update' permission (SMART v2) or legacy 'write' + 'read' permission (SMART v1/backward compatibility).</remarks>
@@ -293,10 +296,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             EnsureArg.IsNotNull(service, nameof(service));
 
             var actions = DataActions.Read | DataActions.Write;
-            var gradular = includeGranular ? DataActions.Search | DataActions.Update : DataActions.None;
+            var granular = includeGranular ? DataActions.Search | DataActions.Update : DataActions.None;
             return service.CheckAccess(
-                actions | gradular,
-                x => (x & actions) == actions || (x & gradular) == gradular,
+                actions | granular,
+                x => (x & actions) == actions || (x & granular) == granular,
                 throwException,
                 cancellationToken);
         }


### PR DESCRIPTION
## Description
Updates the data action check in Conditional-delete to ensure a user has delete data action

## Related issues
Addresses [issue [AB#194199](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/194199)].

## Testing
Manual testing in OSS and PaaS, and additional unit tests added

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
