### PR TITLE
delete search param bug

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -334,7 +334,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             var cosmosWrapper = new FhirCosmosResourceWrapper(resource);
             UpdateSortIndex(cosmosWrapper);
 
-            if (cosmosWrapper.SearchIndices == null || cosmosWrapper.SearchIndices.Count == 0)
+            if ((cosmosWrapper.SearchIndices == null || cosmosWrapper.SearchIndices.Count == 0)
+                 && !(cosmosWrapper.IsDeleted && cosmosWrapper.ResourceTypeName == KnownResourceTypes.SearchParameter)) // allow empty for sesarch param deletes
             {
                 throw new MissingSearchIndicesException(string.Format(Microsoft.Health.Fhir.Core.Resources.MissingSearchIndices, resource.ResourceTypeName));
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -271,23 +271,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             {
                 try
                 {
-                    if (resource.Wrapper.ResourceTypeName == KnownResourceTypes.SearchParameter && resource.Wrapper.IsDeleted)
-                    {
-                        var pending = GetPendingSearchParameterStatus();
-                        if (pending?.Status == SearchParameterStatus.PendingDelete || pending?.Status == SearchParameterStatus.PendingHardDelete)
-                        {
-                            var existing = await GetAsync(new ResourceKey(resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId), cancellationToken);
-                            if (existing == null)
-                            {
-                                throw new ResourceNotFoundException(string.Format(Fhir.Core.Resources.ResourceNotFoundById, resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId));
-                            }
-
-                            await PersistPendingSearchParameterStatusUpdateAsync(cancellationToken);
-
-                            return new UpsertOutcome(existing, SaveOutcomeType.Updated);
-                        }
-                    }
-
                     var upsertOutcome = await InternalUpsertAsync(
                         resource.Wrapper,
                         resource.WeakETag,
@@ -324,6 +307,22 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             bool requireETagOnUpdate = false)
         {
             EnsureArg.IsNotNull(resource, nameof(resource));
+
+            // Skip write for SearchParameter in pending delete - just return existing
+            if (resource.ResourceTypeName == KnownResourceTypes.SearchParameter && resource.IsDeleted)
+            {
+                var pending = GetPendingSearchParameterStatus();
+                if (pending?.Status == SearchParameterStatus.PendingDelete || pending?.Status == SearchParameterStatus.PendingHardDelete)
+                {
+                    var existing = await GetAsync(new ResourceKey(resource.ResourceTypeName, resource.ResourceId), cancellationToken);
+                    if (existing == null)
+                    {
+                        throw new ResourceNotFoundException(string.Format(Fhir.Core.Resources.ResourceNotFoundById, resource.ResourceTypeName, resource.ResourceId));
+                    }
+
+                    return new UpsertOutcome(existing, SaveOutcomeType.Updated);
+                }
+            }
 
             var cosmosWrapper = new FhirCosmosResourceWrapper(resource);
             UpdateSortIndex(cosmosWrapper);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -271,6 +271,29 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             {
                 try
                 {
+                    // For SearchParameter resources with PendingDelete/PendingHardDelete, skip resource write (matching SQL behavior)
+                    if (string.Equals(resource.Wrapper.ResourceTypeName, KnownResourceTypes.SearchParameter, StringComparison.Ordinal) &&
+                        resource.Wrapper.IsDeleted)
+                    {
+                        var pendingStatus = GetPendingSearchParameterStatus();
+                        if (pendingStatus?.Status == SearchParameterStatus.PendingDelete ||
+                            pendingStatus?.Status == SearchParameterStatus.PendingHardDelete)
+                        {
+                            // Read existing resource to return in response (resource write is skipped)
+                            var existingResource = await GetAsync(new ResourceKey(resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId), cancellationToken);
+                            if (existingResource == null)
+                            {
+                                throw new ResourceNotFoundException(string.Format(Microsoft.Health.Fhir.Core.Resources.ResourceNotFoundById, resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId));
+                            }
+
+                            // Persist only the status (matching SQL line 415-420 where resource is excluded from merge)
+                            await PersistPendingSearchParameterStatusUpdateAsync(cancellationToken);
+
+                            // Return existing resource unchanged
+                            return new UpsertOutcome(existingResource, SaveOutcomeType.Updated);
+                        }
+                    }
+
                     var upsertOutcome = await InternalUpsertAsync(
                         resource.Wrapper,
                         resource.WeakETag,
@@ -502,22 +525,33 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
         }
 
-        private async Task PersistPendingSearchParameterStatusUpdateAsync(CancellationToken cancellationToken)
+        private ResourceSearchParameterStatus GetPendingSearchParameterStatus()
         {
             var context = _requestContextAccessor.RequestContext;
             if (context?.Properties == null)
             {
-                return;
+                return null;
             }
 
             if (!context.Properties.TryGetValue(SearchParameterRequestContextPropertyNames.PendingStatus, out var value) ||
                 value is not ResourceSearchParameterStatus status)
             {
+                return null;
+            }
+
+            return status;
+        }
+
+        private async Task PersistPendingSearchParameterStatusUpdateAsync(CancellationToken cancellationToken)
+        {
+            var status = GetPendingSearchParameterStatus();
+            if (status == null)
+            {
                 return;
             }
 
             await _searchParameterStatusDataStore.UpsertStatuses([status], cancellationToken);
-            context.Properties.Remove(SearchParameterRequestContextPropertyNames.PendingStatus);
+            _requestContextAccessor.RequestContext.Properties.Remove(SearchParameterRequestContextPropertyNames.PendingStatus);
         }
 
         public async Task<ResourceWrapper> GetAsync(ResourceKey key, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             UpdateSortIndex(cosmosWrapper);
 
             if ((cosmosWrapper.SearchIndices == null || cosmosWrapper.SearchIndices.Count == 0)
-                 && !(cosmosWrapper.IsDeleted && cosmosWrapper.ResourceTypeName == KnownResourceTypes.SearchParameter)) // allow empty for sesarch param deletes
+                 && !(cosmosWrapper.IsDeleted && cosmosWrapper.ResourceTypeName == KnownResourceTypes.SearchParameter)) // allow empty for search param deletes
             {
                 throw new MissingSearchIndicesException(string.Format(Microsoft.Health.Fhir.Core.Resources.MissingSearchIndices, resource.ResourceTypeName));
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
                 // Internally Bundle Operation calls "MergeAsync".
                 UpsertOutcome result = await operation.AppendResourceAsync(resource, this, cancellationToken).ConfigureAwait(false);
-                if (string.Equals(resource.Wrapper.ResourceTypeName, KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
+                if (resource.Wrapper.ResourceTypeName == KnownResourceTypes.SearchParameter)
                 {
                     await PersistPendingSearchParameterStatusUpdateAsync(cancellationToken);
                 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -520,17 +520,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
         }
 
-        private ResourceSearchParameterStatus GetPendingSearchParameterStatus()
-        {
-            var context = _requestContextAccessor.RequestContext;
-            if (context?.Properties == null || !context.Properties.TryGetValue(SearchParameterRequestContextPropertyNames.PendingStatus, out var status))
-            {
-                return null;
-            }
-
-            return (ResourceSearchParameterStatus)status;
-        }
-
         private async Task PersistPendingSearchParameterStatusUpdateAsync(CancellationToken cancellationToken)
         {
             var status = GetPendingSearchParameterStatus();
@@ -541,6 +530,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
             await _searchParameterStatusDataStore.UpsertStatuses([status], cancellationToken);
             _requestContextAccessor.RequestContext.Properties.Remove(SearchParameterRequestContextPropertyNames.PendingStatus);
+        }
+
+        private ResourceSearchParameterStatus GetPendingSearchParameterStatus()
+        {
+            var context = _requestContextAccessor.RequestContext;
+            if (context?.Properties == null || !context.Properties.TryGetValue(SearchParameterRequestContextPropertyNames.PendingStatus, out var status))
+            {
+                return null;
+            }
+
+            return (ResourceSearchParameterStatus)status;
         }
 
         public async Task<ResourceWrapper> GetAsync(ResourceKey key, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -271,26 +271,20 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             {
                 try
                 {
-                    // For SearchParameter resources with PendingDelete/PendingHardDelete, skip resource write (matching SQL behavior)
-                    if (string.Equals(resource.Wrapper.ResourceTypeName, KnownResourceTypes.SearchParameter, StringComparison.Ordinal) &&
-                        resource.Wrapper.IsDeleted)
+                    if (resource.Wrapper.ResourceTypeName == KnownResourceTypes.SearchParameter && resource.Wrapper.IsDeleted)
                     {
-                        var pendingStatus = GetPendingSearchParameterStatus();
-                        if (pendingStatus?.Status == SearchParameterStatus.PendingDelete ||
-                            pendingStatus?.Status == SearchParameterStatus.PendingHardDelete)
+                        var pending = GetPendingSearchParameterStatus();
+                        if (pending?.Status == SearchParameterStatus.PendingDelete || pending?.Status == SearchParameterStatus.PendingHardDelete)
                         {
-                            // Read existing resource to return in response (resource write is skipped)
-                            var existingResource = await GetAsync(new ResourceKey(resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId), cancellationToken);
-                            if (existingResource == null)
+                            var existing = await GetAsync(new ResourceKey(resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId), cancellationToken);
+                            if (existing == null)
                             {
-                                throw new ResourceNotFoundException(string.Format(Microsoft.Health.Fhir.Core.Resources.ResourceNotFoundById, resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId));
+                                throw new ResourceNotFoundException(string.Format(Fhir.Core.Resources.ResourceNotFoundById, resource.Wrapper.ResourceTypeName, resource.Wrapper.ResourceId));
                             }
 
-                            // Persist only the status (matching SQL line 415-420 where resource is excluded from merge)
                             await PersistPendingSearchParameterStatusUpdateAsync(cancellationToken);
 
-                            // Return existing resource unchanged
-                            return new UpsertOutcome(existingResource, SaveOutcomeType.Updated);
+                            return new UpsertOutcome(existing, SaveOutcomeType.Updated);
                         }
                     }
 
@@ -302,7 +296,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                         cancellationToken,
                         resource.RequireETagOnUpdate);
 
-                    if (string.Equals(resource.Wrapper.ResourceTypeName, KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
+                    if (resource.Wrapper.ResourceTypeName == KnownResourceTypes.SearchParameter)
                     {
                         await PersistPendingSearchParameterStatusUpdateAsync(cancellationToken);
                     }
@@ -335,9 +329,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             UpdateSortIndex(cosmosWrapper);
 
             if ((cosmosWrapper.SearchIndices == null || cosmosWrapper.SearchIndices.Count == 0)
-                 && !(cosmosWrapper.IsDeleted && cosmosWrapper.ResourceTypeName == KnownResourceTypes.SearchParameter)) // allow empty for sesarch param deletes
+                 && !(cosmosWrapper.IsDeleted && cosmosWrapper.ResourceTypeName == KnownResourceTypes.SearchParameter)) // allow empty for search param deletes
             {
-                throw new MissingSearchIndicesException(string.Format(Microsoft.Health.Fhir.Core.Resources.MissingSearchIndices, resource.ResourceTypeName));
+                throw new MissingSearchIndicesException(string.Format(Fhir.Core.Resources.MissingSearchIndices, resource.ResourceTypeName));
             }
 
             var partitionKey = new PartitionKey(cosmosWrapper.PartitionKey);
@@ -529,18 +523,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         private ResourceSearchParameterStatus GetPendingSearchParameterStatus()
         {
             var context = _requestContextAccessor.RequestContext;
-            if (context?.Properties == null)
+            if (context?.Properties == null || !context.Properties.TryGetValue(SearchParameterRequestContextPropertyNames.PendingStatus, out var status))
             {
                 return null;
             }
 
-            if (!context.Properties.TryGetValue(SearchParameterRequestContextPropertyNames.PendingStatus, out var value) ||
-                value is not ResourceSearchParameterStatus status)
-            {
-                return null;
-            }
-
-            return status;
+            return (ResourceSearchParameterStatus)status;
         }
 
         private async Task PersistPendingSearchParameterStatusUpdateAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -217,6 +217,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             _logger.LogWarning(sqlEx, "Optimistic concurrency conflict occurred while calling dbo.MergeResourcesAndSearchParams");
                             throw new BadRequestException(Core.Resources.SearchParameterConcurrencyConflict);
                         }
+                        else if (sqlEx.IsReindexJobConflict())
+                        {
+                            _logger.LogWarning(sqlEx, "Reindex job conflict occurred while calling dbo.MergeResourcesAndSearchParams");
+                            throw new JobConflictException(sqlEx.Message);
+                        }
                     }
 
                     _logger.LogError(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}}", retries);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -217,11 +217,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             _logger.LogWarning(sqlEx, "Optimistic concurrency conflict occurred while calling dbo.MergeResourcesAndSearchParams");
                             throw new BadRequestException(Core.Resources.SearchParameterConcurrencyConflict);
                         }
-                        else if (sqlEx.IsReindexJobConflict())
-                        {
-                            _logger.LogWarning(sqlEx, "Reindex job conflict occurred while calling dbo.MergeResourcesAndSearchParams");
-                            throw new JobConflictException(sqlEx.Message);
-                        }
                     }
 
                     _logger.LogError(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}}", retries);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 
                 foreach (var code in codes)
                 {
-                    var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}{code}");
+                    var searchParam = CreatePersonSearchParam(code, $"{urlPrefix}{code}");
                     bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{code}" }, Resource = searchParam });
                 }
 
@@ -196,7 +196,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             async Task<FhirResponse> CreatePersonSearchParamAsync(string code, bool isBundle, bool isParal)
             {
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = new List<EntryComponent>() };
-                var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}{code}");
+                var searchParam = CreatePersonSearchParam(code, $"{urlPrefix}{code}");
 
                 if (isBundle)
                 {
@@ -272,7 +272,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 
                 foreach (var code in codes)
                 {
-                    var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}{code}");
+                    var searchParam = CreatePersonSearchParam(code, $"{urlPrefix}{code}");
                     bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{code}" }, Resource = searchParam });
                 }
 
@@ -307,7 +307,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = [] };
 
                 var id = ids[0];
-                var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}c-1", id);
+                var searchParam = CreatePersonSearchParam(code, $"{urlPrefix}c-1", id);
                 bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
 
                 id = ids[1];
@@ -544,7 +544,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 {
                     var code = codes[i];
                     var id = ids[i];
-                    var searchParam = CreateSearchParameterForPerson(code, urls[i], id);
+                    var searchParam = CreatePersonSearchParam(code, urls[i], id);
                     bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
                 }
 
@@ -1116,6 +1116,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             }
         }
 
+        [Fact]
+        public async Task GivenSearchParamCreate_WhenReindexIsRunning_ThenConflictIsReturned()
+        {
+            var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
+            Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
+
+            var code = "conflict-test";
+            var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
+            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.CreateAsync(searchParam));
+
+            Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
+            Assert.Contains("reindex", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
         // left as async to minimize changes
         private async Task<Person> CreatePersonResourceAsync(string id, string name)
         {
@@ -1206,7 +1220,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             }
         }
 
-        private SearchParameter CreateSearchParameterForPerson(string code, string url, string id = null)
+        private SearchParameter CreatePersonSearchParam(string code, string url, string id = null)
         {
 #if R5
             var resourceTypes = new List<VersionIndependentResourceTypesAll?> { VersionIndependentResourceTypesAll.Person };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -107,27 +107,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             {
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = new List<EntryComponent>() };
 
-#if R5
-                var resourceTypes = new List<VersionIndependentResourceTypesAll?>([Enum.Parse<VersionIndependentResourceTypesAll>("Person")]);
-#else
-                var resourceTypes = new List<ResourceType?>([Enum.Parse<ResourceType>("Person")]);
-#endif
-
                 foreach (var code in codes)
                 {
-                    var searchParam = new SearchParameter
-                    {
-                        Id = code,
-                        Url = $"{urlPrefix}{code}",
-                        Name = code,
-                        Code = code,
-                        Status = PublicationStatus.Active,
-                        Type = SearchParamType.Token,
-                        Expression = "Person.id",
-                        Description = "any",
-                        Base = resourceTypes,
-                    };
-
+                    var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}{code}");
                     bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{code}" }, Resource = searchParam });
                 }
 
@@ -214,24 +196,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             async Task<FhirResponse> CreatePersonSearchParamAsync(string code, bool isBundle, bool isParal)
             {
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = new List<EntryComponent>() };
-#if R5
-                var resourceTypes = new List<VersionIndependentResourceTypesAll?>([Enum.Parse<VersionIndependentResourceTypesAll>("Person")]);
-#else
-                var resourceTypes = new List<ResourceType?>([Enum.Parse<ResourceType>("Person")]);
-#endif
-
-                var searchParam = new SearchParameter
-                {
-                    Id = code,
-                    Url = $"{urlPrefix}{code}",
-                    Name = code,
-                    Code = code,
-                    Status = PublicationStatus.Active,
-                    Type = SearchParamType.Token,
-                    Expression = "Person.id",
-                    Description = "any",
-                    Base = resourceTypes,
-                };
+                var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}{code}");
 
                 if (isBundle)
                 {
@@ -305,27 +270,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             {
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = new List<EntryComponent>() };
 
-#if R5
-                var resourceTypes = new List<VersionIndependentResourceTypesAll?>([Enum.Parse<VersionIndependentResourceTypesAll>("Person")]);
-#else
-                var resourceTypes = new List<ResourceType?>([Enum.Parse<ResourceType>("Person")]);
-#endif
-
                 foreach (var code in codes)
                 {
-                    var searchParam = new SearchParameter
-                    {
-                        Id = code,
-                        Url = $"{urlPrefix}{code}",
-                        Name = code,
-                        Code = code,
-                        Status = PublicationStatus.Active,
-                        Type = SearchParamType.Token,
-                        Expression = "Person.id",
-                        Description = "any",
-                        Base = resourceTypes,
-                    };
-
+                    var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}{code}");
                     bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{code}" }, Resource = searchParam });
                 }
 
@@ -360,19 +307,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = [] };
 
                 var id = ids[0];
-                var searchParam = new SearchParameter
-                {
-                    Id = id,
-                    Url = $"{urlPrefix}c-1",
-                    Name = code,
-                    Code = code,
-                    Status = PublicationStatus.Active,
-                    Type = SearchParamType.Token,
-                    Expression = "Person.id",
-                    Description = "any",
-                    Base = personTypes,
-                };
-
+                var searchParam = CreateSearchParameterForPerson(code, $"{urlPrefix}c-1", id);
                 bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
 
                 id = ids[1];
@@ -605,28 +540,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             async Task<Bundle> CreatePersonSearchParamsAsync()
             {
                 var bundle = new Bundle { Type = isBatch ? Bundle.BundleType.Batch : Bundle.BundleType.Transaction, Entry = [] };
-#if R5
-                var resourceTypes = new List<VersionIndependentResourceTypesAll?>() { VersionIndependentResourceTypesAll.Person };
-#else
-                var resourceTypes = new List<ResourceType?>() { ResourceType.Person };
-#endif
                 for (var i = 0; i < ids.Count; i++)
                 {
                     var code = codes[i];
                     var id = ids[i];
-                    var searchParam = new SearchParameter
-                    {
-                        Id = id,
-                        Url = urls[i],
-                        Name = code,
-                        Code = code,
-                        Status = PublicationStatus.Active,
-                        Type = SearchParamType.Token,
-                        Expression = "Person.id",
-                        Description = "any",
-                        Base = resourceTypes,
-                    };
-
+                    var searchParam = CreateSearchParameterForPerson(code, urls[i], id);
                     bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
                 }
 
@@ -1286,6 +1204,28 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 _output.WriteLine($"Failed to create search parameter: {ex.Message}");
                 throw;
             }
+        }
+
+        private SearchParameter CreateSearchParameterForPerson(string code, string url, string id = null)
+        {
+#if R5
+            var resourceTypes = new List<VersionIndependentResourceTypesAll?> { VersionIndependentResourceTypesAll.Person };
+#else
+            var resourceTypes = new List<ResourceType?> { ResourceType.Person };
+#endif
+
+            return new SearchParameter
+            {
+                Id = id ?? code,
+                Url = url,
+                Name = code,
+                Code = code,
+                Status = PublicationStatus.Active,
+                Type = SearchParamType.Token,
+                Expression = "Person.id",
+                Description = "any",
+                Base = resourceTypes,
+            };
         }
 
         private async Task<Specimen> CreateSpecimenResourceAsync(string id, string name)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1130,6 +1130,33 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             Assert.Contains("reindex", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GivenSearchParamDelete_WhenReindexIsRunning_ThenConflictIsReturned(bool hardDelete)
+        {
+            var code = hardDelete ? "hard-delete-conflict-test" : "soft-delete-conflict-test";
+            var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
+            var created = await _fixture.TestFhirClient.CreateAsync(searchParam);
+            Assert.NotNull(created.Resource);
+
+            var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
+            Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
+
+            FhirClientException exception;
+            if (hardDelete)
+            {
+                exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.HardDeleteAsync(created.Resource));
+            }
+            else
+            {
+                exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.DeleteAsync(created.Resource));
+            }
+
+            Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
+            Assert.Contains("reindex", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
         // left as async to minimize changes
         private async Task<Person> CreatePersonResourceAsync(string id, string name)
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1133,7 +1133,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             Assert.Equal(OperationStatus.Completed, reindexStatus);
 
             var create = await _fixture.TestFhirClient.CreateAsync(searchParam);
-            Assert.Equal(HttpStatusCode.OK, create.StatusCode);
+            Assert.Equal(HttpStatusCode.Created, create.StatusCode);
         }
 
         [Theory]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1117,23 +1117,29 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         }
 
         [Fact]
-        public async Task GivenSearchParamCreate_WhenReindexIsRunning_ThenConflictIsReturned()
+        public async Task GivenSearchParamCreate_ThenConflictWhenReindexAndSuccessAfter()
         {
             var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
             Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
 
             var code = "conflict-test";
             var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
-            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.CreateAsync(searchParam));
 
+            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.CreateAsync(searchParam));
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
             Assert.Contains("reindex", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+            var reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
+            Assert.Equal(OperationStatus.Completed, reindexStatus);
+
+            var create = await _fixture.TestFhirClient.CreateAsync(searchParam);
+            Assert.Equal(HttpStatusCode.OK, create.StatusCode);
         }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task GivenSearchParamDelete_WhenReindexIsRunning_ThenConflictIsReturned(bool hardDelete)
+        public async Task GivenSearchParamDelete_ThenConflictWhenReindexAndSuccessOnNext(bool hardDelete)
         {
             var code = hardDelete ? "hard-delete-conflict-test" : "soft-delete-conflict-test";
             var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
@@ -1143,18 +1149,30 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
             Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
 
-            FhirClientException exception;
-            if (hardDelete)
-            {
-                exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.HardDeleteAsync(created.Resource));
-            }
-            else
-            {
-                exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.DeleteAsync(created.Resource));
-            }
-
+            // conflict
+            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.DeleteAsync($"SearchParameter/{code}?hardDelete={hardDelete}"));
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
             Assert.Contains("reindex", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+            var reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
+            Assert.Equal(OperationStatus.Completed, reindexStatus);
+
+            // success
+            var delete = await _fixture.TestFhirClient.DeleteAsync($"SearchParameter/{code}?hardDelete={hardDelete}");
+            Assert.Equal(HttpStatusCode.OK, delete.StatusCode);
+
+            // resource is still there
+            var resource = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}");
+            Assert.NotNull(resource?.Resource);
+
+            reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
+            Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
+            reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
+            Assert.Equal(OperationStatus.Completed, reindexStatus);
+
+            // reindex deleted resource
+            var notFoundEx = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}"));
+            Assert.Equal(hardDelete ? HttpStatusCode.NotFound : HttpStatusCode.Gone, notFoundEx.StatusCode);
         }
 
         // left as async to minimize changes

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1125,15 +1125,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             var code = "conflict-test";
             var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
 
-            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.CreateAsync(searchParam));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.UpdateAsync(searchParam)); // use PUT to retain id
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
             Assert.Contains("reindex", exception.Message, StringComparison.OrdinalIgnoreCase);
 
             var reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
             Assert.Equal(OperationStatus.Completed, reindexStatus);
 
-            var create = await _fixture.TestFhirClient.CreateAsync(searchParam);
-            Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+            var create = await _fixture.TestFhirClient.UpdateAsync(searchParam); // use PUT to retain id
+            Assert.True(create.StatusCode == HttpStatusCode.OK || create.StatusCode == HttpStatusCode.Created);
+            Assert.Equal(code, create.Resource.Id);
         }
 
         [Theory]
@@ -1143,8 +1144,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         {
             var code = hardDelete ? "hard-delete-conflict-test" : "soft-delete-conflict-test";
             var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
-            var created = await _fixture.TestFhirClient.CreateAsync(searchParam);
-            Assert.NotNull(created.Resource);
+            var create = await _fixture.TestFhirClient.UpdateAsync(searchParam); // use PUT to retain id
+            Assert.True(create.StatusCode == HttpStatusCode.OK || create.StatusCode == HttpStatusCode.Created);
+            Assert.Equal(code, create.Resource.Id);
 
             var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
             Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
@@ -1159,9 +1161,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 
             // success
             var delete = await _fixture.TestFhirClient.DeleteAsync($"SearchParameter/{code}?hardDelete={hardDelete}");
-            Assert.Equal(HttpStatusCode.OK, delete.StatusCode);
+            Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
 
-            // resource is still there
+            // resource is stil there
             var resource = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}");
             Assert.NotNull(resource?.Resource);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1163,7 +1163,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             var delete = await _fixture.TestFhirClient.DeleteAsync($"SearchParameter/{code}?hardDelete={hardDelete}");
             Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
 
-            // resource is stil there
+            // resource is still there
             var resource = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}");
             Assert.NotNull(resource?.Resource);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1177,6 +1177,72 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             Assert.Equal(hardDelete ? HttpStatusCode.NotFound : HttpStatusCode.Gone, notFoundEx.StatusCode);
         }
 
+        [Fact]
+        public async Task GivenSearchParamBundleDelete_ThenConflictWhenReindexAndSuccessOnNext()
+        {
+            var code = "soft-delete-bundle-conflict-test";
+            var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
+            var create = await _fixture.TestFhirClient.UpdateAsync(searchParam); // use PUT to retain id
+            Assert.True(create.StatusCode == HttpStatusCode.OK || create.StatusCode == HttpStatusCode.Created);
+            Assert.Equal(code, create.Resource.Id);
+
+            var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
+            Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
+
+            // Create a batch bundle with a DELETE entry for the SearchParameter
+            var bundle = new Bundle
+            {
+                Type = BundleType.Batch,
+                Entry = [new() { Request = new Bundle.RequestComponent { Method = Bundle.HTTPVerb.DELETE, Url = $"SearchParameter/{code}" } }],
+            };
+
+            // conflict - bundle delete should fail while reindex is running
+            var bundleConflict = await _fixture.TestFhirClient.PostBundleAsync(bundle, new FhirBundleOptions { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel });
+            Assert.Equal(HttpStatusCode.OK, bundleConflict.Response.StatusCode); // Batch returns 200
+            Assert.NotNull(bundleConflict.Resource?.Entry);
+            Assert.Single(bundleConflict.Resource.Entry);
+            var deleteResponse = bundleConflict.Resource.Entry[0].Response;
+            Assert.Equal(((int)HttpStatusCode.Conflict).ToString(), deleteResponse.Status);
+            Assert.Contains("reindex", deleteResponse.Outcome?.ToString() ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+
+            var reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
+            Assert.Equal(OperationStatus.Completed, reindexStatus);
+
+            // success - bundle delete should succeed after reindex completes
+            var bundleResponse = await _fixture.TestFhirClient.PostBundleAsync(bundle, new FhirBundleOptions { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel });
+            Assert.Equal(HttpStatusCode.OK, bundleResponse.Response.StatusCode);
+            Assert.NotNull(bundleResponse.Resource?.Entry);
+            Assert.Single(bundleResponse.Resource.Entry);
+            var successResponse = bundleResponse.Resource.Entry[0].Response;
+            Assert.Equal(((int)HttpStatusCode.NoContent).ToString(), successResponse.Status);
+
+            // resource is still there (soft-deleted)
+            var resource = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}");
+            Assert.NotNull(resource?.Resource);
+
+            reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
+            Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
+            reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
+            Assert.Equal(OperationStatus.Completed, reindexStatus);
+
+            // reindex deleted resource - should now be gone
+            var notFoundEx = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}"));
+            Assert.Equal(HttpStatusCode.Gone, notFoundEx.StatusCode);
+
+            // verify history is preserved
+            var history = await _fixture.TestFhirClient.ReadHistoryAsync(ResourceType.SearchParameter, code);
+            Assert.NotNull(history.Resource);
+            Assert.NotEmpty(history.Resource.Entry);
+            Assert.True(history.Resource.Entry.Count >= 2, "History should contain at least 2 versions (create + delete)");
+
+            // verify last version is soft-deleted (check request method is DELETE)
+            var lastEntry = history.Resource.Entry.First();
+            Assert.NotNull(lastEntry.Request);
+            Assert.Equal(Bundle.HTTPVerb.DELETE, lastEntry.Request.Method);
+            Assert.NotNull(lastEntry.Resource);
+            Assert.Equal(code, lastEntry.Resource.Id);
+        }
+
         // left as async to minimize changes
         private async Task<Person> CreatePersonResourceAsync(string id, string name)
         {


### PR DESCRIPTION
Soft delete of search param resource for Cosmos was not delayed. Now it is. New tests added. 
Copilot overview below is correct.