### PR TITLE
Add feature flag gating 3-column reference-type filtered stats

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceCircuitBreakerTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceCircuitBreakerTests.cs
@@ -94,29 +94,29 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
         }
 
         [Fact]
-        public void GivenOpenBreaker_WhenCooldownElapsed_ThenSingleProbeIsAllowedThrough()
+        public void GivenOpenBreaker_WhenCooldownElapsed_ThenBreakerClosesAndLookupsResume()
         {
             SqlServerSearchService.SetQueryStoreCircuitStateForTests(
                 SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold,
                 DateTime.UtcNow.AddSeconds(-1).Ticks);
 
-            // Cooldown has elapsed: the first caller wins the compare-and-swap and is let through as a probe,
-            // which clears the open deadline.
+            // Cooldown has elapsed: the first caller atomically clears the open deadline, closing the
+            // breaker so lookups resume (subject to the concurrency gate).
             Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
             Assert.Equal(0, SqlServerSearchService.GetQueryStoreCircuitOpenUntilTicksForTests());
         }
 
         [Fact]
-        public void GivenProbeAfterCooldown_WhenProbeFails_ThenBreakerReopens()
+        public void GivenClosedBreakerAfterCooldown_WhenNextFailureRecorded_ThenBreakerReopens()
         {
             SqlServerSearchService.SetQueryStoreCircuitStateForTests(
                 SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold,
                 DateTime.UtcNow.AddSeconds(-1).Ticks);
 
-            // Probe is let through...
+            // Cooldown elapsed: the breaker closes and the next lookup is allowed through...
             Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
 
-            // ...but the probe fails, which (already at/over threshold) re-opens the breaker for another cooldown.
+            // ...but because the failure counter is still at threshold, a single failure re-opens it.
             SqlServerSearchService.RecordQueryStoreFailure();
 
             Assert.False(SqlServerSearchService.TryEnterQueryStoreCircuit());

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceCircuitBreakerTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceCircuitBreakerTests.cs
@@ -1,0 +1,134 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
+{
+    /// <summary>
+    /// Unit tests for the diagnostic Query Store circuit breaker in <see cref="SqlServerSearchService"/>.
+    /// The breaker suspends Query Store enrichment after a run of consecutive failures so a truly
+    /// overloaded database is not compounded by diagnostic load, while slow-query warnings keep flowing.
+    /// The breaker state is process-global static, so these tests reset it before each case and run
+    /// sequentially within this single class.
+    /// </summary>
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SqlServerSearchServiceCircuitBreakerTests
+    {
+        public SqlServerSearchServiceCircuitBreakerTests()
+        {
+            // RecordQueryStoreSuccess zeroes both the consecutive-failure counter and the open deadline,
+            // giving every test a clean, closed breaker regardless of prior test state.
+            SqlServerSearchService.RecordQueryStoreSuccess();
+        }
+
+        [Fact]
+        public void GivenClosedBreaker_WhenTryEnter_ThenReturnsTrue()
+        {
+            Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
+        }
+
+        [Fact]
+        public void GivenFailuresBelowThreshold_WhenTryEnter_ThenBreakerStaysClosed()
+        {
+            for (int i = 0; i < SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold - 1; i++)
+            {
+                SqlServerSearchService.RecordQueryStoreFailure();
+            }
+
+            Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
+        }
+
+        [Fact]
+        public void GivenFailuresAtThreshold_WhenTryEnter_ThenBreakerOpens()
+        {
+            for (int i = 0; i < SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold; i++)
+            {
+                SqlServerSearchService.RecordQueryStoreFailure();
+            }
+
+            Assert.False(SqlServerSearchService.TryEnterQueryStoreCircuit());
+        }
+
+        [Fact]
+        public void GivenFailuresBelowThreshold_WhenSuccessRecorded_ThenFailureCountResets()
+        {
+            // Accumulate failures just short of tripping, record a success, then accumulate the same
+            // number again. Because the success reset the counter, the breaker must remain closed.
+            for (int i = 0; i < SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold - 1; i++)
+            {
+                SqlServerSearchService.RecordQueryStoreFailure();
+            }
+
+            SqlServerSearchService.RecordQueryStoreSuccess();
+
+            for (int i = 0; i < SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold - 1; i++)
+            {
+                SqlServerSearchService.RecordQueryStoreFailure();
+            }
+
+            Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
+        }
+
+        [Fact]
+        public void GivenOpenBreaker_WhenSuccessRecorded_ThenBreakerCloses()
+        {
+            for (int i = 0; i < SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold; i++)
+            {
+                SqlServerSearchService.RecordQueryStoreFailure();
+            }
+
+            Assert.False(SqlServerSearchService.TryEnterQueryStoreCircuit());
+
+            SqlServerSearchService.RecordQueryStoreSuccess();
+
+            Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
+        }
+
+        [Fact]
+        public void GivenOpenBreaker_WhenWithinCooldown_ThenTryEnterReturnsFalse()
+        {
+            SqlServerSearchService.SetQueryStoreCircuitStateForTests(
+                SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold,
+                DateTime.UtcNow.Add(SqlServerSearchService.QueryStoreCircuitBreakerCooldown).Ticks);
+
+            Assert.False(SqlServerSearchService.TryEnterQueryStoreCircuit());
+        }
+
+        [Fact]
+        public void GivenOpenBreaker_WhenCooldownElapsed_ThenSingleProbeIsAllowedThrough()
+        {
+            SqlServerSearchService.SetQueryStoreCircuitStateForTests(
+                SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold,
+                DateTime.UtcNow.AddSeconds(-1).Ticks);
+
+            // Cooldown has elapsed: the first caller wins the compare-and-swap and is let through as a probe,
+            // which clears the open deadline.
+            Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
+            Assert.Equal(0, SqlServerSearchService.GetQueryStoreCircuitOpenUntilTicksForTests());
+        }
+
+        [Fact]
+        public void GivenProbeAfterCooldown_WhenProbeFails_ThenBreakerReopens()
+        {
+            SqlServerSearchService.SetQueryStoreCircuitStateForTests(
+                SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold,
+                DateTime.UtcNow.AddSeconds(-1).Ticks);
+
+            // Probe is let through...
+            Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
+
+            // ...but the probe fails, which (already at/over threshold) re-opens the breaker for another cooldown.
+            SqlServerSearchService.RecordQueryStoreFailure();
+
+            Assert.False(SqlServerSearchService.TryEnterQueryStoreCircuit());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceCircuitBreakerTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceCircuitBreakerTests.cs
@@ -35,26 +35,17 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
             Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
         }
 
-        [Fact]
-        public void GivenFailuresBelowThreshold_WhenTryEnter_ThenBreakerStaysClosed()
+        [Theory]
+        [InlineData(SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold - 1, true)] // just below threshold: breaker stays closed
+        [InlineData(SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold, false)] // reaches threshold: breaker opens
+        public void GivenConsecutiveFailures_WhenTryEnter_ThenBreakerOpensOnlyAtThreshold(int failureCount, bool expectedCanEnter)
         {
-            for (int i = 0; i < SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold - 1; i++)
+            for (int i = 0; i < failureCount; i++)
             {
                 SqlServerSearchService.RecordQueryStoreFailure();
             }
 
-            Assert.True(SqlServerSearchService.TryEnterQueryStoreCircuit());
-        }
-
-        [Fact]
-        public void GivenFailuresAtThreshold_WhenTryEnter_ThenBreakerOpens()
-        {
-            for (int i = 0; i < SqlServerSearchService.QueryStoreCircuitBreakerFailureThreshold; i++)
-            {
-                SqlServerSearchService.RecordQueryStoreFailure();
-            }
-
-            Assert.False(SqlServerSearchService.TryEnterQueryStoreCircuit());
+            Assert.Equal(expectedCanEnter, SqlServerSearchService.TryEnterQueryStoreCircuit());
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -1269,7 +1269,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             // Circuit breaker: if too many consecutive lookups have failed/timed out, the database is
             // likely overloaded. Suspend Query Store enrichment for a cooldown window so diagnostics
             // don't compound the problem. The slow query is still logged below — only the enrichment
-            // is skipped. When the cooldown elapses, exactly one probe lookup is allowed through.
+            // is skipped. When the cooldown elapses, the breaker closes and lookups resume (bounded by
+            // the concurrency gate below); the failure counter stays elevated, so the next failure
+            // re-opens the breaker while any success fully resets it.
             if (!TryEnterQueryStoreCircuit())
             {
                 _logger.LogWarning(
@@ -1341,9 +1343,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         /// to proceed. The breaker is "open" (returns <c>false</c>) once
         /// <see cref="QueryStoreCircuitBreakerFailureThreshold"/> consecutive failures have occurred,
         /// and stays open until the <see cref="QueryStoreCircuitBreakerCooldown"/> deadline. When the
-        /// cooldown elapses, exactly one caller wins a compare-and-swap and is let through as a probe;
-        /// its success (<see cref="RecordQueryStoreSuccess"/>) closes the breaker, its failure
-        /// (<see cref="RecordQueryStoreFailure"/>) pushes the deadline out by another cooldown.
+        /// cooldown elapses, the first caller to observe it atomically clears the deadline and the
+        /// breaker closes, so subsequent callers proceed as well (bounded by the concurrency gate).
+        /// The consecutive-failure counter is not reset by this transition, so the next
+        /// <see cref="RecordQueryStoreFailure"/> immediately re-opens the breaker, while any
+        /// <see cref="RecordQueryStoreSuccess"/> fully resets it.
         /// </summary>
         internal static bool TryEnterQueryStoreCircuit()
         {
@@ -1360,9 +1364,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 return false;
             }
 
-            // Cooldown elapsed. Let exactly one probe through by atomically clearing the deadline.
-            // Whoever wins the CAS proceeds; concurrent callers see the reset value and either
-            // proceed (0) or observe a fresh deadline set by the probe's failure.
+            // Cooldown elapsed. Close the breaker by atomically clearing the deadline. The caller that
+            // wins the CAS performs the transition and proceeds; a concurrent caller that reads the
+            // stale deadline loses the CAS and is skipped for this pass, but any later caller reads 0
+            // (closed) and proceeds normally. The failure counter is left intact, so a subsequent
+            // failure re-opens the breaker while a success resets it.
             return Interlocked.CompareExchange(ref _queryStoreCircuitOpenUntilTicks, 0, openUntil) == openUntil;
         }
 
@@ -1379,8 +1385,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         /// <summary>
         /// Records a failed/timed-out Query Store lookup. Once the consecutive-failure count reaches
         /// <see cref="QueryStoreCircuitBreakerFailureThreshold"/>, the breaker opens for
-        /// <see cref="QueryStoreCircuitBreakerCooldown"/>. A failure while already open (the probe
-        /// failing) simply extends the cooldown by another window.
+        /// <see cref="QueryStoreCircuitBreakerCooldown"/>. Because the count is not reset on the
+        /// open-to-closed transition, the first failure after a cooldown re-opens the breaker for
+        /// another window.
         /// </summary>
         internal static void RecordQueryStoreFailure()
         {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -58,6 +58,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         internal const string LongRunningQueryDetailsParameterId = "Search.LongRunningQueryDetails.IsEnabled";
         internal const string LongRunningQueryDetailsThresholdId = "Search.LongRunningQueryDetails.Threshold";
         internal const int LongRunningThresholdMillisecondsDefault = 5000;
+
+        /// <summary>
+        /// Feature flag that gates creation of the 3-column reference-type filtered statistic on the
+        /// ReferenceSearchParam table (the stat that additionally filters on ReferenceResourceTypeId,
+        /// i.e. <c>WHERE ResourceTypeId = .. AND SearchParamId = .. AND ReferenceResourceTypeId = ..</c>).
+        /// Off by default: unless a row exists in the Parameters table with this Id set to an enabled
+        /// value, these stats are not created and reference searches fall back to the broader 2-column
+        /// filtered statistic (ResourceTypeId + SearchParamId).
+        /// </summary>
+        internal const string ReferenceResourceTypeFilteredStatsParameterId = "Search.ReferenceResourceTypeFilteredStats.IsEnabled";
         private const string SortValueColumnName = "SortValue";
 
         private readonly ISqlServerFhirModel _model;
@@ -94,8 +104,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         /// affect search query connections.
         /// </summary>
         internal const int QueryStoreLookupTimeoutSeconds = 5;
+
+        /// <summary>
+        /// Maximum number of diagnostic Query Store lookups allowed to run concurrently across the
+        /// process. Each lookup opens its own SQL connection, so this caps the diagnostic feature's
+        /// connection and CPU footprint. Slots are acquired with a zero-wait try-or-skip, so a burst
+        /// of long-running queries can never storm the server with diagnostic lookups. Kept small
+        /// because the backing database can be a shared elastic pool, where a large aggregate of
+        /// concurrent diagnostic lookups (per pod) would compete with customer traffic.
+        /// </summary>
+        internal const int MaxConcurrentQueryStoreLookups = 5;
+        private static readonly SemaphoreSlim _queryStoreLookupGate = new SemaphoreSlim(MaxConcurrentQueryStoreLookups, MaxConcurrentQueryStoreLookups);
         private static CachedParameter<SqlServerSearchService> _longRunningQueryDetails;
         private static CachedParameter<SqlServerSearchService> _longRunningThreshold;
+        private static CachedParameter<SqlServerSearchService> _referenceResourceTypeFilteredStats;
 
         public SqlServerSearchService(
             ISearchOptionsFactory searchOptionsFactory,
@@ -170,6 +192,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 if (_longRunningThreshold == null)
                 {
                     _longRunningThreshold = new CachedParameter<SqlServerSearchService>(LongRunningQueryDetailsThresholdId, LongRunningThresholdMillisecondsDefault, logger);
+                }
+
+                if (_referenceResourceTypeFilteredStats == null)
+                {
+                    // Default 0 (disabled): the 3-column reference-type filtered stat is only created
+                    // when an operator adds a row to the Parameters table with this Id enabled.
+                    _referenceResourceTypeFilteredStats = new CachedParameter<SqlServerSearchService>(ReferenceResourceTypeFilteredStatsParameterId, 0, logger);
                 }
             }
         }
@@ -840,6 +869,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                 bool isStoredProcSnapshot = sqlCommand.CommandType == CommandType.StoredProcedure;
                                 long executionTimeSnapshot = executionStopwatch.ElapsedMilliseconds;
 
+                                // Always records the long-running warning. Query Store enrichment is
+                                // best-effort and appended asynchronously only when a diagnostic slot is free.
                                 FireAndForgetQueryStoreLookup(queryTextSnapshot, isStoredProcSnapshot, executionTimeSnapshot);
                             }
                         }
@@ -1210,6 +1241,21 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         /// </summary>
         private void FireAndForgetQueryStoreLookup(string queryText, bool isStoredProcedure, long executionTime)
         {
+            // Try-or-skip: grab a diagnostic slot without waiting. If all slots are already taken,
+            // skip the expensive Query Store enrichment (which opens a new DB connection) rather than
+            // queueing it. This prevents a burst of long-running queries from each opening a diagnostic
+            // connection and storming the server. We still emit the long-running warning so the slow
+            // query is never lost — only the enrichment is dropped.
+            if (!_queryStoreLookupGate.Wait(0))
+            {
+                _logger.LogWarning(
+                    "Long-running SQL ({ElapsedMilliseconds}ms). Query={Query} QueryStoreStats={QueryStoreStats}",
+                    executionTime,
+                    queryText,
+                    "Skipped: diagnostic concurrency limit reached.");
+                return;
+            }
+
             _ = Task.Run(async () =>
             {
                 try
@@ -1235,6 +1281,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         executionTime,
                         queryText,
                         "Query Store lookup failed.");
+                }
+                finally
+                {
+                    // Always release the slot, even if the lookup threw, so the diagnostic gate
+                    // can't leak slots and permanently disable long-running query logging.
+                    _queryStoreLookupGate.Release();
                 }
             });
         }
@@ -2013,6 +2065,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 ?? Array.Empty<(string TableName, string ColumnName, short ResourceTypeId, short SearchParamId, short? ReferenceResourceTypeId)>();
         }
 
+        /// <summary>
+        /// Forces the next read of the reference-resource-type filtered statistics feature flag to bypass the
+        /// in-memory cache and re-query the Parameters table. Intended for integration tests that toggle the flag.
+        /// </summary>
+        internal static void ResetReferenceResourceTypeFilteredStatsCache()
+        {
+            _referenceResourceTypeFilteredStats?.Reset();
+        }
+
         internal async Task<IReadOnlyList<(string TableName, string ColumnName, short ResourceTypeId, short SearchParamId, short? ReferenceResourceTypeId)>> GetStatsFromDatabase(CancellationToken cancel)
         {
             return await GetStatsFromDatabase(_sqlRetryService, _logger, cancel);
@@ -2275,6 +2336,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                 bool isStoredProcSnapshot = sqlCommand.CommandType == CommandType.StoredProcedure;
                                 long executionTimeSnapshot = executionStopwatch.ElapsedMilliseconds;
 
+                                // Always records the long-running warning. Query Store enrichment is
+                                // best-effort and appended asynchronously only when a diagnostic slot is free.
                                 FireAndForgetQueryStoreLookup(queryTextSnapshot, isStoredProcSnapshot, executionTimeSnapshot);
                             }
                         }
@@ -2990,6 +3053,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
             private async Task Create(string tableName, string columnName, short resourceTypeId, short searchParamId, short? referenceResourceTypeId, ISqlRetryService sqlRetryService, ILogger<SqlServerSearchService> logger, CancellationToken cancel)
             {
+                // The 3-column reference-type filtered stat (which additionally filters on ReferenceResourceTypeId)
+                // is gated behind a feature flag that is OFF by default. When disabled, fall back to the broader
+                // 2-column filtered stat (ResourceTypeId + SearchParamId) so reference searches still get a stat.
+                if (referenceResourceTypeId.HasValue && !_referenceResourceTypeFilteredStats.IsEnabled(sqlRetryService))
+                {
+                    referenceResourceTypeId = null;
+                }
+
                 if (_stats.ContainsKey((tableName, columnName, resourceTypeId, searchParamId, referenceResourceTypeId)))
                 {
                     logger.LogInformation("ResourceSearchParamStats.FoundInCache Table={Table} Column={Column} Type={ResourceType} Param={SearchParam} RefType={ReferenceResourceType}", tableName, columnName, resourceTypeId, searchParamId, referenceResourceTypeId);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -115,6 +115,31 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         /// </summary>
         internal const int MaxConcurrentQueryStoreLookups = 5;
         private static readonly SemaphoreSlim _queryStoreLookupGate = new SemaphoreSlim(MaxConcurrentQueryStoreLookups, MaxConcurrentQueryStoreLookups);
+
+        /// <summary>
+        /// Number of consecutive Query Store lookup failures (errors or timeouts) that trips the
+        /// diagnostic circuit breaker. Once tripped, Query Store enrichment is suspended for
+        /// <see cref="QueryStoreCircuitBreakerCooldown"/> so a truly overloaded database is not
+        /// compounded by diagnostic load. Any single successful lookup resets the counter to zero.
+        /// </summary>
+        internal const int QueryStoreCircuitBreakerFailureThreshold = 5;
+
+        /// <summary>
+        /// How long Query Store enrichment stays suspended after the circuit breaker trips. When the
+        /// cooldown elapses, exactly one probe lookup is allowed through: if it succeeds the breaker
+        /// resets, otherwise the cooldown restarts. Slow-query warnings are always logged regardless
+        /// of breaker state — only the Query Store stats lookup is skipped.
+        /// </summary>
+        internal static readonly TimeSpan QueryStoreCircuitBreakerCooldown = TimeSpan.FromSeconds(10);
+
+        // Circuit breaker state for the diagnostic Query Store lookups. Static (per-process/per-pod)
+        // and mutated only through Interlocked/Volatile so no lock is needed on the hot search path.
+        // _queryStoreConsecutiveFailures counts consecutive failures; when it reaches the threshold
+        // the breaker is "open" until _queryStoreCircuitOpenUntilTicks (a DateTime.UtcNow.Ticks
+        // deadline). A value of 0 means the breaker is closed.
+        private static int _queryStoreConsecutiveFailures;
+        private static long _queryStoreCircuitOpenUntilTicks;
+
         private static CachedParameter<SqlServerSearchService> _longRunningQueryDetails;
         private static CachedParameter<SqlServerSearchService> _longRunningThreshold;
         private static CachedParameter<SqlServerSearchService> _referenceResourceTypeFilteredStats;
@@ -1241,6 +1266,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         /// </summary>
         private void FireAndForgetQueryStoreLookup(string queryText, bool isStoredProcedure, long executionTime)
         {
+            // Circuit breaker: if too many consecutive lookups have failed/timed out, the database is
+            // likely overloaded. Suspend Query Store enrichment for a cooldown window so diagnostics
+            // don't compound the problem. The slow query is still logged below — only the enrichment
+            // is skipped. When the cooldown elapses, exactly one probe lookup is allowed through.
+            if (!TryEnterQueryStoreCircuit())
+            {
+                _logger.LogWarning(
+                    "Long-running SQL ({ElapsedMilliseconds}ms). Query={Query} QueryStoreStats={QueryStoreStats}",
+                    executionTime,
+                    queryText,
+                    "Skipped: diagnostic circuit breaker open (database appears overloaded).");
+                return;
+            }
+
             // Try-or-skip: grab a diagnostic slot without waiting. If all slots are already taken,
             // skip the expensive Query Store enrichment (which opens a new DB connection) rather than
             // queueing it. This prevents a burst of long-running queries from each opening a diagnostic
@@ -1269,12 +1308,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         QueryStoreLookupTimeoutSeconds,
                         executionTime,
                         loggingCts.Token);
+
+                    // A single success closes the breaker and clears the consecutive-failure count.
+                    RecordQueryStoreSuccess();
                 }
                 catch (Exception ex)
                 {
                     // The Query Store lookup is best-effort diagnostics. Swallow any failure so the
                     // fire-and-forget task never surfaces an unobserved exception. The exception is
                     // passed to the logger (queryable via env_ex_* columns), so it isn't repeated in the message.
+                    // Count the failure toward the circuit breaker so a truly overloaded DB trips it.
+                    RecordQueryStoreFailure();
+
                     _logger.LogWarning(
                         ex,
                         "Long-running SQL ({ElapsedMilliseconds}ms). Query={Query} QueryStoreStats={QueryStoreStats}",
@@ -1289,6 +1334,82 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     _queryStoreLookupGate.Release();
                 }
             });
+        }
+
+        /// <summary>
+        /// Diagnostic circuit breaker gate. Returns <c>true</c> when a Query Store lookup is allowed
+        /// to proceed. The breaker is "open" (returns <c>false</c>) once
+        /// <see cref="QueryStoreCircuitBreakerFailureThreshold"/> consecutive failures have occurred,
+        /// and stays open until the <see cref="QueryStoreCircuitBreakerCooldown"/> deadline. When the
+        /// cooldown elapses, exactly one caller wins a compare-and-swap and is let through as a probe;
+        /// its success (<see cref="RecordQueryStoreSuccess"/>) closes the breaker, its failure
+        /// (<see cref="RecordQueryStoreFailure"/>) pushes the deadline out by another cooldown.
+        /// </summary>
+        internal static bool TryEnterQueryStoreCircuit()
+        {
+            long openUntil = Interlocked.Read(ref _queryStoreCircuitOpenUntilTicks);
+            if (openUntil == 0)
+            {
+                // Breaker closed — normal operation.
+                return true;
+            }
+
+            if (DateTime.UtcNow.Ticks < openUntil)
+            {
+                // Still within the cooldown window — stay open.
+                return false;
+            }
+
+            // Cooldown elapsed. Let exactly one probe through by atomically clearing the deadline.
+            // Whoever wins the CAS proceeds; concurrent callers see the reset value and either
+            // proceed (0) or observe a fresh deadline set by the probe's failure.
+            return Interlocked.CompareExchange(ref _queryStoreCircuitOpenUntilTicks, 0, openUntil) == openUntil;
+        }
+
+        /// <summary>
+        /// Records a successful Query Store lookup: resets the consecutive-failure counter and closes
+        /// the circuit breaker. Any single success from any thread fully recovers the breaker.
+        /// </summary>
+        internal static void RecordQueryStoreSuccess()
+        {
+            Interlocked.Exchange(ref _queryStoreConsecutiveFailures, 0);
+            Interlocked.Exchange(ref _queryStoreCircuitOpenUntilTicks, 0);
+        }
+
+        /// <summary>
+        /// Records a failed/timed-out Query Store lookup. Once the consecutive-failure count reaches
+        /// <see cref="QueryStoreCircuitBreakerFailureThreshold"/>, the breaker opens for
+        /// <see cref="QueryStoreCircuitBreakerCooldown"/>. A failure while already open (the probe
+        /// failing) simply extends the cooldown by another window.
+        /// </summary>
+        internal static void RecordQueryStoreFailure()
+        {
+            int failures = Interlocked.Increment(ref _queryStoreConsecutiveFailures);
+            if (failures >= QueryStoreCircuitBreakerFailureThreshold)
+            {
+                Interlocked.Exchange(
+                    ref _queryStoreCircuitOpenUntilTicks,
+                    DateTime.UtcNow.Add(QueryStoreCircuitBreakerCooldown).Ticks);
+            }
+        }
+
+        /// <summary>
+        /// Test-only seam: deterministically seeds the diagnostic circuit breaker's static state so
+        /// unit tests can exercise the open/cooldown/probe transitions without waiting real time.
+        /// </summary>
+        internal static void SetQueryStoreCircuitStateForTests(int consecutiveFailures, long openUntilTicks)
+        {
+            Interlocked.Exchange(ref _queryStoreConsecutiveFailures, consecutiveFailures);
+            Interlocked.Exchange(ref _queryStoreCircuitOpenUntilTicks, openUntilTicks);
+        }
+
+        /// <summary>
+        /// Test-only seam: reads the diagnostic circuit breaker's open deadline (0 when closed) so
+        /// unit tests can assert that a probe cleared it.
+        /// </summary>
+        internal static long GetQueryStoreCircuitOpenUntilTicksForTests()
+        {
+            return Interlocked.Read(ref _queryStoreCircuitOpenUntilTicks);
         }
 
         private async Task LogQueryStoreByTextAsync(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
@@ -102,9 +102,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
-        public async Task GivenSearchByReferenceParam_NormalPath_StatsAreCreated()
+        public async Task GivenSearchByReferenceParam_ThreeColumnTypedStatIsGatedByFeatureFlag()
         {
-            // Arrange — DiagnosticReport.subject is a reference search parameter stored in dbo.ReferenceSearchParam
+            // DiagnosticReport.subject is a reference search parameter stored in dbo.ReferenceSearchParam.
+            // The 3-column ReferenceResourceTypeId-filtered stat is gated behind the
+            // Search.ReferenceResourceTypeFilteredStats.IsEnabled feature flag, which is OFF by default.
+            // Both phases run inside a single test so the ordering of the shared feature flag is controlled.
             const string resourceType = "DiagnosticReport";
             const string searchParamUrl = "http://hl7.org/fhir/SearchParameter/DiagnosticReport-subject";
             var query = new[] { Tuple.Create("subject", "Patient/test-patient-1") };
@@ -113,25 +116,36 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             short searchParamId = sqlSearchService.Model.GetSearchParamId(new Uri(searchParamUrl));
             short patientTypeId = sqlSearchService.Model.GetResourceTypeId("Patient");
 
-            // Act
-            await _fixture.SearchService.SearchAsync(resourceType, query, CancellationToken.None);
-
-            // Assert — a filtered stat on ReferenceResourceId with ReferenceResourceTypeId in the filter
-            var cacheAfter = SqlServerSearchService.GetStatsFromCache().ToList();
-            var databaseAfter = (await sqlSearchService.GetStatsFromDatabase(CancellationToken.None)).ToList();
-
-            bool MatchesStat((string TableName, string ColumnName, short ResourceTypeId, short SearchParamId, short? ReferenceResourceTypeId) s) =>
+            bool IsReferenceIdStat((string TableName, string ColumnName, short ResourceTypeId, short SearchParamId, short? ReferenceResourceTypeId) s) =>
                 s.TableName == VLatest.ReferenceSearchParam.TableName
                 && s.ColumnName == VLatest.ReferenceSearchParam.ReferenceResourceId.Metadata.Name
                 && s.ResourceTypeId == resourceTypeId
-                && s.SearchParamId == searchParamId
-                && s.ReferenceResourceTypeId == patientTypeId;
+                && s.SearchParamId == searchParamId;
 
-            // Cache
-            Assert.True(cacheAfter.Any(MatchesStat), "Expected the cache to contain a filtered statistics entry for ReferenceResourceId with a ReferenceResourceTypeId filter.");
+            try
+            {
+                // Phase 1 — flag disabled (default). The typed reference search must fall back to the broader
+                // 2-column stat (no ReferenceResourceTypeId filter) and must NOT create the gated 3-column stat.
+                await SetReferenceResourceTypeFilteredStatsFlagAsync(enabled: false);
+                await _fixture.SearchService.SearchAsync(resourceType, query, CancellationToken.None);
 
-            // Database
-            Assert.True(databaseAfter.Any(MatchesStat), "Expected the database to contain a filtered statistics entry for ReferenceResourceId with a ReferenceResourceTypeId filter.");
+                var disabledDatabase = (await sqlSearchService.GetStatsFromDatabase(CancellationToken.None)).ToList();
+                Assert.Contains(disabledDatabase, s => IsReferenceIdStat(s) && s.ReferenceResourceTypeId == null);
+                Assert.DoesNotContain(disabledDatabase, s => IsReferenceIdStat(s) && s.ReferenceResourceTypeId == patientTypeId);
+
+                // Phase 2 — flag enabled. The same typed reference search now creates the 3-column stat that
+                // additionally filters on ReferenceResourceTypeId.
+                await SetReferenceResourceTypeFilteredStatsFlagAsync(enabled: true);
+                await _fixture.SearchService.SearchAsync(resourceType, query, CancellationToken.None);
+
+                var enabledDatabase = (await sqlSearchService.GetStatsFromDatabase(CancellationToken.None)).ToList();
+                Assert.Contains(enabledDatabase, s => IsReferenceIdStat(s) && s.ReferenceResourceTypeId == patientTypeId);
+            }
+            finally
+            {
+                // Restore the default (disabled) state so the process-global flag does not leak into other tests.
+                await SetReferenceResourceTypeFilteredStatsFlagAsync(enabled: false);
+            }
         }
 
         [Fact]
@@ -200,6 +214,27 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                   && _.ColumnName == "Code"
                   && _.ResourceTypeId != patientResourceTypeId
                   && _.SearchParamId == genderParamId);
+        }
+
+        private async Task SetReferenceResourceTypeFilteredStatsFlagAsync(bool enabled)
+        {
+            using var conn = await _fixture.SqlHelper.GetSqlConnectionAsync();
+            if (conn.State != System.Data.ConnectionState.Open)
+            {
+                await conn.OpenAsync(CancellationToken.None);
+            }
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+DELETE FROM dbo.Parameters WHERE Id = @id;
+IF @number IS NOT NULL
+    INSERT INTO dbo.Parameters (Id, Number) VALUES (@id, @number);";
+            cmd.Parameters.AddWithValue("@id", SqlServerSearchService.ReferenceResourceTypeFilteredStatsParameterId);
+            cmd.Parameters.AddWithValue("@number", enabled ? (object)1 : DBNull.Value);
+            await cmd.ExecuteNonQueryAsync(CancellationToken.None);
+
+            // Force the cached feature-flag value to be re-read from the Parameters table on the next stats call.
+            SqlServerSearchService.ResetReferenceResourceTypeFilteredStatsCache();
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
@@ -25,11 +25,14 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
+    [Collection(SqlServerCreateStatsTests.SerialCollectionName)]
     [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.DataSourceValidation)]
     public class SqlServerCreateStatsTests : IClassFixture<FhirStorageTestsFixture>
     {
+        internal const string SerialCollectionName = "SqlServerCreateStatsTests serial collection";
+
         private readonly FhirStorageTestsFixture _fixture;
         private readonly ITestOutputHelper _output;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTestsCollection.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTestsCollection.cs
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    /// <summary>
+    /// Runs <see cref="SqlServerCreateStatsTests"/> in a non-parallel collection. That class toggles
+    /// the process-global, static <c>Search.ReferenceResourceTypeFilteredStats.IsEnabled</c> cache;
+    /// serializing the collection prevents other parallel test classes from observing that flag while
+    /// it is temporarily toggled here.
+    /// </summary>
+    [CollectionDefinition(SqlServerCreateStatsTests.SerialCollectionName, DisableParallelization = true)]
+    public sealed class SqlServerCreateStatsTestsCollection
+    {
+    }
+}


### PR DESCRIPTION
Related work item: [AB#197291](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/197291)

## What this does

- Puts the new 3-column filtered stat on `dbo.ReferenceSearchParam` (`ResourceTypeId` + `SearchParamId` + `ReferenceResourceTypeId`) behind a new flag `Search.ReferenceResourceTypeFilteredStats.IsEnabled`, defaulting to **off**. When off, typed reference searches use the existing 2-column stat.
- Adds a concurrency limit and a circuit breaker around the slow-query diagnostic logger (`FireAndForgetQueryStoreLookup`) so it can't overload the database.

## Why

OSS-CI R4 SQL E2E started timing out at 120 min with SQL CPU at 100%. It was a feedback loop:

new 3-column stat → plan cache invalidated → giant compartment/chained queries recompile → compile time (35-41s) pushes the query over the 5s "long-running" threshold → diagnostic logger fires → the logger's `LIKE` scan over `sys.query_store_query_text` is expensive → CPU saturates → more queries cross 5s → more logger calls → snowball.

The logger query alone used ~2.27 hours of CPU (8,166 executions), which is the 2-hour timeout.

## Numbers (both runs had the logger flag on)

| Metric | 4.0.804 (passed) | 4.0.810 (timed out) |
|---|---|---|
| Long-running SQL events | 3 (whole run) | 2,552 (first 88 min) |
| p50 | 5,789 ms | 17,579 ms |
| p95 | 9,767 ms | 36,035 ms |
| max | 9,767 ms | 102,891 ms |
| queries > 10s | 0 | 2,489 |
| queries > 20s | 0 | 1,037 |
| compile time (compartment/chained) | ~47 ms | 35,000-41,000 ms |

## Testing

- Unit tests for the circuit breaker (open / cooldown / probe transitions).
- Integration test covering the 2-column fallback (flag off) and 3-column path (flag on).

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
