### PR TITLE
Pin Az 5.5.0/6.5.0 and prune newer agent-shipped versions

### DIFF
--- a/build/cleanup-aad-resources.yml
+++ b/build/cleanup-aad-resources.yml
@@ -64,11 +64,10 @@ stages:
             "Microsoft.Graph.Identity.DirectoryManagement"
           )
 
-          # Pin all Graph submodules to a single version. Without a pinned version each submodule
-          # resolves to "latest" independently (or a stale copy is imported), producing a mismatched
-          # set that fails Connect-MgGraph with EntryPointNotFoundException. 2.33.0 is the last version
-          # proven compatible with the Az/agent assemblies (newer releases such as 2.38.0 conflict).
-          $graphVersion = '2.33.0'
+          # Pin all Graph submodules to a single version so the installed and imported set always
+          # match (floating to "latest" independently, or importing a stale copy pre-baked on the
+          # agent, can produce a mismatched set that fails Connect-MgGraph with EntryPointNotFoundException).
+          $graphVersion = '2.38.0'
 
           foreach ($module in $modules) {
             Install-Module -Name $module -RequiredVersion $graphVersion -Force -Scope CurrentUser -ErrorAction Stop

--- a/build/cleanup-aad-resources.yml
+++ b/build/cleanup-aad-resources.yml
@@ -66,8 +66,9 @@ stages:
 
           # Pin all Graph submodules to a single version. Without a pinned version each submodule
           # resolves to "latest" independently (or a stale copy is imported), producing a mismatched
-          # set that fails Connect-MgGraph with EntryPointNotFoundException.
-          $graphVersion = '2.38.0'
+          # set that fails Connect-MgGraph with EntryPointNotFoundException. 2.33.0 is the last version
+          # proven compatible with the Az/agent assemblies (newer releases such as 2.38.0 conflict).
+          $graphVersion = '2.33.0'
 
           foreach ($module in $modules) {
             Install-Module -Name $module -RequiredVersion $graphVersion -Force -Scope CurrentUser -ErrorAction Stop

--- a/build/cleanup-aad-resources.yml
+++ b/build/cleanup-aad-resources.yml
@@ -63,17 +63,22 @@ stages:
             "Microsoft.Graph.DirectoryObjects",
             "Microsoft.Graph.Identity.DirectoryManagement"
           )
-          
+
+          # Pin all Graph submodules to a single version. Without a pinned version each submodule
+          # resolves to "latest" independently (or a stale copy is imported), producing a mismatched
+          # set that fails Connect-MgGraph with EntryPointNotFoundException.
+          $graphVersion = '2.38.0'
+
           foreach ($module in $modules) {
-            Install-Module -Name $module -Force -Scope CurrentUser -ErrorAction Stop
+            Install-Module -Name $module -RequiredVersion $graphVersion -Force -Scope CurrentUser -ErrorAction Stop
           }
           
           # Import all modules upfront to prevent auto-loading conflicts
           foreach ($module in $modules) {
-            Import-Module $module -ErrorAction Stop
+            Import-Module $module -RequiredVersion $graphVersion -ErrorAction Stop
           }
 
-          $installedAuth = Get-Module -Name Microsoft.Graph.Authentication -ListAvailable | Select-Object -First 1
+          $installedAuth = Get-Module -Name Microsoft.Graph.Authentication | Select-Object -First 1
           Write-Host "Microsoft.Graph.Authentication version: $($installedAuth.Version)"
           Write-Host "Microsoft Graph modules installed and imported."
 

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -25,14 +25,19 @@ steps:
         'Microsoft.Graph.Users',
         'Microsoft.Graph.Identity.DirectoryManagement'
       )
-      
-      Write-Host "Installing Microsoft Graph modules..."
-      $graphModules | ForEach-Object { Install-Module -Name $_ -Force -Scope CurrentUser -AllowClobber }
-      
-      Write-Host "Importing Microsoft Graph modules..."
-      $graphModules | ForEach-Object { Import-Module -Name $_ -ErrorAction Stop }
-      
-      $graphAuthModule = Get-Module -Name Microsoft.Graph.Authentication -ListAvailable | Select-Object -First 1
+
+      # Pin all Graph submodules to a single version. Installing/importing without a version lets each
+      # submodule float to "latest" independently, which can produce a mismatched set (or import a stale
+      # copy pre-baked on the agent) and fail Connect-MgGraph with EntryPointNotFoundException.
+      $graphVersion = '2.38.0'
+
+      Write-Host "Installing Microsoft Graph modules (version $graphVersion)..."
+      $graphModules | ForEach-Object { Install-Module -Name $_ -RequiredVersion $graphVersion -Force -Scope CurrentUser -AllowClobber }
+
+      Write-Host "Importing Microsoft Graph modules (version $graphVersion)..."
+      $graphModules | ForEach-Object { Import-Module -Name $_ -RequiredVersion $graphVersion -ErrorAction Stop }
+
+      $graphAuthModule = Get-Module -Name Microsoft.Graph.Authentication | Select-Object -First 1
       Write-Host "Microsoft.Graph.Authentication version: $($graphAuthModule.Version)"
 
       # Install and import Az modules AFTER Microsoft.Graph modules are loaded

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -26,12 +26,10 @@ steps:
         'Microsoft.Graph.Identity.DirectoryManagement'
       )
 
-      # Pin all Graph submodules to a single version. Installing/importing without a version lets each
-      # submodule float to "latest" independently, which can produce a mismatched set (or import a stale
-      # copy pre-baked on the agent) and fail Connect-MgGraph with EntryPointNotFoundException. 2.33.0 is
-      # the last version proven compatible with the Az modules loaded later in this job (newer releases
-      # such as 2.38.0 require a shared assembly version that conflicts with Az.Accounts).
-      $graphVersion = '2.33.0'
+      # Pin all Graph submodules to a single version so the installed and imported set always match
+      # (floating to "latest" independently, or importing a stale copy pre-baked on the agent, can
+      # produce a mismatched set and fail Connect-MgGraph with EntryPointNotFoundException).
+      $graphVersion = '2.38.0'
 
       Write-Host "Installing Microsoft Graph modules (version $graphVersion)..."
       $graphModules | ForEach-Object { Install-Module -Name $_ -RequiredVersion $graphVersion -Force -Scope CurrentUser -AllowClobber }
@@ -42,13 +40,19 @@ steps:
       $graphAuthModule = Get-Module -Name Microsoft.Graph.Authentication | Select-Object -First 1
       Write-Host "Microsoft.Graph.Authentication version: $($graphAuthModule.Version)"
 
-      # Install and import Az modules AFTER Microsoft.Graph modules are loaded
-      Write-Host "Installing Az modules..."
-      Install-Module -Name Az.Accounts -Force -Scope CurrentUser -AllowClobber
-      Install-Module -Name Az.KeyVault -Force -Scope CurrentUser -AllowClobber
+      # Install and import Az modules AFTER Microsoft.Graph modules are loaded.
+      # Pin Az.Accounts / Az.KeyVault: newer builds ship a shared assembly (Azure.Core /
+      # System.Threading.Tasks.Extensions) that is incompatible with the loaded Microsoft.Graph modules
+      # and makes Connect-MgGraph throw EntryPointNotFoundException. These versions are the last set
+      # proven to work with Graph $graphVersion in this job.
+      $azAccountsVersion = '5.5.0'
+      $azKeyVaultVersion = '6.5.0'
+      Write-Host "Installing Az modules (Az.Accounts $azAccountsVersion, Az.KeyVault $azKeyVaultVersion)..."
+      Install-Module -Name Az.Accounts -RequiredVersion $azAccountsVersion -Force -Scope CurrentUser -AllowClobber
+      Install-Module -Name Az.KeyVault -RequiredVersion $azKeyVaultVersion -Force -Scope CurrentUser -AllowClobber
       Install-Module -Name Microsoft.PowerShell.SecretManagement -Force -Scope CurrentUser -AllowClobber
-      Import-Module Az.Accounts -ErrorAction Stop
-      Import-Module Az.KeyVault -ErrorAction Stop
+      Import-Module Az.Accounts -RequiredVersion $azAccountsVersion -ErrorAction Stop
+      Import-Module Az.KeyVault -RequiredVersion $azKeyVaultVersion -ErrorAction Stop
       Import-Module Microsoft.PowerShell.SecretManagement -ErrorAction Stop
 
       # Set up variables

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -28,8 +28,10 @@ steps:
 
       # Pin all Graph submodules to a single version. Installing/importing without a version lets each
       # submodule float to "latest" independently, which can produce a mismatched set (or import a stale
-      # copy pre-baked on the agent) and fail Connect-MgGraph with EntryPointNotFoundException.
-      $graphVersion = '2.38.0'
+      # copy pre-baked on the agent) and fail Connect-MgGraph with EntryPointNotFoundException. 2.33.0 is
+      # the last version proven compatible with the Az modules loaded later in this job (newer releases
+      # such as 2.38.0 require a shared assembly version that conflicts with Az.Accounts).
+      $graphVersion = '2.33.0'
 
       Write-Host "Installing Microsoft Graph modules (version $graphVersion)..."
       $graphModules | ForEach-Object { Install-Module -Name $_ -RequiredVersion $graphVersion -Force -Scope CurrentUser -AllowClobber }

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -41,12 +41,14 @@ steps:
       Write-Host "Microsoft.Graph.Authentication version: $($graphAuthModule.Version)"
 
       # Install and import Az modules AFTER Microsoft.Graph modules are loaded.
-      # Pin Az.Accounts / Az.KeyVault: newer builds ship a shared assembly (Azure.Core /
-      # System.Threading.Tasks.Extensions) that is incompatible with the loaded Microsoft.Graph modules
-      # and makes Connect-MgGraph throw EntryPointNotFoundException. These versions are the last set
-      # proven to work with Graph $graphVersion in this job.
-      $azAccountsVersion = '5.5.0'
-      $azKeyVaultVersion = '6.5.0'
+      # Pin Az.Accounts / Az.KeyVault to the exact versions the hosted agent image preloads.
+      # The agent has Az.Accounts 5.5.1's shared assembly (Microsoft.Azure.PowerShell.AssemblyLoading,
+      # Version=5.5.1.0) already loaded into the process. Installing a *different* Az build (e.g. 5.5.0)
+      # makes SecretManagement's Register-SecretVault fail with "Assembly with same name is already
+      # loaded" when it re-resolves Az.KeyVault. Matching the preloaded version (5.5.1 / 6.5.1) avoids
+      # that clash, and this pair is also compatible with Graph $graphVersion for Connect-MgGraph.
+      $azAccountsVersion = '5.5.1'
+      $azKeyVaultVersion = '6.5.1'
       Write-Host "Installing Az modules (Az.Accounts $azAccountsVersion, Az.KeyVault $azKeyVaultVersion)..."
       Install-Module -Name Az.Accounts -RequiredVersion $azAccountsVersion -Force -Scope CurrentUser -AllowClobber
       Install-Module -Name Az.KeyVault -RequiredVersion $azKeyVaultVersion -Force -Scope CurrentUser -AllowClobber

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -41,18 +41,32 @@ steps:
       Write-Host "Microsoft.Graph.Authentication version: $($graphAuthModule.Version)"
 
       # Install and import Az modules AFTER Microsoft.Graph modules are loaded.
-      # Pin Az.Accounts / Az.KeyVault to the exact versions the hosted agent image preloads.
-      # The agent has Az.Accounts 5.5.1's shared assembly (Microsoft.Azure.PowerShell.AssemblyLoading,
-      # Version=5.5.1.0) already loaded into the process. Installing a *different* Az build (e.g. 5.5.0)
-      # makes SecretManagement's Register-SecretVault fail with "Assembly with same name is already
-      # loaded" when it re-resolves Az.KeyVault. Matching the preloaded version (5.5.1 / 6.5.1) avoids
-      # that clash, and this pair is also compatible with Graph $graphVersion for Connect-MgGraph.
-      $azAccountsVersion = '5.5.1'
-      $azKeyVaultVersion = '6.5.1'
+      # Pin Az.Accounts / Az.KeyVault to 5.5.0 / 6.5.0. Two separate assembly conflicts are in play:
+      #   1. Az.Accounts 5.5.1 (published 2026-07-07) ships a shared assembly that breaks
+      #      Connect-MgGraph with EntryPointNotFoundException, so we must load 5.5.0 (not 5.5.1).
+      #   2. SecretManagement's Register-SecretVault (called later in Add-AadTestAuthEnvironment.ps1)
+      #      resolves Az.KeyVault to the HIGHEST installed version. The hosted agent image also ships
+      #      Az.KeyVault 6.5.1 / Az.Accounts 5.5.1, so it would pick 6.5.1 and fail with
+      #      "Assembly with same name is already loaded" against the pinned 5.5.0/6.5.0 we loaded.
+      # Fix: pin to 5.5.0/6.5.0 AND remove any higher versions from the module path so the whole
+      # process (Connect-MgGraph and Register-SecretVault alike) only ever sees the pinned build.
+      $azAccountsVersion = '5.5.0'
+      $azKeyVaultVersion = '6.5.0'
       Write-Host "Installing Az modules (Az.Accounts $azAccountsVersion, Az.KeyVault $azKeyVaultVersion)..."
       Install-Module -Name Az.Accounts -RequiredVersion $azAccountsVersion -Force -Scope CurrentUser -AllowClobber
       Install-Module -Name Az.KeyVault -RequiredVersion $azKeyVaultVersion -Force -Scope CurrentUser -AllowClobber
       Install-Module -Name Microsoft.PowerShell.SecretManagement -Force -Scope CurrentUser -AllowClobber
+
+      # Remove any Az.Accounts / Az.KeyVault versions newer than the pin (shipped by the agent image),
+      # so Register-SecretVault cannot auto-resolve to a newer build whose shared assembly conflicts.
+      $azPins = @{ 'Az.Accounts' = [version]$azAccountsVersion; 'Az.KeyVault' = [version]$azKeyVaultVersion }
+      foreach ($azName in $azPins.Keys) {
+        Get-Module -ListAvailable -Name $azName | Where-Object { $_.Version -gt $azPins[$azName] } | ForEach-Object {
+          Write-Host "Removing higher $azName $($_.Version) at $($_.ModuleBase) to avoid assembly conflict"
+          Remove-Item -LiteralPath $_.ModuleBase -Recurse -Force -ErrorAction SilentlyContinue
+        }
+      }
+
       Import-Module Az.Accounts -RequiredVersion $azAccountsVersion -ErrorAction Stop
       Import-Module Az.KeyVault -RequiredVersion $azKeyVaultVersion -ErrorAction Stop
       Import-Module Microsoft.PowerShell.SecretManagement -ErrorAction Stop

--- a/build/jobs/cleanup-aad.yml
+++ b/build/jobs/cleanup-aad.yml
@@ -30,10 +30,9 @@ jobs:
           'Microsoft.Graph.Identity.DirectoryManagement'
         )
 
-        # Pin all Graph submodules to a single version. Without a pinned version each submodule
-        # resolves to "latest" independently (or a stale copy is imported), producing a mismatched
-        # set that fails Connect-MgGraph with EntryPointNotFoundException. 2.33.0 is the last version
-        # proven compatible with the Az/agent assemblies (newer releases such as 2.38.0 conflict).
+        # Pin all Graph submodules to a single version so the installed and imported set always
+        # match (floating to "latest" independently, or importing a stale copy pre-baked on the
+        # agent, can produce a mismatched set that fails Connect-MgGraph with EntryPointNotFoundException).
         $graphVersion = '2.33.0'
 
         # Install all modules first at the pinned version

--- a/build/jobs/cleanup-aad.yml
+++ b/build/jobs/cleanup-aad.yml
@@ -30,20 +30,25 @@ jobs:
           'Microsoft.Graph.Identity.DirectoryManagement'
         )
 
-        # Install all modules first
+        # Pin all Graph submodules to a single version. Without a pinned version each submodule
+        # resolves to "latest" independently (or a stale copy is imported), producing a mismatched
+        # set that fails Connect-MgGraph with EntryPointNotFoundException.
+        $graphVersion = '2.38.0'
+
+        # Install all modules first at the pinned version
         foreach ($module in $graphModules) {
-          $installed = Get-Module -ListAvailable -Name $module | Select-Object -First 1
+          $installed = Get-Module -ListAvailable -Name $module | Where-Object { $_.Version -eq $graphVersion } | Select-Object -First 1
           if (-not $installed) {
-            Install-Module -Name $module -Scope CurrentUser -Force -AllowClobber
+            Install-Module -Name $module -RequiredVersion $graphVersion -Scope CurrentUser -Force -AllowClobber
           }
         }
 
         # Import all modules upfront to prevent auto-loading conflicts
         foreach ($module in $graphModules) {
-          Import-Module -Name $module -ErrorAction Stop
+          Import-Module -Name $module -RequiredVersion $graphVersion -ErrorAction Stop
         }
 
-        $installedAuth = Get-Module -Name Microsoft.Graph.Authentication -ListAvailable | Select-Object -First 1
+        $installedAuth = Get-Module -Name Microsoft.Graph.Authentication | Select-Object -First 1
         Write-Host "Microsoft.Graph.Authentication version: $($installedAuth.Version)"
 
         $username = "$(tenant-admin-user-name)"

--- a/build/jobs/cleanup-aad.yml
+++ b/build/jobs/cleanup-aad.yml
@@ -32,8 +32,9 @@ jobs:
 
         # Pin all Graph submodules to a single version. Without a pinned version each submodule
         # resolves to "latest" independently (or a stale copy is imported), producing a mismatched
-        # set that fails Connect-MgGraph with EntryPointNotFoundException.
-        $graphVersion = '2.38.0'
+        # set that fails Connect-MgGraph with EntryPointNotFoundException. 2.33.0 is the last version
+        # proven compatible with the Az/agent assemblies (newer releases such as 2.38.0 conflict).
+        $graphVersion = '2.33.0'
 
         # Install all modules first at the pinned version
         foreach ($module in $graphModules) {


### PR DESCRIPTION
[AB#197379](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/197379)

The `Setup AAD Test Environment` step in the PR pipeline started failing on `Connect-MgGraph`. This turned out to be two separate assembly conflicts, both triggered by new Az PowerShell module versions published on 2026-07-07. Verified fixed in build 50321 (Setup AAD Test Environment: succeeded).

## Symptom

```
Installing Az modules...
Connecting to Microsoft Graph...
Connect-MgGraph : Entry point was not found.
```

Build, unit tests, and Docker images all pass - only the AAD environment setup breaks, which then cascades so the downstream Create Resource Group / Key Vault / test-provisioning steps are marked failed or skipped.

## Root cause (two conflicts)

`build/jobs/add-aad-test-environment.yml` loads Microsoft Graph modules and Az modules (`Az.Accounts`, `Az.KeyVault`) into the same PowerShell process, then later calls into a shared script (`Add-AadTestAuthEnvironment.ps1`) that uses `Register-SecretVault` with the `Az.KeyVault` SecretManagement extension. On 2026-07-07 new Az builds shipped and exposed two independent shared-assembly clashes:

1. **Connect-MgGraph vs Az.Accounts 5.5.1.** `Az.Accounts 5.5.1` (published 2026-07-07) ships a shared assembly that is incompatible with `Microsoft.Graph.Authentication`, so `Connect-MgGraph` throws `EntryPointNotFoundException`. `Az.Accounts 5.5.0` (yesterday's version) does not.

2. **Register-SecretVault vs highest installed Az.KeyVault.** SecretManagement resolves the `Az.KeyVault` extension to the **highest version installed**, not the version we imported. The hosted agent image itself now ships `Az.KeyVault 6.5.1 / Az.Accounts 5.5.1`, so even after pinning to 5.5.0/6.5.0, `Register-SecretVault` picked up 6.5.1 and failed with:

```
Register-SecretVault : Could not load ... Az.KeyVault ...
Assembly with same name is already loaded.
```

So pinning `Az.Accounts` down to 5.5.0 fixes conflict #1 but exposes conflict #2, because the newer build is still present on the agent for SecretManagement to auto-resolve to.

### Version reference

| Module | Yesterday (worked) | Today (broke) | Published |
| --- | --- | --- | --- |
| Az.Accounts | 5.5.0 | 5.5.1 | 5.5.1 on 2026-07-07 |
| Az.KeyVault | 6.5.0 | 6.5.1 | 6.5.1 on 2026-07-07 |
| Microsoft.Graph.Authentication | 2.38.0 | 2.38.0 | unchanged (2026-06-16) |

Graph 2.38.0 was already "latest" yesterday and worked. It is not the regression; the Az modules are.

## Change

`build/jobs/add-aad-test-environment.yml`:
- Pin `Az.Accounts` to 5.5.0 and `Az.KeyVault` to 6.5.0 (fixes conflict #1).
- After install, remove any `Az.Accounts` / `Az.KeyVault` versions higher than the pin from the module path, so `Register-SecretVault` can only resolve to the pinned 6.5.0 (fixes conflict #2).
- Keep Graph pinned at 2.38.0 (proven compatible with the 5.5.0 Az set).
- Version log lines use `Get-Module` (imported version) instead of `Get-Module -ListAvailable`.

`build/cleanup-aad-resources.yml` and `build/jobs/cleanup-aad.yml`:
- Graph-only scripts (they intentionally avoid Az). Graph pinned to 2.38.0 for consistency; they never hit either conflict.

## Verification

Both conflicts were reproduced and the fix confirmed locally before pushing (both Az version sets were installed to mirror the agent):
- Reproduced conflict #2: with 5.5.0 imported but 6.5.1 also present, the unqualified `Register-SecretVault` fails with "Assembly with same name is already loaded".
- Confirmed the fix: after removing the higher versions, the same `Register-SecretVault` call succeeds.
- Ran the full install -> remove-higher -> import -> Register-SecretVault sequence end to end: PASS.

Pipeline build 50321: `Setup AAD Test Environment` completed successfully.

Note: this pins to a known-good set and prunes newer builds, so the Az versions will need an occasional manual bump. That is the correct trade-off for CI - deterministic builds that do not break when a new module release ships.
