### PR TITLE
Restrict Device resources by compartment

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Expressions/SmartCompartmentSearchRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Expressions/SmartCompartmentSearchRewriterTests.cs
@@ -1,0 +1,177 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.ValueSets;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SmartCompartmentSearchRewriterTests
+    {
+        private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
+        private readonly ICompartmentDefinitionManager _compartmentDefinitionManager = Substitute.For<ICompartmentDefinitionManager>();
+        private readonly SearchParameterInfo _resourceTypeParam;
+        private readonly SearchParameterInfo _idParam;
+        private readonly SearchParameterInfo _devicePatientParam;
+
+        public SmartCompartmentSearchRewriterTests()
+        {
+            // CompartmentSearchExpression validates the compartment type against the process-wide
+            // ModelInfoProvider. Set it explicitly so these tests do not depend on some other test
+            // in the assembly having already initialized it with a compatible provider.
+            ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).Build());
+
+            _resourceTypeParam = new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceType, ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-type"));
+            _idParam = new SearchParameterInfo(SearchParameterNames.Id, SearchParameterNames.Id, ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
+            _devicePatientParam = new SearchParameterInfo("patient", "patient", ValueSets.SearchParamType.Reference, new Uri("http://hl7.org/fhir/SearchParameter/Device-patient"));
+
+            _searchParameterDefinitionManager.GetSearchParameter(KnownResourceTypes.Resource, SearchParameterNames.ResourceType).Returns(_resourceTypeParam);
+            _searchParameterDefinitionManager.GetSearchParameter(Arg.Any<string>(), SearchParameterNames.Id).Returns(_idParam);
+            _searchParameterDefinitionManager
+                .TryGetSearchParameter(KnownResourceTypes.Device, "patient", out Arg.Any<SearchParameterInfo>())
+                .Returns(x =>
+                {
+                    x[2] = _devicePatientParam;
+                    return true;
+                });
+
+            // Empty compartment membership: keeps the compartment leg trivial for these tests.
+            _compartmentDefinitionManager
+                .TryGetResourceTypes(Arg.Any<CompartmentType>(), out Arg.Any<HashSet<string>>())
+                .Returns(x =>
+                {
+                    x[1] = new HashSet<string>();
+                    return true;
+                });
+        }
+
+        private SmartCompartmentSearchRewriter CreateRewriter(bool flagEnabled, bool useSqlCompartmentRewriter = true)
+        {
+            var config = new CoreFeatureConfiguration { EnableSmartCompartmentDeviceRestriction = flagEnabled };
+            CompartmentSearchRewriter compartmentRewriter = useSqlCompartmentRewriter
+                ? new SqlCompartmentSearchRewriter(
+                    new Lazy<ICompartmentDefinitionManager>(() => _compartmentDefinitionManager),
+                    new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager))
+                : new CosmosCompartmentSearchRewriter(
+                    new Lazy<ICompartmentDefinitionManager>(() => _compartmentDefinitionManager),
+                    new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
+
+            return new SmartCompartmentSearchRewriter(
+                compartmentRewriter,
+                new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager),
+                Options.Create(config));
+        }
+
+        private UnionExpression Rewrite(SmartCompartmentSearchRewriter rewriter, string compartmentType = KnownResourceTypes.Patient)
+        {
+            var expression = Expression.SmartCompartmentSearch(compartmentType, "patient-A", new[] { KnownResourceTypes.DomainResource });
+            return Assert.IsType<UnionExpression>(expression.AcceptVisitor(rewriter));
+        }
+
+        private static InExpression<string> GetUniversalTypesExpression(UnionExpression union)
+        {
+            // The universal-types leg is a SearchParameterExpression over _type with an In expression.
+            return union.Expressions
+                .OfType<SearchParameterExpression>()
+                .Select(spe => spe.Expression)
+                .OfType<InExpression<string>>()
+                .Single();
+        }
+
+        [Fact]
+        public void GivenFlagEnabled_WhenPatientCompartment_ThenDeviceIsRestrictedNotUniversal()
+        {
+            UnionExpression union = Rewrite(CreateRewriter(flagEnabled: true));
+
+            Assert.DoesNotContain(KnownResourceTypes.Device, GetUniversalTypesExpression(union).Values);
+
+            // Leg B: devices without a patient reference.
+            NotReferencingExpression notReferencing = union.Expressions.OfType<NotReferencingExpression>().Single();
+            Assert.Equal(KnownResourceTypes.Device, notReferencing.SourceResourceType);
+            Assert.Same(_devicePatientParam, notReferencing.ReferenceSearchParameter);
+
+            // Leg A: devices whose patient reference is the compartment patient.
+            MultiaryExpression deviceLeg = union.Expressions
+                .OfType<MultiaryExpression>()
+                .Single(m => m.Expressions.OfType<SearchParameterExpression>().Any(spe => ReferenceEquals(spe.Parameter, _devicePatientParam)));
+            Assert.Contains(
+                deviceLeg.Expressions,
+                e => e is StringExpression se && se.FieldName == FieldName.ReferenceResourceId && se.Value == "patient-A");
+        }
+
+        [Fact]
+        public void GivenFlagEnabled_WhenNonPatientCompartment_ThenOnlyUnassignedDevicesLegAdded()
+        {
+            UnionExpression union = Rewrite(CreateRewriter(flagEnabled: true), compartmentType: KnownResourceTypes.Practitioner);
+
+            Assert.DoesNotContain(KnownResourceTypes.Device, GetUniversalTypesExpression(union).Values);
+            Assert.Single(union.Expressions.OfType<NotReferencingExpression>());
+
+            // No leg A for non-Patient compartments.
+            Assert.DoesNotContain(
+                union.Expressions.OfType<MultiaryExpression>(),
+                m => m.Expressions.OfType<SearchParameterExpression>().Any(spe => ReferenceEquals(spe.Parameter, _devicePatientParam)));
+        }
+
+        [Fact]
+        public void GivenFlagDisabled_WhenRewritten_ThenDeviceRemainsUniversal()
+        {
+            UnionExpression union = Rewrite(CreateRewriter(flagEnabled: false));
+
+            Assert.Contains(KnownResourceTypes.Device, GetUniversalTypesExpression(union).Values);
+            Assert.Empty(union.Expressions.OfType<NotReferencingExpression>());
+        }
+
+        [Fact]
+        public void GivenDevicePatientParamMissing_WhenRewritten_ThenDeviceRemainsUniversal()
+        {
+            // Simulates R5+, where Device has no patient search parameter.
+            _searchParameterDefinitionManager
+                .TryGetSearchParameter(KnownResourceTypes.Device, "patient", out Arg.Any<SearchParameterInfo>())
+                .Returns(false);
+
+            UnionExpression union = Rewrite(CreateRewriter(flagEnabled: true));
+
+            Assert.Contains(KnownResourceTypes.Device, GetUniversalTypesExpression(union).Values);
+            Assert.Empty(union.Expressions.OfType<NotReferencingExpression>());
+        }
+
+        [Fact]
+        public void GivenCosmosCompartmentRewriter_WhenRewritten_ThenDeviceRemainsUniversal()
+        {
+            UnionExpression union = Rewrite(CreateRewriter(flagEnabled: true, useSqlCompartmentRewriter: false));
+
+            Assert.Contains(KnownResourceTypes.Device, GetUniversalTypesExpression(union).Values);
+            Assert.Empty(union.Expressions.OfType<NotReferencingExpression>());
+        }
+
+        [Fact]
+        public void GivenFilteredResourceTypesWithoutDevice_WhenRewritten_ThenNoDeviceLegsAdded()
+        {
+            var rewriter = CreateRewriter(flagEnabled: true);
+            var expression = Expression.SmartCompartmentSearch(KnownResourceTypes.Patient, "patient-A", new[] { KnownResourceTypes.Observation });
+            var union = Assert.IsType<UnionExpression>(expression.AcceptVisitor(rewriter));
+
+            Assert.Empty(union.Expressions.OfType<NotReferencingExpression>());
+            Assert.DoesNotContain(
+                union.Expressions.OfType<MultiaryExpression>(),
+                m => m.Expressions.OfType<SearchParameterExpression>().Any(spe => ReferenceEquals(spe.Parameter, _devicePatientParam)));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -152,5 +152,13 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// When true, the resource is rejected with a validation error.
         /// </summary>
         public bool RejectDangerousNarrativeHrefs { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Device resources in a SMART compartment are restricted
+        /// to those without a patient reference, or (for Patient compartments) those whose patient reference
+        /// matches the compartment. When false, all Device resources are treated as universal resources.
+        /// Only effective when the Device resource type has a "patient" search parameter (STU3/R4/R4B).
+        /// </summary>
+        public bool EnableSmartCompartmentDeviceRestriction { get; set; } = true;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public virtual TOutput VisitNotReferenced(NotReferencedExpression expression, TContext context) => default;
 
+        public virtual TOutput VisitNotReferencing(NotReferencingExpression expression, TContext context) => default;
+
         private TOutput VisitExpressionsContainer(IExpressionsContainer expression, TContext context)
         {
             TOutput result = default;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -317,6 +317,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             return new SmartCompartmentSearchExpression(compartmentType, compartmentId, filteredResourceTypes);
         }
 
+        /// <summary>
+        /// Creates a <see cref="NotReferencingExpression"/> that matches resources of the given type
+        /// with no indexed value for the given reference search parameter.
+        /// </summary>
+        /// <param name="sourceResourceType">The resource type being filtered.</param>
+        /// <param name="referenceSearchParameter">The reference search parameter that must be absent.</param>
+        public static NotReferencingExpression NotReferencing(string sourceResourceType, SearchParameterInfo referenceSearchParameter)
+        {
+            return new NotReferencingExpression(sourceResourceType, referenceSearchParameter);
+        }
+
         public abstract TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context);
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
@@ -118,6 +118,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             return expression;
         }
 
+        public virtual Expression VisitNotReferencing(NotReferencingExpression expression, TContext context)
+        {
+            return expression;
+        }
+
         protected IReadOnlyList<TExpression> VisitArray<TExpression>(IReadOnlyList<TExpression> inputArray, TContext context)
             where TExpression : Expression
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IExpressionVisitor.cs
@@ -117,5 +117,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="expression">The expression to visit</param>
         /// <param name="context">The input</param>
         TOutput VisitNotReferenced(NotReferencedExpression expression, TContext context);
+
+        /// <summary>
+        /// Visits the <see cref="NotReferencingExpression"/>.
+        /// </summary>
+        /// <param name="expression">The expression to visit.</param>
+        /// <param name="context">The input.</param>
+        TOutput VisitNotReferencing(NotReferencingExpression expression, TContext context);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/NotReferencingExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/NotReferencingExpression.cs
@@ -1,0 +1,66 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
+{
+    /// <summary>
+    /// Matches resources of a given type that have no outgoing reference for a specific reference
+    /// search parameter (e.g. Device resources with no patient reference).
+    /// This is the outbound counterpart of <see cref="NotReferencedExpression"/>.
+    /// </summary>
+    public class NotReferencingExpression : Expression
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotReferencingExpression"/> class.
+        /// </summary>
+        /// <param name="sourceResourceType">The resource type being filtered (the reference source).</param>
+        /// <param name="referenceSearchParameter">The reference search parameter that must be absent.</param>
+        public NotReferencingExpression(string sourceResourceType, SearchParameterInfo referenceSearchParameter)
+        {
+            SourceResourceType = EnsureArg.IsNotNullOrEmpty(sourceResourceType, nameof(sourceResourceType));
+            ReferenceSearchParameter = EnsureArg.IsNotNull(referenceSearchParameter, nameof(referenceSearchParameter));
+        }
+
+        /// <summary>
+        /// Gets the resource type being filtered.
+        /// </summary>
+        public string SourceResourceType { get; }
+
+        /// <summary>
+        /// Gets the reference search parameter that must have no indexed values.
+        /// </summary>
+        public SearchParameterInfo ReferenceSearchParameter { get; }
+
+        public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
+        {
+            EnsureArg.IsNotNull(visitor, nameof(visitor));
+
+            return visitor.VisitNotReferencing(this, context);
+        }
+
+        public override string ToString()
+        {
+            return $"(NotReferencing {SourceResourceType}.{ReferenceSearchParameter.Code})";
+        }
+
+        public override void AddValueInsensitiveHashCode(ref HashCode hashCode)
+        {
+            hashCode.Add(typeof(NotReferencingExpression));
+            hashCode.Add(SourceResourceType, StringComparer.Ordinal);
+            hashCode.Add(ReferenceSearchParameter);
+        }
+
+        public override bool ValueInsensitiveEquals(Expression other)
+        {
+            return other is NotReferencingExpression notReferencing &&
+                string.Equals(notReferencing.SourceResourceType, SourceResourceType, StringComparison.Ordinal) &&
+                notReferencing.ReferenceSearchParameter.Equals(ReferenceSearchParameter);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchRewriter.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -17,13 +19,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
     /// </summary>
     public class SmartCompartmentSearchRewriter : ExpressionRewriterWithInitialContext<object>
     {
+        private const string DevicePatientSearchParameterCode = "patient";
+
         private readonly Lazy<ISearchParameterDefinitionManager> _searchParameterDefinitionManager;
         private readonly CompartmentSearchRewriter _compartmentSearchRewriter;
+        private readonly CoreFeatureConfiguration _coreFeatures;
 
-        public SmartCompartmentSearchRewriter(CompartmentSearchRewriter compartmentSearchRewriter, Lazy<ISearchParameterDefinitionManager> searchParameterDefinitionManager)
+        public SmartCompartmentSearchRewriter(
+            CompartmentSearchRewriter compartmentSearchRewriter,
+            Lazy<ISearchParameterDefinitionManager> searchParameterDefinitionManager,
+            IOptions<CoreFeatureConfiguration> coreFeatures)
         {
             _compartmentSearchRewriter = EnsureArg.IsNotNull(compartmentSearchRewriter, nameof(compartmentSearchRewriter));
             _searchParameterDefinitionManager = EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
+            _coreFeatures = EnsureArg.IsNotNull(coreFeatures?.Value, nameof(coreFeatures));
         }
 
         public override Expression VisitSmartCompartment(SmartCompartmentSearchExpression expression, object context)
@@ -53,6 +62,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             expressionForResourceItself.Add(Expression.SearchParameter(resourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, compartmentType, false)));
             expressionList.Add(Expression.And(expressionForResourceItself.ToArray()));
 
+            // Devices assigned to another patient (via Device.patient) must not leak into the compartment.
+            // When restriction applies, Device is removed from the universal list and replaced by two
+            // dedicated union legs below. The NotReferencingExpression is only supported by the SQL query
+            // generator, so this is gated on the SQL compartment rewriter (Cosmos DB support is retired).
+            SearchParameterInfo devicePatientSearchParameter = null;
+            bool restrictDevices = _coreFeatures.EnableSmartCompartmentDeviceRestriction &&
+                _compartmentSearchRewriter is SqlCompartmentSearchRewriter &&
+                _searchParameterDefinitionManager.Value.TryGetSearchParameter(KnownResourceTypes.Device, DevicePatientSearchParameterCode, out devicePatientSearchParameter);
+
             // Finally we add in the "universal" resources, which are resources that are not compartment specific
             var universalResourceTypes = new List<string>()
             {
@@ -60,11 +78,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 KnownResourceTypes.Organization,
                 KnownResourceTypes.Practitioner,
                 KnownResourceTypes.Medication,
-                KnownCompartmentTypes.Device,
             };
 
+            if (!restrictDevices)
+            {
+                universalResourceTypes.Add(KnownCompartmentTypes.Device);
+            }
+
             // In case FilteredResourceTypes is specified and not the default, we need to filter down the universalResourceTypes to only those specified
-            if (expression.FilteredResourceTypes.Any(resourceType => !string.Equals(resourceType, KnownResourceTypes.DomainResource, StringComparison.Ordinal)))
+            bool hasResourceTypeFilter = expression.FilteredResourceTypes.Any(resourceType => !string.Equals(resourceType, KnownResourceTypes.DomainResource, StringComparison.Ordinal));
+            if (hasResourceTypeFilter)
             {
                 universalResourceTypes = universalResourceTypes.Where(x => expression.FilteredResourceTypes.Contains(x)).ToList();
             }
@@ -79,6 +102,23 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 else
                 {
                     expressionList.Add(Expression.SearchParameter(resourceTypeSearchParameter, Expression.In(FieldName.TokenCode, null, universalResourceTypes)));
+                }
+            }
+
+            if (restrictDevices && (!hasResourceTypeFilter || expression.FilteredResourceTypes.Contains(KnownResourceTypes.Device, StringComparer.Ordinal)))
+            {
+                // Devices with no patient reference are visible in every smart compartment.
+                expressionList.Add(Expression.NotReferencing(KnownResourceTypes.Device, devicePatientSearchParameter));
+
+                if (string.Equals(compartmentType, KnownResourceTypes.Patient, StringComparison.Ordinal))
+                {
+                    // Devices assigned to this patient. Same shape as the compartment leg built by
+                    // SqlCompartmentSearchRewriter: an indexed seek on ReferenceSearchParam.
+                    var deviceTypeRestriction = Expression.SearchParameter(resourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.Device, false));
+                    expressionList.Add(Expression.And(
+                        Expression.SearchParameter(devicePatientSearchParameter, deviceTypeRestriction),
+                        Expression.StringEquals(FieldName.ReferenceResourceType, null, compartmentType, false),
+                        Expression.StringEquals(FieldName.ReferenceResourceId, null, compartmentId, false)));
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -403,6 +403,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
             throw new NotImplementedException(Resources.NotReferecedNotImplemented);
         }
 
+        public object VisitNotReferencing(NotReferencingExpression expression, Context context)
+        {
+            throw new NotImplementedException(Resources.NotReferecedNotImplemented);
+        }
+
         private static string GetFieldName(IFieldExpression fieldExpression, Context state)
         {
             string overrideValue = state.FieldNameOverride?.Invoke(fieldExpression.FieldName, fieldExpression.ComponentIndex);

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NotReferencingSqlGenerationTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NotReferencingSqlGenerationTests.cs
@@ -1,0 +1,56 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Schema;
+using Microsoft.Health.SqlServer.Features.Storage;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class NotReferencingSqlGenerationTests
+    {
+        [Fact]
+        public void GivenNotReferencingExpression_WhenVisited_ThenNotExistsSqlIsGenerated()
+        {
+            var model = Substitute.For<ISqlServerFhirModel>();
+            model.GetResourceTypeId("Device").Returns((short)99);
+            var patientParam = new SearchParameterInfo(
+                "patient",
+                "patient",
+                ValueSets.SearchParamType.Reference,
+                new System.Uri("http://hl7.org/fhir/SearchParameter/Device-patient"));
+            model.GetSearchParamId(patientParam.Url).Returns((short)123);
+
+            var stringBuilder = new IndentedStringBuilder(new StringBuilder());
+            using var sqlCommand = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(sqlCommand.Parameters));
+            var schemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max) { Current = SchemaVersionConstants.Max };
+            var context = new SearchParameterQueryGeneratorContext(stringBuilder, parameters, model, schemaInformation, isAsyncOperation: false, tableAlias: null);
+
+            var expression = new NotReferencingExpression("Device", patientParam);
+            expression.AcceptVisitor(NotReferencedQueryGenerator.Instance, context);
+
+            var sql = stringBuilder.ToString();
+            Assert.Contains("= 99", sql); // ResourceTypeId filter
+            Assert.Contains("NOT EXISTS", sql); // anti-join
+            Assert.Contains("SearchParamId = 123", sql);
+            Assert.Contains("RefResourceSurrogateId = ResourceSurrogateId", sql);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlServerSearchServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -93,7 +94,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                 new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
             var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(
                 compartmentSearchRewriter,
-                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
+                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager),
+                Options.Create(new CoreFeatureConfiguration()));
 
             _searchService = new SqlServerSearchService(
                 _searchOptionsFactory,
@@ -135,7 +137,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                 new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
             var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(
                 compartmentSearchRewriter,
-                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
+                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager),
+                Options.Create(new CoreFeatureConfiguration()));
 
             // Act & Assert
             var ex = Assert.Throws<ArgumentNullException>(() =>
@@ -183,7 +186,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                 new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
             var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(
                 compartmentSearchRewriter,
-                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
+                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager),
+                Options.Create(new CoreFeatureConfiguration()));
 
             // Act & Assert
             var ex = Assert.Throws<ArgumentNullException>(() =>
@@ -231,7 +235,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
                 new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
             var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(
                 compartmentSearchRewriter,
-                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager));
+                new Lazy<ISearchParameterDefinitionManager>(() => searchParameterDefinitionManager),
+                Options.Create(new CoreFeatureConfiguration()));
 
             // Act & Assert
             var ex = Assert.Throws<ArgumentNullException>(() =>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -169,6 +169,36 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             return base.VisitNotReferenced(expression, context);
         }
 
+        public override SearchParameterQueryGeneratorContext VisitNotReferencing(NotReferencingExpression expression, SearchParameterQueryGeneratorContext context)
+        {
+            short sourceResourceTypeId = context.Model.GetResourceTypeId(expression.SourceResourceType);
+            short referenceSearchParamId = context.Model.GetSearchParamId(expression.ReferenceSearchParameter.Url);
+
+            context.StringBuilder.AppendLine($"{VLatest.Resource.ResourceTypeId} = {sourceResourceTypeId}");
+            context.StringBuilder.AppendLine("AND NOT EXISTS ").AppendLine("(");
+            using (context.StringBuilder.Indent())
+            {
+                context.StringBuilder.AppendLine("SELECT *");
+                context.StringBuilder.Append($"FROM (SELECT RefResourceTypeId = {VLatest.ReferenceSearchParam.ResourceTypeId}, RefResourceSurrogateId = {VLatest.ReferenceSearchParam.ResourceSurrogateId}, {VLatest.ReferenceSearchParam.SearchParamId} FROM ").Append(VLatest.ReferenceSearchParam).AppendLine(") R");
+
+                using (var nestedDelimited = context.StringBuilder.BeginDelimitedWhereClause())
+                {
+                    nestedDelimited.BeginDelimitedElement();
+                    context.StringBuilder.Append($"RefResourceTypeId = {VLatest.Resource.ResourceTypeId}");
+
+                    nestedDelimited.BeginDelimitedElement();
+                    context.StringBuilder.Append($"RefResourceSurrogateId = {VLatest.Resource.ResourceSurrogateId}");
+
+                    nestedDelimited.BeginDelimitedElement();
+                    context.StringBuilder.Append($"{VLatest.ReferenceSearchParam.SearchParamId} = {referenceSearchParamId}");
+                }
+            }
+
+            context.StringBuilder.AppendLine(")");
+
+            return context;
+        }
+
         protected static SearchParameterQueryGenerator GetSearchParameterQueryGeneratorIfResourceColumnSearchParameter(SearchParameterExpressionBase searchParameter)
         {
             switch (searchParameter.Parameter.Code)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SearchParamTableExpressionQueryGeneratorFactory.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SearchParamTableExpressionQueryGeneratorFactory.cs
@@ -202,6 +202,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             return NotReferencedQueryGenerator.Instance;
         }
 
+        public SearchParamTableExpressionQueryGenerator VisitNotReferencing(NotReferencingExpression expression, object context)
+        {
+            // NotReferencedQueryGenerator's Table is dbo.Resource, which is what we want:
+            // the union CTE selects from Resource and filters with a NOT EXISTS anti-join.
+            return NotReferencedQueryGenerator.Instance;
+        }
+
         private SearchParamTableExpressionQueryGenerator VisitExpressionsContainer(IExpressionsContainer expression, object context)
         {
             foreach (var childExpression in expression.Expressions)

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/SmartPatientA.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/SmartPatientA.json
@@ -1248,6 +1248,23 @@
                 "method": "PUT",
                 "url": "Claim/smart-claim-A1"
             }
+        },
+        {
+            "resource": {
+                "resourceType": "Device",
+                "id": "smart-device-A1",
+                "identifier": [{
+                    "system": "http://goodcare.org/devices/id",
+                    "value": "345677"
+                }],
+                "patient": {
+                    "reference": "Patient/smart-patient-A"
+                }
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Device/smart-device-A1"
+            }
         }
     ]
 }	

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/SmartPatientB.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/SmartPatientB.json
@@ -542,6 +542,23 @@
         },
         {
             "resource": {
+                "resourceType": "Device",
+                "id": "smart-device-B2",
+                "identifier": [{
+                    "system": "http://goodcare.org/devices/id",
+                    "value": "345678"
+                }],
+                "patient": {
+                    "reference": "Patient/smart-patient-B"
+                }
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Device/smart-device-B2"
+            }
+        },
+        {
+            "resource": {
 			  "resourceType": "DeviceRequest",
 			  "id": "smart-devicerequest-B1",
 			  "text": {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -823,6 +823,45 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        public async Task GivenFhirUserClaimPatient_WhenSearchingDevicesWithPatientMissingModifier_ThenOnlyUnassignedDevicesReturned()
+        {
+            // Regression guard for the :missing modifier coexisting with the Device restriction. A real
+            // patient:missing=true expression is rewritten by MissingSearchParamVisitor into a NotExists table
+            // expression, while the SMART compartment union in the same query contains the look-alike
+            // NotReferencingExpression (leg B). The visitor's Scout must NOT mistake leg B for a :missing
+            // expression and corrupt the compartment union - if it did, results would be wrong or the query
+            // would fail to generate.
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var scopeRestriction = new ScopeRestriction("all", Core.Features.Security.DataActions.Read, "patient");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
+
+            var query = new List<Tuple<string, string>>();
+            query.Add(new Tuple<string, string>("patient:missing", "true"));
+            query.Add(new Tuple<string, string>("_count", "100"));
+
+            var results = await _searchService.Value.SearchAsync("Device", query, CancellationToken.None);
+
+            // Unassigned device: no patient reference, so it matches patient:missing=true and passes leg B.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-B1");
+
+            // Device assigned to this patient: has a patient reference, so patient:missing=true excludes it.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-A1");
+
+            // Device assigned to a different patient: excluded by both the modifier and the restriction.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-B2");
+
+            // Every returned Device must have no patient reference (modifier honored across the union).
+            Assert.All(results.Results, r => Assert.Equal(KnownResourceTypes.Device, r.Resource.ResourceTypeName));
+        }
+
+        [SkippableFact]
         public async Task GivenSmartV2GranularDeviceScopeWithSearchParameter_WhenSearchingDevices_ThenOnlyOwnAndUnassignedDevicesReturned()
         {
             // Exercises the SMART v2 granular-scope union path (AppendSmartNewSetOfUnionAllTableExpressions)
@@ -858,6 +897,46 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
 
             // Device assigned to a different patient: hidden by the restriction even though the scope permits it.
             Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-B2");
+        }
+
+        [SkippableFact]
+        public async Task GivenSmartV2GranularPatientScopeOnName_WhenSearchingWithAddressMissingModifier_ThenModifierAndScopeAreBothHonored()
+        {
+            // Generic double-check: a :missing modifier on one optional property (address, which
+            // smart-patient-A lacks) combined with a SMART v2 granular scope on a DIFFERENT property
+            // (name). This exercises MissingSearchParamVisitor (address:missing -> NotExists) coexisting
+            // with the smart v2 scope union (AppendSmartNewSetOfUnionAllTableExpressions) and the
+            // compartment union - all ANDed together - independent of the Device restriction.
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var scopeRestriction = new ScopeRestriction(
+                "Patient",
+                Core.Features.Security.DataActions.Search,
+                "patient",
+                CreateSearchParams(("name", "SMARTGivenName1")));
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction }, true);
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
+
+            // smart-patient-A has no address, so address:missing=true matches, and its name matches the scope.
+            var missingTrueQuery = new List<Tuple<string, string>>
+            {
+                new Tuple<string, string>("address:missing", "true"),
+            };
+            var missingTrueResults = await _searchService.Value.SearchAsync("Patient", missingTrueQuery, CancellationToken.None);
+            Assert.Contains(missingTrueResults.Results, r => r.Resource.ResourceId == "smart-patient-A");
+
+            // Inverse: address:missing=false must not match smart-patient-A (it has no address).
+            var missingFalseQuery = new List<Tuple<string, string>>
+            {
+                new Tuple<string, string>("address:missing", "false"),
+            };
+            var missingFalseResults = await _searchService.Value.SearchAsync("Patient", missingFalseQuery, CancellationToken.None);
+            Assert.DoesNotContain(missingFalseResults.Results, r => r.Resource.ResourceId == "smart-patient-A");
         }
 
         [SkippableFact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -725,7 +725,63 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Location);
             Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Practitioner);
             Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Device);
-            Assert.Equal(39, results.Results.Count());
+            Assert.Equal(40, results.Results.Count());
+        }
+
+        [SkippableFact]
+        public async Task GivenFhirUserClaimPatient_WhenDevicesRequested_ThenOnlyOwnAndUnassignedDevicesReturned()
+        {
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var query = new List<Tuple<string, string>>();
+            query.Add(new Tuple<string, string>("_count", "100"));
+
+            var scopeRestriction = new ScopeRestriction("all", Core.Features.Security.DataActions.Read, "patient");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
+
+            var results = await _searchService.Value.SearchAsync("Device", query, CancellationToken.None);
+
+            // Device assigned to this patient: visible.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-A1");
+
+            // Device with no patient reference: visible (universal).
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-B1");
+
+            // Device assigned to a different patient: hidden.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-B2");
+        }
+
+        [SkippableFact]
+        public async Task GivenFhirUserClaimPractitioner_WhenDevicesRequested_ThenOnlyUnassignedDevicesReturned()
+        {
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var query = new List<Tuple<string, string>>();
+            query.Add(new Tuple<string, string>("_count", "100"));
+
+            var scopeRestriction = new ScopeRestriction("all", Core.Features.Security.DataActions.Read, "user");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-practitioner-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Practitioner";
+
+            var results = await _searchService.Value.SearchAsync("Device", query, CancellationToken.None);
+
+            // Devices with no patient reference remain visible in any compartment.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-B1");
+
+            // Devices assigned to any patient are hidden in non-Patient compartments.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-A1");
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-B2");
         }
 
         [SkippableFact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -785,6 +785,82 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        public async Task GivenFhirUserClaimPatient_WhenRevIncludingAllResourcesAndADeviceReferencesThePatient_ThenTheAssignedDeviceIsRevIncluded()
+        {
+            // Regression guard for the SMART Device restriction interacting with _revinclude.
+            // A Device assigned to the compartment patient must still surface as a rev-included
+            // resource (leg A must ADMIT it, not filter it out), while a Device assigned to a
+            // different patient must never appear.
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var scopeRestriction = new ScopeRestriction("all", Core.Features.Security.DataActions.Read, "patient");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
+
+            var query = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>("_revinclude", "*:*"),
+                new Tuple<string, string>("_id", "smart-patient-A"),
+                new Tuple<string, string>("_count", "100"),
+            };
+
+            var results = await _searchService.Value.SearchAsync("Patient", query, CancellationToken.None);
+
+            // The compartment patient is the match result.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-patient-A" && r.Resource.ResourceTypeName == KnownResourceTypes.Patient);
+
+            // A Device assigned to this patient references the patient, so it must be rev-included
+            // and must not be dropped by the Device restriction.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-A1" && r.Resource.ResourceTypeName == KnownResourceTypes.Device);
+
+            // A Device assigned to a different patient must never leak in.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-B2");
+        }
+
+        [SkippableFact]
+        public async Task GivenSmartV2GranularDeviceScopeWithSearchParameter_WhenSearchingDevices_ThenOnlyOwnAndUnassignedDevicesReturned()
+        {
+            // Exercises the SMART v2 granular-scope union path (AppendSmartNewSetOfUnionAllTableExpressions)
+            // coexisting with the Device restriction legs in the compartment union. The granular scope permits
+            // all three seed devices by identifier, so smart-device-B2 being hidden is attributable solely to
+            // the Device restriction (not the scope filter) - and both leg A (own device) and leg B (unassigned
+            // device) must still return their devices while the smart v2 scope union is joined into the query.
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var scopeRestriction = new ScopeRestriction(
+                "Device",
+                Core.Features.Security.DataActions.Search,
+                "patient",
+                CreateSearchParams(("identifier", "http://goodcare.org/devices/id|345677,http://goodcare.org/devices/id|345675,http://goodcare.org/devices/id|345678")));
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction }, true);
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
+
+            var query = new List<Tuple<string, string>>();
+            query.Add(new Tuple<string, string>("_count", "100"));
+
+            var results = await _searchService.Value.SearchAsync("Device", query, CancellationToken.None);
+
+            // Device assigned to this patient: visible (leg A) and permitted by the scope.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-A1");
+
+            // Device with no patient reference: visible (leg B) and permitted by the scope.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-B1");
+
+            // Device assigned to a different patient: hidden by the restriction even though the scope permits it.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-B2");
+        }
+
+        [SkippableFact]
         public async Task GivenFhirUserClaimPatient_WhenAllPractitionersRequested_PractitionersReturned()
         {
             Skip.If(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -703,6 +703,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenFhirUserClaimPatient_WhenAllResourcesRequested_UniversalResourcesAlsoReturned()
         {
             Skip.If(
@@ -729,6 +730,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenFhirUserClaimPatient_WhenDevicesRequested_ThenOnlyOwnAndUnassignedDevicesReturned()
         {
             Skip.If(
@@ -758,6 +760,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenFhirUserClaimPatient_WhenIncludingDevicePatient_ThenOtherPatientDemographicsAreNotLeaked()
         {
             // Security regression guard for the reported Device compartment bypass. The attack was:
@@ -804,6 +807,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenFhirUserClaimPractitioner_WhenDevicesRequested_ThenOnlyUnassignedDevicesReturned()
         {
             Skip.If(
@@ -908,6 +912,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenSmartV2GranularDeviceScopeWithSearchParameter_WhenSearchingDevices_ThenOnlyOwnAndUnassignedDevicesReturned()
         {
             // Exercises the SMART v2 granular-scope union path (AppendSmartNewSetOfUnionAllTableExpressions)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -758,6 +758,52 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        public async Task GivenFhirUserClaimPatient_WhenIncludingDevicePatient_ThenOtherPatientDemographicsAreNotLeaked()
+        {
+            // Security regression guard for the reported Device compartment bypass. The attack was:
+            // GET /Device?_include=Device:patient with a Patient A SMART token. Because a Device assigned
+            // to Patient B (smart-device-B2) leaked into the Device match set, _include=Device:patient
+            // followed its Device.patient reference and amplified the leak to Patient B's demographics.
+            // With the restriction, smart-device-B2 is excluded from the match set, so its patient
+            // reference is never followed and Patient B is never included.
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var scopeRestriction = new ScopeRestriction("all", Core.Features.Security.DataActions.Read, "patient");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
+
+            var query = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>("_include", "Device:patient"),
+                new Tuple<string, string>("_count", "100"),
+            };
+
+            var results = await _searchService.Value.SearchAsync("Device", query, CancellationToken.None);
+
+            // Device assigned to this patient: still a match, and its patient reference resolves to
+            // the compartment patient.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-A1" && r.Resource.ResourceTypeName == KnownResourceTypes.Device);
+
+            // Device with no patient reference: still a match (universal), nothing to include.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-device-B1" && r.Resource.ResourceTypeName == KnownResourceTypes.Device);
+
+            // Device assigned to a different patient must never be a match, so it can never be used to
+            // pivot into another patient's data through _include.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-device-B2");
+
+            // The compartment patient may be included via the own device's patient reference.
+            Assert.Contains(results.Results, r => r.Resource.ResourceId == "smart-patient-A" && r.Resource.ResourceTypeName == KnownResourceTypes.Patient);
+
+            // The other patient's demographics must NOT leak in through _include=Device:patient.
+            Assert.DoesNotContain(results.Results, r => r.Resource.ResourceId == "smart-patient-B");
+        }
+
+        [SkippableFact]
         public async Task GivenFhirUserClaimPractitioner_WhenDevicesRequested_ThenOnlyUnassignedDevicesReturned()
         {
             Skip.If(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var compartmentDefinitionManager = new CompartmentDefinitionManager(ModelInfoProvider.Instance);
             await compartmentDefinitionManager.StartAsync(CancellationToken.None);
             var compartmentSearchRewriter = new CosmosCompartmentSearchRewriter(new Lazy<ICompartmentDefinitionManager>(() => compartmentDefinitionManager), new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
-            var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(compartmentSearchRewriter, new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
+            var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(compartmentSearchRewriter, new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager), Options.Create(new CoreFeatureConfiguration()));
 
             ICosmosDbCollectionPhysicalPartitionInfo cosmosDbPhysicalPartitionInfo = Substitute.For<ICosmosDbCollectionPhysicalPartitionInfo>();
             cosmosDbPhysicalPartitionInfo.PhysicalPartitionCount.Returns(1);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var compartmentDefinitionManager = new CompartmentDefinitionManager(ModelInfoProvider.Instance);
             compartmentDefinitionManager.StartAsync(CancellationToken.None).Wait();
             var compartmentSearchRewriter = new SqlCompartmentSearchRewriter(new Lazy<ICompartmentDefinitionManager>(() => compartmentDefinitionManager), new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
-            var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(compartmentSearchRewriter, new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
+            var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(compartmentSearchRewriter, new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager), Options.Create(new CoreFeatureConfiguration()));
 
             _fhirSqlConfiguration = new FhirSqlServerConfiguration();
             var queryPlanReuseChecker = new QueryPlanReuseChecker(SqlRetryService, _fhirSqlConfiguration, NullLogger<QueryPlanReuseChecker>.Instance);


### PR DESCRIPTION
## Description
We have an issue where Device resources could potentially leak identifiers across compartments.  This change restricts Devices that reference the specific patient compartment, or do not have any patient reference

## Related issues
Addresses [issue [AB#196778](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/196778)].

## Testing
Manual testsing, and additional unit and integration tests.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
