### PR TITLE
Parallel bulk update ignores_lastUpdated filter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJobTests.cs
@@ -851,12 +851,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkUpdate
         [InlineData("eb2026-07-06")]
         public async Task GivenBulkUpdateJob_WhenLastUpdatedFilterIsGivenAndIsParallelIsTrue_ThenProcessingJobsUseCtPathNotSurrogateIdRanges(string lastUpdatedValue)
         {
-            // Regression test: _lastUpdated was previously in allowedParams, which caused the orchestrator to
-            // take the fast surrogateId-scan path. The stored proc (dbo.GetResourcesByTypeAndSurrogateIdRange)
-            // ignores all search parameters and uses only the surrogate-id bounds, so the date filter was
-            // silently dropped and ALL resources were updated instead of only the filtered subset.
-            // After removing _lastUpdated from allowedParams, the orchestrator correctly falls through to
-            // the continuation-token (CT) path which uses the full search expression including the date filter.
             _queueClient.ClearReceivedCalls();
             _searchService.ClearReceivedCalls();
 

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJobTests.cs
@@ -898,7 +898,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkUpdate
             // The _lastUpdated filter must be forwarded to the processing job so the SQL layer applies it
             Assert.Contains(actualDefinition.SearchParameters, p =>
                 p.Item1.Equals(KnownQueryParameterNames.LastUpdated, StringComparison.OrdinalIgnoreCase)
-                && p.Item2.Contains(lastUpdatedValue.Substring(2)));
+                && string.Equals(p.Item2, lastUpdatedValue, StringComparison.OrdinalIgnoreCase));
         }
 
         public static IEnumerable<object[]> GetAllowedSearchParameters()

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJobTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkUpdate
 
             var searchParams = new List<Tuple<string, string>>()
             {
-                new Tuple<string, string>("_lastUpdated", "value"),
+                new Tuple<string, string>(KnownQueryParameterNames.MaxCount, "100"),
             };
 
             var resourceTypes = new HashSet<string> { "Patient", "Observation" };
@@ -842,6 +842,71 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkUpdate
             await Assert.ThrowsAsync<JsonReaderException>(async () => await _orchestratorJob.ExecuteAsync(jobInfo, CancellationToken.None));
         }
 
+        [Theory]
+        [InlineData("gt2026-07-06")]
+        [InlineData("ge2026-07-06")]
+        [InlineData("lt2026-07-06")]
+        [InlineData("le2026-07-06")]
+        [InlineData("sa2026-07-06")]
+        [InlineData("eb2026-07-06")]
+        public async Task GivenBulkUpdateJob_WhenLastUpdatedFilterIsGivenAndIsParallelIsTrue_ThenProcessingJobsUseCtPathNotSurrogateIdRanges(string lastUpdatedValue)
+        {
+            // Regression test: _lastUpdated was previously in allowedParams, which caused the orchestrator to
+            // take the fast surrogateId-scan path. The stored proc (dbo.GetResourcesByTypeAndSurrogateIdRange)
+            // ignores all search parameters and uses only the surrogate-id bounds, so the date filter was
+            // silently dropped and ALL resources were updated instead of only the filtered subset.
+            // After removing _lastUpdated from allowedParams, the orchestrator correctly falls through to
+            // the continuation-token (CT) path which uses the full search expression including the date filter.
+            _queueClient.ClearReceivedCalls();
+            _searchService.ClearReceivedCalls();
+
+            _searchService
+                .SearchAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<Tuple<string, string>>>(), Arg.Any<CancellationToken>(), Arg.Any<bool>(), Arg.Any<ResourceVersionType>(), Arg.Any<bool>(), Arg.Any<bool>())
+                .Returns(_ => Task.FromResult(GenerateSearchResult(2, null)));
+
+            var searchParams = new List<Tuple<string, string>>
+            {
+                new Tuple<string, string>(KnownQueryParameterNames.LastUpdated, lastUpdatedValue),
+            };
+
+            var definition = new BulkUpdateDefinition(JobType.BulkUpdateOrchestrator, "Patient", searchParams, "test", "test", "test", null, isParallel: true);
+            var jobInfo = new JobInfo()
+            {
+                GroupId = 1,
+                Definition = JsonConvert.SerializeObject(definition),
+                CreateDate = DateTime.UtcNow,
+            };
+
+            await _orchestratorJob.ExecuteAsync(jobInfo, CancellationToken.None);
+
+            // CT path: SearchAsync is called, GetUsedResourceTypes is NOT called (that is the surrogateId path)
+            await _searchService.DidNotReceiveWithAnyArgs().GetUsedResourceTypes(Arg.Any<CancellationToken>());
+            await _searchService.Received(1).SearchAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<Tuple<string, string>>>(), Arg.Any<CancellationToken>(), Arg.Any<bool>(), Arg.Any<ResourceVersionType>(), Arg.Any<bool>(), Arg.Any<bool>());
+
+            // Exactly one processing job queued
+            await _queueClient.ReceivedWithAnyArgs(1).EnqueueAsync(Arg.Any<byte>(), Arg.Any<string[]>(), Arg.Any<long?>(), false, Arg.Any<CancellationToken>());
+
+            var calls = _queueClient.ReceivedCalls()
+                .Where(call => call.GetMethodInfo().Name == nameof(IQueueClient.EnqueueAsync))
+                .ToList();
+            var definitions = calls
+                .Select(call => (string[])call.GetArguments()[1])
+                .SelectMany(defs => defs)
+                .ToArray();
+
+            Assert.Single(definitions);
+            var actualDefinition = JsonConvert.DeserializeObject<BulkUpdateDefinition>(definitions[0]);
+
+            // Processing job must NOT have surrogate-id range bounds (proves CT path was taken)
+            Assert.Null(actualDefinition.StartSurrogateId);
+            Assert.Null(actualDefinition.EndSurrogateId);
+
+            // The _lastUpdated filter must be forwarded to the processing job so the SQL layer applies it
+            Assert.Contains(actualDefinition.SearchParameters, p =>
+                p.Item1.Equals(KnownQueryParameterNames.LastUpdated, StringComparison.OrdinalIgnoreCase)
+                && p.Item2.Contains(lastUpdatedValue.Substring(2)));
+        }
+
         public static IEnumerable<object[]> GetAllowedSearchParameters()
         {
             yield return new object[]
@@ -852,31 +917,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkUpdate
             {
                 new List<Tuple<string, string>>
                 {
-                    new Tuple<string, string>("_lastUpdated", "value"),
-                },
-            };
-            yield return new object[]
-            {
-                new List<Tuple<string, string>>
-                {
                     new Tuple<string, string>("_maxCount", "value"),
-                },
-            };
-            yield return new object[]
-            {
-                new List<Tuple<string, string>>
-                {
-                    new Tuple<string, string>("_lastUpdated", "value"),
-                    new Tuple<string, string>("_maxCount", "value"),
-                },
-            };
-            yield return new object[]
-            {
-                new List<Tuple<string, string>>
-                {
-                    new Tuple<string, string>("_lastUpdated", "value1"),
-                    new Tuple<string, string>("_lastUpdated", "value2"),
-                    new Tuple<string, string>("_lastUpdated", "value3"),
                 },
             };
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJob.cs
@@ -91,7 +91,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkUpdate
                     // Collect allowed parameter names (case-insensitive)
                     var allowedParams = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                     {
-                        KnownQueryParameterNames.LastUpdated,
                         KnownQueryParameterNames.MaxCount,
                     };
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkUpdate/BulkUpdateOrchestratorJob.cs
@@ -174,9 +174,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkUpdate
 
                     var searchParams = definition.SearchParameters?.ToList() ?? new List<Tuple<string, string>>();
 
-                    var createDate = new PartialDateTime(new DateTimeOffset(jobInfo.CreateDate, TimeSpan.Zero));
-                    searchParams.Add(Tuple.Create(KnownQueryParameterNames.LastUpdated, $"lt{createDate}"));
-
                     searchParams.Add(Tuple.Create(KnownQueryParameterNames.Count, definition.MaximumNumberOfResourcesPerQuery.ToString(CultureInfo.InvariantCulture)));
                     if (!string.IsNullOrEmpty(lastEnqueuedMaxContinuationToken))
                     {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
@@ -716,6 +716,83 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
+        [SkippableTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        public async Task GivenBulkUpdateWithLastUpdatedFilter_WhenCompleted_ThenOnlyResourcesCreatedAfterCutoffAreUpdated(bool isParallel)
+        {
+            // Regression test for: _lastUpdated was in allowedParams, causing the orchestrator to take
+            // the fast surrogateId-scan path which silently drops the date filter and updates ALL resources.
+            // Repro: customer ran PATCH /Patient/$bulk-update?_lastUpdated=gt{date} and all 271 patients
+            // were updated instead of only the ~80 created after the cutoff date.
+            CheckBulkUpdateEnabled();
+
+            var tag = Guid.NewGuid().ToString();
+
+            // Step 1: Create 2 "early" patients that should NOT be touched by the bulk update
+            await CreatePatients(tag, 2);
+
+            // Capture a timestamp strictly after the early patients are committed.
+            // The 1-second buffers ensure early patients have lastUpdated < cutoff
+            // and late patients have lastUpdated > cutoff.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+            var cutoff = DateTimeOffset.UtcNow;
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // Step 2: Create 3 "late" patients that SHOULD be updated
+            await CreatePatients(tag, 3);
+
+            // Sanity check: confirm the _lastUpdated filter returns exactly 3 resources
+            var cutoffStr = cutoff.UtcDateTime.ToString("s") + "Z"; // e.g. 2026-07-08T12:30:00Z
+            var countResult = await _fhirClient.SearchAsync(
+                ResourceType.Patient,
+                $"_tag={tag}&_lastUpdated=gt{cutoffStr}&_summary=count");
+            Assert.Equal(3, countResult.Resource.Total);
+
+            // Step 3: Run bulk update scoped to the tag AND the _lastUpdated cutoff.
+            // Before the fix this would have updated all 5 patients; after the fix only 3 should be updated.
+            var patchRequest = new Parameters()
+                .AddAddPatchParameter("Patient", "active", new FhirBoolean(true));
+            ChangeTypeToUpsertPatchParameter(patchRequest);
+
+            var queryParam = new Dictionary<string, string>
+            {
+                { "_lastUpdated", $"gt{cutoffStr}" },
+                { "_isParallel", isParallel.ToString() },
+            };
+
+            using HttpResponseMessage response = await SendBulkUpdateRequest(tag, patchRequest, "Patient/$bulk-update", queryParam);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+            // Expect exactly 3 updated — the 2 early patients must NOT appear here
+            BulkUpdateResult expectedResults = new BulkUpdateResult();
+            expectedResults.ResourcesUpdated.Add("Patient", 3);
+            await MonitorBulkUpdateJob(response.Content.Headers.ContentLocation, expectedResults);
+
+            // Step 4: Verify the 3 late patients now have active=true
+            var latePatients = await _fhirClient.SearchAsync(
+                ResourceType.Patient,
+                $"_tag={tag}&_lastUpdated=gt{cutoffStr}");
+            Assert.Equal(3, latePatients.Resource.Entry.Count);
+            foreach (var entry in latePatients.Resource.Entry)
+            {
+                var patient = (Patient)entry.Resource;
+                Assert.True(patient.Active == true, $"Patient {patient.Id} (late) should have active=true after bulk update.");
+            }
+
+            // Step 5: Verify the 2 early patients were NOT updated (active still null/not-set)
+            var earlyPatients = await _fhirClient.SearchAsync(
+                ResourceType.Patient,
+                $"_tag={tag}&_lastUpdated=le{cutoffStr}");
+            Assert.Equal(2, earlyPatients.Resource.Entry.Count);
+            foreach (var entry in earlyPatients.Resource.Entry)
+            {
+                var patient = (Patient)entry.Resource;
+                Assert.True(patient.Active != true, $"Patient {patient.Id} (early) should NOT have been updated by the bulk update.");
+            }
+        }
+
         private async Task RunBulkUpdateRequest(
             Parameters patchRequest,
             BulkUpdateResult expectedResults,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
@@ -722,10 +722,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenBulkUpdateWithLastUpdatedFilter_WhenCompleted_ThenOnlyResourcesCreatedAfterCutoffAreUpdated(bool isParallel)
         {
-            // Regression test for: _lastUpdated was in allowedParams, causing the orchestrator to take
-            // the fast surrogateId-scan path which silently drops the date filter and updates ALL resources.
-            // Repro: customer ran PATCH /Patient/$bulk-update?_lastUpdated=gt{date} and all 271 patients
-            // were updated instead of only the ~80 created after the cutoff date.
             CheckBulkUpdateEnabled();
 
             var tag = Guid.NewGuid().ToString();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
@@ -740,7 +740,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await CreatePatients(tag, 3);
 
             // Sanity check: confirm the _lastUpdated filter returns exactly 3 resources
-            var cutoffStr = cutoff.UtcDateTime.ToString("s") + "Z"; // e.g. 2026-07-08T12:30:00Z
+            var cutoffStr = cutoff.UtcDateTime.ToString("o"); // e.g. 2026-07-08T12:30:00.0000000Z
             var countResult = await _fhirClient.SearchAsync(
                 ResourceType.Patient,
                 $"_tag={tag}&_lastUpdated=gt{cutoffStr}&_summary=count");


### PR DESCRIPTION
## Description
When `PATCH /{resourceType}/$bulk-update` was called with `_lastUpdated` as
the only search parameter (e.g. `_lastUpdated=gt2026-07-06`), the operation
updated **all** resources instead of only the filtered subset.

**Root cause:** `_lastUpdated` was included in `allowedParams` in
`BulkUpdateOrchestratorJob.ExecuteAsync`. This caused `noOtherSearchParameters`
to evaluate as `true`, sending the job down the fast surrogateId-scan path.
The stored procedure `dbo.GetResourcesByTypeAndSurrogateIdRange` accepts only
surrogate-id range bounds and ignores all other search parameters — so the
`_lastUpdated` filter was silently dropped and every resource of that type
was updated.

## Related issues
Addresses [[AB197545](https://microsofthealth.visualstudio.com/Health/_workitems/edit/197545)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
