### PR TITLE
Prevent traffic before storage initialization

### DIFF
--- a/docs/superpowers/plans/2026-07-13-fhir-separate-health-probes.md
+++ b/docs/superpowers/plans/2026-07-13-fhir-separate-health-probes.md
@@ -1,0 +1,1076 @@
+# Separate Kubernetes Health Probes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the FHIR server's single `/health/check` endpoint into four probe-specific endpoints (`/health/check`, `/health/startup`, `/health/ready`, `/health/live`) so Kubernetes stops routing traffic to pods before storage is initialized, without crash-looping pods on persistent (e.g. CMK) failures.
+
+**Architecture:** Health checks declare probe membership via tags (`probe:startup`, `probe:readiness`, plus the shared package's existing `datastore:sqlServer`). Four routes are mapped in `FhirServerApplicationBuilderExtensions.UseFhirServer`, each filtered by a tag predicate with an explicit HTTP status map. `StorageInitializedHealthCheck` becomes a pure Healthy/Unhealthy startup gate (no CMK/Key Vault call). No `healthcare-shared-components` change is required.
+
+**Tech Stack:** .NET / ASP.NET Core health checks (`Microsoft.Extensions.Diagnostics.HealthChecks`), MediatR notifications, xUnit + NSubstitute, `Microsoft.Extensions.Time.Testing.FakeTimeProvider` + the repo's `Clock`/`ClockResolver` abstraction.
+
+**Source spec:** `docs/superpowers/specs/2026-07-13-fhir-separate-health-probes-design.md`
+
+---
+
+## File Structure
+
+**New files**
+- `src/Microsoft.Health.Fhir.Api/Features/Health/HealthCheckTags.cs` — tag string constants.
+- `src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheckState.cs` — immutable state record for the behavior check.
+- `src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckRegistrationTests.cs` — registration/assertion tests.
+- `src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckEndpointTests.cs` — endpoint routing/status tests (TestServer).
+
+**Modified files**
+- `src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheckConfiguration.cs` — remove `StartupDegradedDelay`.
+- `src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs` — pure gate; drop CMK + constructor validation; `volatile`.
+- `src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs` — thread-safe immutable-state swap.
+- `src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs` — 3 new route constants.
+- `src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs` — 4 routes, shared response writer, startup assertion.
+- `src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs` — add tags to Behavior + Storage checks.
+- `src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs` — tag Cosmos data-store check.
+- `src/Microsoft.Health.Fhir.Shared.Web/Startup.cs` — bind config with `.Validate().ValidateOnStart()`.
+- `src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs` — rewrite for pure gate.
+- `src/Microsoft.Health.Fhir.Api.UnitTests/Features/Health/ImproperBehaviorHealthCheckTests.cs` — add concurrency test.
+
+---
+
+## Task 1: Tag constants
+
+**Files:**
+- Create: `src/Microsoft.Health.Fhir.Api/Features/Health/HealthCheckTags.cs`
+
+- [ ] **Step 1: Create the constants file**
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// Health-check tag constants used to select which checks each Kubernetes probe runs.
+    /// A tag typo silently fails open (an empty selection resolves to Healthy => HTTP 200),
+    /// so every registration and predicate MUST reference these constants rather than literals.
+    /// </summary>
+    public static class HealthCheckTags
+    {
+        /// <summary>Tag for the startup gate check (<see cref="StorageInitializedHealthCheck"/>).</summary>
+        public const string ProbeStartup = "probe:startup";
+
+        /// <summary>Tag for checks that participate in the readiness/routing decision.</summary>
+        public const string ProbeReadiness = "probe:readiness";
+
+        /// <summary>
+        /// Mirrors the tag applied by the healthcare-shared-components SQL registration.
+        /// A startup assertion fails loudly if the shared value ever drifts from this literal.
+        /// </summary>
+        public const string DataStoreSqlServer = "datastore:sqlServer";
+    }
+}
+```
+
+- [ ] **Step 2: Build the Api project**
+
+Run: `dotnet build src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj -clp:ErrorsOnly`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Api/Features/Health/HealthCheckTags.cs
+git commit -m "feat(health): add HealthCheckTags constants"
+```
+
+---
+
+## Task 2: Route constants
+
+**Files:**
+- Modify: `src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs:80`
+
+- [ ] **Step 1: Add the three route constants**
+
+Locate this line (currently line 80):
+
+```csharp
+        public const string HealthCheck = "/health/check";
+```
+
+Replace it with:
+
+```csharp
+        public const string HealthCheck = "/health/check";
+        public const string HealthCheckStartup = "/health/startup";
+        public const string HealthCheckReady = "/health/ready";
+        public const string HealthCheckLive = "/health/live";
+```
+
+- [ ] **Step 2: Build the Core project**
+
+Run: `dotnet build src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj -clp:ErrorsOnly`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs
+git commit -m "feat(health): add startup/ready/live route constants"
+```
+
+---
+
+## Task 3: Simplify the configuration
+
+**Files:**
+- Modify: `src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheckConfiguration.cs`
+
+- [ ] **Step 1: Replace the file contents**
+
+The `StartupDegradedDelay` knob is removed (the gate no longer has a Degraded tier). Replace the whole file with:
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// Configures the startup health-check gate.
+    /// </summary>
+    public class StorageInitializedHealthCheckConfiguration
+    {
+        /// <summary>
+        /// The configuration section name.
+        /// </summary>
+        public const string SectionName = "HealthChecks:StorageInitialization";
+
+        /// <summary>
+        /// Gets or sets the absolute backstop after which the startup gate hands off to
+        /// readiness (returns Healthy) regardless of initialization state. Must satisfy the
+        /// invariant: legit-init-p99 &lt; StorageInitializationTimeout &lt; k8s-startup-budget.
+        /// </summary>
+        public TimeSpan StorageInitializationTimeout { get; set; } = TimeSpan.FromMinutes(5);
+    }
+}
+```
+
+- [ ] **Step 2: Do not build yet**
+
+This intentionally breaks `StorageInitializedHealthCheck` (still references `StartupDegradedDelay`) and its tests. Those are fixed in Task 4. Proceed directly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheckConfiguration.cs
+git commit -m "refactor(health): remove StartupDegradedDelay from storage-init config"
+```
+
+---
+
+## Task 4: Rewrite `StorageInitializedHealthCheck` as a pure gate (TDD)
+
+**Files:**
+- Test: `src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs`
+- Modify: `src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs`
+
+- [ ] **Step 1: Rewrite the failing tests**
+
+Replace the entire contents of `StorageInitializedHealthCheckTests.cs` with the pure-gate tests below. The check no longer takes `IDatabaseStatusReporter`, no longer validates in its constructor, and never returns `Degraded`.
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Messages.Search;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.Features.Health;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.DataSourceValidation)]
+public class StorageInitializedHealthCheckTests
+{
+    [Fact]
+    public async Task GivenStorageInitialized_WhenCheckHealthAsync_ThenReturnsHealthy()
+    {
+        StorageInitializedHealthCheck sut = CreateSut();
+
+        await sut.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+
+        HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task GivenNotInitialized_WhenCheckHealthAsyncBeforeTimeout_ThenReturnsUnhealthy()
+    {
+        StorageInitializedHealthCheck sut = CreateSut();
+
+        HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("Storage is initializing", result.Description);
+    }
+
+    [Fact]
+    public async Task GivenNotInitializedAndTimeoutElapsed_WhenCheckHealthAsync_ThenReturnsHealthyBackstop()
+    {
+        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.UtcNow);
+        using (Mock.Property(() => ClockResolver.TimeProvider, timeProvider))
+        {
+            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(1));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(2));
+
+            HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+    }
+
+    [Fact]
+    public async Task GivenNotInitializedAtExactBoundary_WhenCheckHealthAsync_ThenReturnsHealthyBackstop()
+    {
+        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.UtcNow);
+        using (Mock.Property(() => ClockResolver.TimeProvider, timeProvider))
+        {
+            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(2));
+
+            HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+    }
+
+    [Fact]
+    public async Task GivenConcurrentNotificationAndProbes_WhenCheckHealthAsync_ThenHandoffIsObserved()
+    {
+        StorageInitializedHealthCheck sut = CreateSut();
+        using var cts = new CancellationTokenSource();
+
+        Task reader = Task.Run(async () =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+            }
+        });
+
+        await sut.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+        HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+        cts.Cancel();
+        await reader;
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public void GivenDefaultConfiguration_ThenStorageInitializationTimeoutMatchesDocumentedInvariant()
+    {
+        // Guards the K8s-budget invariant: the documented app timeout is 5 minutes.
+        // If this default changes, the fhir-paas startup budget must be re-checked (must stay strictly greater).
+        Assert.Equal(TimeSpan.FromMinutes(5), new StorageInitializedHealthCheckConfiguration().StorageInitializationTimeout);
+    }
+
+    private static StorageInitializedHealthCheck CreateSut(TimeSpan? storageInitializationTimeout = null)
+    {
+        return new StorageInitializedHealthCheck(
+            Options.Create(
+                new StorageInitializedHealthCheckConfiguration
+                {
+                    StorageInitializationTimeout = storageInitializationTimeout ?? TimeSpan.FromMinutes(5),
+                }));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile / fail**
+
+Run: `dotnet test src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.csproj --filter FullyQualifiedName~StorageInitializedHealthCheckTests`
+Expected: Build FAIL — `StorageInitializedHealthCheck` constructor still requires `IDatabaseStatusReporter` and references removed members.
+
+- [ ] **Step 3: Rewrite the health check as a pure gate**
+
+Replace the entire contents of `StorageInitializedHealthCheck.cs` with:
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Core;
+using Microsoft.Health.Fhir.Core.Messages.Search;
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// Pure startup gate. Returns Healthy once storage initialization completes or the configured
+    /// timeout backstop elapses (hand off to readiness); otherwise Unhealthy. It makes no CMK /
+    /// Key Vault call — CMK routability is handled by the readiness data-store check.
+    /// </summary>
+    public class StorageInitializedHealthCheck : IHealthCheck, INotificationHandler<SearchParametersInitializedNotification>
+    {
+        private readonly StorageInitializedHealthCheckConfiguration _configuration;
+        private readonly DateTimeOffset _started = Clock.UtcNow;
+        private volatile bool _storageReady;
+
+        private const string SuccessfullyInitializedMessage = "Successfully initialized.";
+
+        public StorageInitializedHealthCheck(IOptions<StorageInitializedHealthCheckConfiguration> configuration)
+        {
+            _configuration = EnsureArg.IsNotNull(configuration, nameof(configuration)).Value;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            if (_storageReady)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy(SuccessfullyInitializedMessage));
+            }
+
+            TimeSpan waited = Clock.UtcNow - _started;
+            if (waited >= _configuration.StorageInitializationTimeout)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy(
+                    $"Startup timeout elapsed after {(int)waited.TotalSeconds}s; handing off to readiness."));
+            }
+
+            return Task.FromResult(new HealthCheckResult(
+                HealthStatus.Unhealthy,
+                $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
+        }
+
+        public Task Handle(SearchParametersInitializedNotification notification, CancellationToken cancellationToken)
+        {
+            _storageReady = true;
+            return Task.CompletedTask;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.csproj --filter FullyQualifiedName~StorageInitializedHealthCheckTests`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs
+git commit -m "refactor(health): make StorageInitializedHealthCheck a pure startup gate"
+```
+
+---
+
+## Task 5: Bind config with `ValidateOnStart`
+
+**Files:**
+- Modify: `src/Microsoft.Health.Fhir.Shared.Web/Startup.cs:84-85`
+
+- [ ] **Step 1: Replace the `Configure` call with a validated options binding**
+
+Find (lines 84-85):
+
+```csharp
+            services.Configure<StorageInitializedHealthCheckConfiguration>(
+                Configuration.GetSection(StorageInitializedHealthCheckConfiguration.SectionName));
+```
+
+Replace with:
+
+```csharp
+            services.AddOptions<StorageInitializedHealthCheckConfiguration>()
+                .Bind(Configuration.GetSection(StorageInitializedHealthCheckConfiguration.SectionName))
+                .Validate(
+                    c => c.StorageInitializationTimeout >= TimeSpan.Zero,
+                    $"{nameof(StorageInitializedHealthCheckConfiguration.StorageInitializationTimeout)} must be non-negative.")
+                .ValidateOnStart();
+```
+
+- [ ] **Step 2: Verify `System` and options usings exist**
+
+Run: `rg -n "using System;|using Microsoft.Extensions.DependencyInjection;" src/Microsoft.Health.Fhir.Shared.Web/Startup.cs`
+Expected: both present. `AddOptions`/`Bind`/`Validate`/`ValidateOnStart` live in `Microsoft.Extensions.DependencyInjection` (already imported). If `using System;` is missing, add it.
+
+- [ ] **Step 3: Build the Web project**
+
+Run: `dotnet build src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.csproj -clp:ErrorsOnly`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+git commit -m "feat(health): validate storage-init config on start"
+```
+
+---
+
+## Task 6: Thread-safe `ImproperBehaviorHealthCheck` (TDD)
+
+**Files:**
+- Create: `src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheckState.cs`
+- Modify: `src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs`
+- Test: `src/Microsoft.Health.Fhir.Api.UnitTests/Features/Health/ImproperBehaviorHealthCheckTests.cs`
+
+- [ ] **Step 1: Add the failing concurrency test**
+
+Append this test to the existing `ImproperBehaviorHealthCheckTests` class (after the existing `[Theory]` method, before the closing brace of the class). It asserts the `(isHealthy, message)` pair is always observed consistently — an unhealthy result must always carry the notification message.
+
+```csharp
+        [Fact]
+        public async Task GivenConcurrentNotificationsAndProbes_WhenCheckingHealth_ThenStateIsConsistent()
+        {
+            using var cts = new System.Threading.CancellationTokenSource();
+
+            Task reader = Task.Run(async () =>
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    HealthCheckResult result = await _healthCheck.CheckHealthAsync(null, CancellationToken.None);
+                    if (result.Status == HealthStatus.Unhealthy)
+                    {
+                        // An unhealthy result must always carry the appended message (no torn read).
+                        Assert.Contains("boom", result.Description);
+                    }
+                }
+            });
+
+            await _healthCheck.Handle(new ImproperBehaviorNotification("boom"), CancellationToken.None);
+            cts.Cancel();
+            await reader;
+
+            HealthCheckResult final = await _healthCheck.CheckHealthAsync(null, CancellationToken.None);
+            Assert.Equal(HealthStatus.Unhealthy, final.Status);
+            Assert.Contains("boom", final.Description);
+        }
+```
+
+- [ ] **Step 2: Run the test to confirm it compiles and passes against current code (baseline)**
+
+Run: `dotnet test src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.Api.UnitTests.csproj --filter FullyQualifiedName~ImproperBehaviorHealthCheckTests`
+Expected: PASS (the race is timing-dependent and may pass even against the unsynced code). This test documents the invariant; the refactor below makes it hold deterministically. Proceed regardless of baseline result.
+
+- [ ] **Step 3: Create the immutable state record**
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// Immutable snapshot of the improper-behavior health state so the health flag and its
+    /// accompanying message are always published together atomically.
+    /// </summary>
+    internal sealed record ImproperBehaviorHealthCheckState(bool IsHealthy, string Message)
+    {
+        public static readonly ImproperBehaviorHealthCheckState Healthy = new(true, string.Empty);
+    }
+}
+```
+
+- [ ] **Step 4: Replace `ImproperBehaviorHealthCheck.cs` with a lock-guarded immutable swap**
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Health.Fhir.Core.Features.Health;
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    public class ImproperBehaviorHealthCheck : IHealthCheck, INotificationHandler<ImproperBehaviorNotification>
+    {
+        private readonly object _lock = new();
+        private volatile ImproperBehaviorHealthCheckState _state = ImproperBehaviorHealthCheckState.Healthy;
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            ImproperBehaviorHealthCheckState state = _state;
+            if (state.IsHealthy)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy());
+            }
+
+            return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, "Improper server behavior has been detected." + state.Message));
+        }
+
+        public Task Handle(ImproperBehaviorNotification notification, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                _state = new ImproperBehaviorHealthCheckState(false, _state.Message + " " + notification.Message);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the behavior tests to verify they pass**
+
+Run: `dotnet test src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.Api.UnitTests.csproj --filter FullyQualifiedName~ImproperBehaviorHealthCheckTests`
+Expected: PASS (existing theory + new concurrency test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheckState.cs src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs src/Microsoft.Health.Fhir.Api.UnitTests/Features/Health/ImproperBehaviorHealthCheckTests.cs
+git commit -m "fix(health): make ImproperBehaviorHealthCheck state publication atomic"
+```
+
+---
+
+## Task 7: Apply probe tags at registration
+
+**Files:**
+- Modify: `src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs:196` and `:206`
+- Modify: `src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs:316-317`
+
+- [ ] **Step 1: Tag the Behavior and Storage checks in `FhirModule.cs`**
+
+Confirm the file has `using Microsoft.Health.Fhir.Api.Features.Health;` (the checks live there). If missing, add it with the other usings.
+
+Find (line 196):
+
+```csharp
+            services.AddHealthChecks().AddCheck<ImproperBehaviorHealthCheck>(name: "BehaviorHealthCheck");
+```
+
+Replace with:
+
+```csharp
+            services.AddHealthChecks().AddCheck<ImproperBehaviorHealthCheck>(
+                name: "BehaviorHealthCheck",
+                tags: new[] { HealthCheckTags.ProbeReadiness });
+```
+
+Find (line 206):
+
+```csharp
+            services.AddHealthChecks().AddCheck<StorageInitializedHealthCheck>(name: "StorageInitializedHealthCheck");
+```
+
+Replace with:
+
+```csharp
+            services.AddHealthChecks().AddCheck<StorageInitializedHealthCheck>(
+                name: "StorageInitializedHealthCheck",
+                tags: new[] { HealthCheckTags.ProbeStartup });
+```
+
+- [ ] **Step 2: Tag the Cosmos data-store check**
+
+In `FhirServerBuilderCosmosDbRegistrationExtensions.cs`, confirm `using Microsoft.Health.Fhir.Api.Features.Health;` is present (add if missing). Find (lines 316-317):
+
+```csharp
+            fhirServerBuilder.Services.AddHealthChecks()
+                .AddCheck<CosmosDbHealthCheck>(name: "DataStoreHealthCheck");
+```
+
+Replace with:
+
+```csharp
+            fhirServerBuilder.Services.AddHealthChecks()
+                .AddCheck<CosmosDbHealthCheck>(
+                    name: "DataStoreHealthCheck",
+                    tags: new[] { HealthCheckTags.ProbeReadiness });
+```
+
+- [ ] **Step 3: Build the touched projects**
+
+Run: `dotnet build src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.csproj -clp:ErrorsOnly` and `dotnet build src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj -clp:ErrorsOnly`
+Expected: Build succeeded for both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+git commit -m "feat(health): tag health checks for startup/readiness probes"
+```
+
+---
+
+## Task 8: Map four endpoints + shared response writer + startup assertion
+
+**Files:**
+- Modify: `src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs`
+
+- [ ] **Step 1: Replace the `UseFhirServer` body and add helpers**
+
+Replace the whole `UseFhirServer` method (lines 34-89) plus add the two private helpers below. This: (a) validates registrations at startup, (b) maps the four routes each with a tag predicate and explicit status map, (c) extracts the JSON writer.
+
+Replace the method (from `public static IApplicationBuilder UseFhirServer(` through its closing `return app; }`) with:
+
+```csharp
+        public static IApplicationBuilder UseFhirServer(
+            this IApplicationBuilder app,
+            Func<IApplicationBuilder, IApplicationBuilder> useDevelopmentIdentityProvider = null,
+            Func<IApplicationBuilder, IApplicationBuilder> useHttpLoggingMiddleware = null,
+            Func<HealthCheckRegistration, bool> healthCheckOptionsPredicate = null,
+            Func<IEndpointRouteBuilder, IEndpointRouteBuilder> mapAdditionalEndpoints = null)
+        {
+            EnsureArg.IsNotNull(app, nameof(app));
+
+            var config = app.ApplicationServices.GetRequiredService<IOptions<FhirServerConfiguration>>();
+            var pathBase = config.Value.PathBase?.TrimEnd('/');
+            if (!string.IsNullOrWhiteSpace(pathBase))
+            {
+                var pathString = new PathString(pathBase);
+                app.UseMiddleware<PathBaseMiddleware>(pathString);
+            }
+
+            ValidateHealthCheckRegistrations(app.ApplicationServices);
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+
+            app.UseRouting();
+            useDevelopmentIdentityProvider?.Invoke(app);
+            useHttpLoggingMiddleware?.Invoke(app);
+
+            app.UseEndpoints(
+                endpoints =>
+                {
+                    endpoints.MapControllers();
+
+                    // Diagnostic endpoint: everything except the startup gate. Degraded => 200.
+                    endpoints.MapHealthChecks(
+                        new PathString(KnownRoutes.HealthCheck),
+                        new HealthCheckOptions
+                        {
+                            Predicate = reg => (healthCheckOptionsPredicate?.Invoke(reg) ?? true)
+                                && !reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                            ResponseWriter = WriteHealthReportAsync,
+                        });
+
+                    // Startup gate: only the storage-init check. Unhealthy => 503 while initializing.
+                    endpoints.MapHealthChecks(
+                        new PathString(KnownRoutes.HealthCheckStartup),
+                        new HealthCheckOptions
+                        {
+                            Predicate = reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                            ResponseWriter = WriteHealthReportAsync,
+                        });
+
+                    // Readiness/routing: data-store + behavior. Degraded (e.g. CMK) => 200 stays routable.
+                    endpoints.MapHealthChecks(
+                        new PathString(KnownRoutes.HealthCheckReady),
+                        new HealthCheckOptions
+                        {
+                            Predicate = reg => reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer)
+                                || reg.Tags.Contains(HealthCheckTags.ProbeReadiness),
+                            ResponseWriter = WriteHealthReportAsync,
+                        });
+
+                    // Dependency-free HTTP liveness: run no checks => empty report => Healthy => 200.
+                    endpoints.MapHealthChecks(
+                        new PathString(KnownRoutes.HealthCheckLive),
+                        new HealthCheckOptions
+                        {
+                            Predicate = _ => false,
+                            ResponseWriter = WriteHealthReportAsync,
+                        });
+
+                    mapAdditionalEndpoints?.Invoke(endpoints);
+                });
+
+            return app;
+        }
+
+        private static async Task WriteHealthReportAsync(HttpContext httpContext, HealthReport healthReport)
+        {
+            var response = JsonConvert.SerializeObject(
+                new
+                {
+                    overallStatus = healthReport.Status.ToString(),
+                    details = healthReport.Entries.Select(entry => new
+                    {
+                        name = entry.Key,
+                        status = Enum.GetName<HealthStatus>(entry.Value.Status),
+                        description = entry.Value.Description,
+                        data = entry.Value.Data,
+                    }),
+                });
+            httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+            await httpContext.Response.WriteAsync(response).ConfigureAwait(false);
+        }
+
+        private static void ValidateHealthCheckRegistrations(IServiceProvider services)
+        {
+            var options = services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+            bool ReadinessPredicate(HealthCheckRegistration reg) =>
+                reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+
+            int dataStoreCount = options.Registrations.Count(
+                reg => ReadinessPredicate(reg) && string.Equals(reg.Name, "DataStoreHealthCheck", StringComparison.Ordinal));
+            if (dataStoreCount != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Readiness probe must resolve exactly one 'DataStoreHealthCheck' registration but resolved {dataStoreCount}. " +
+                    "This usually indicates a health-check tag typo or a healthcare-shared-components tag rename/package skew.");
+            }
+
+            int startupCount = options.Registrations.Count(reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup));
+            if (startupCount != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Startup probe must resolve exactly one registration but resolved {startupCount}.");
+            }
+        }
+```
+
+- [ ] **Step 2: Add required usings and the `HealthCheckTags` import**
+
+At the top of the file confirm/add:
+- `using System.Collections.Generic;` (may already be transitively fine; add if the build complains)
+- `using Microsoft.Extensions.Diagnostics.HealthChecks;` (already present)
+- `using Microsoft.Health.Fhir.Api.Features.Health;` (NEW — for `HealthCheckTags`)
+
+`HealthCheckServiceOptions` lives in `Microsoft.Extensions.Diagnostics.HealthChecks` (already imported). `HealthReport`/`HealthStatus` are in the same namespace.
+
+- [ ] **Step 3: Build the Api project**
+
+Run: `dotnet build src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj -clp:ErrorsOnly`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+git commit -m "feat(health): map startup/ready/live endpoints with tag predicates and startup assertion"
+```
+
+---
+
+## Task 9: Registration & assertion tests
+
+**Files:**
+- Create: `src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckRegistrationTests.cs`
+
+These tests exercise the exact readiness/startup predicates against `HealthCheckServiceOptions.Registrations` (the same source of truth `ValidateHealthCheckRegistrations` reads) to catch tag drift.
+
+- [ ] **Step 1: Write the tests**
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Api.Features.Health;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Registration;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.Web)]
+public class HealthCheckRegistrationTests
+{
+    private sealed class StubCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(HealthCheckResult.Healthy());
+    }
+
+    private static bool Readiness(HealthCheckRegistration reg) =>
+        reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+
+    [Fact]
+    public void GivenSqlDataStoreTag_WhenResolvingReadiness_ThenExactlyOneDataStoreCheck()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddCheck<StubCheck>("DataStoreHealthCheck", tags: new[] { HealthCheckTags.DataStoreSqlServer })
+            .AddCheck<StubCheck>("BehaviorHealthCheck", tags: new[] { HealthCheckTags.ProbeReadiness })
+            .AddCheck<StubCheck>("StorageInitializedHealthCheck", tags: new[] { HealthCheckTags.ProbeStartup });
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        int dataStoreCount = options.Registrations.Count(r => Readiness(r) && r.Name == "DataStoreHealthCheck");
+        Assert.Equal(1, dataStoreCount);
+        Assert.Equal(1, options.Registrations.Count(r => r.Tags.Contains(HealthCheckTags.ProbeStartup)));
+    }
+
+    [Fact]
+    public void GivenCosmosReadinessTag_WhenResolvingReadiness_ThenExactlyOneDataStoreCheck()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddCheck<StubCheck>("DataStoreHealthCheck", tags: new[] { HealthCheckTags.ProbeReadiness })
+            .AddCheck<StubCheck>("BehaviorHealthCheck", tags: new[] { HealthCheckTags.ProbeReadiness })
+            .AddCheck<StubCheck>("StorageInitializedHealthCheck", tags: new[] { HealthCheckTags.ProbeStartup });
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Equal(1, options.Registrations.Count(r => Readiness(r) && r.Name == "DataStoreHealthCheck"));
+    }
+
+    [Fact]
+    public void GivenMissingDataStoreTag_WhenResolvingReadiness_ThenZeroDataStoreChecks()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddCheck<StubCheck>("DataStoreHealthCheck") // no tag => package-skew simulation
+            .AddCheck<StubCheck>("StorageInitializedHealthCheck", tags: new[] { HealthCheckTags.ProbeStartup });
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Equal(0, options.Registrations.Count(r => Readiness(r) && r.Name == "DataStoreHealthCheck"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `dotnet test src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.csproj --filter FullyQualifiedName~HealthCheckRegistrationTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckRegistrationTests.cs
+git commit -m "test(health): registration tag-resolution tests for readiness/startup"
+```
+
+---
+
+## Task 10: Endpoint routing/status tests (TestServer)
+
+**Files:**
+- Create: `src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckEndpointTests.cs`
+
+These build a minimal ASP.NET Core pipeline (`WebHostBuilder` + `TestServer`) that maps the four routes using the same predicates as `UseFhirServer`, registers stub checks, and asserts HTTP codes. This validates the routing/predicate/default-status-map behavior end-to-end without booting the full FHIR server.
+
+- [ ] **Step 1: Write the endpoint tests**
+
+```csharp
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Health.Fhir.Api.Features.Health;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Registration;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.Web)]
+public class HealthCheckEndpointTests
+{
+    private sealed class FixedCheck : IHealthCheck
+    {
+        private readonly HealthStatus _status;
+
+        public FixedCheck(HealthStatus status) => _status = status;
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(new HealthCheckResult(_status));
+    }
+
+    private static TestServer BuildServer(HealthStatus startupStatus, HealthStatus dataStoreStatus)
+    {
+        var builder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddRouting();
+                services.AddHealthChecks()
+                    .AddCheck("StorageInitializedHealthCheck", new FixedCheck(startupStatus), tags: new[] { HealthCheckTags.ProbeStartup })
+                    .AddCheck("DataStoreHealthCheck", new FixedCheck(dataStoreStatus), tags: new[] { HealthCheckTags.ProbeReadiness })
+                    .AddCheck("BehaviorHealthCheck", new FixedCheck(HealthStatus.Healthy), tags: new[] { HealthCheckTags.ProbeReadiness });
+            })
+            .Configure(app =>
+            {
+                app.UseRouting();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapHealthChecks("/health/check", new HealthCheckOptions
+                    {
+                        Predicate = reg => !reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                    });
+                    endpoints.MapHealthChecks("/health/startup", new HealthCheckOptions
+                    {
+                        Predicate = reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                    });
+                    endpoints.MapHealthChecks("/health/ready", new HealthCheckOptions
+                    {
+                        Predicate = reg => reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer)
+                            || reg.Tags.Contains(HealthCheckTags.ProbeReadiness),
+                    });
+                    endpoints.MapHealthChecks("/health/live", new HealthCheckOptions
+                    {
+                        Predicate = _ => false,
+                    });
+                });
+            });
+
+        return new TestServer(builder);
+    }
+
+    [Fact]
+    public async Task GivenInitializingStartup_WhenGettingStartup_Then503()
+    {
+        using TestServer server = BuildServer(HealthStatus.Unhealthy, HealthStatus.Healthy);
+        HttpResponseMessage response = await server.CreateClient().GetAsync("/health/startup");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenInitializedStartup_WhenGettingStartup_Then200()
+    {
+        using TestServer server = BuildServer(HealthStatus.Healthy, HealthStatus.Healthy);
+        HttpResponseMessage response = await server.CreateClient().GetAsync("/health/startup");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenDegradedDataStore_WhenGettingReady_Then200()
+    {
+        using TestServer server = BuildServer(HealthStatus.Healthy, HealthStatus.Degraded);
+        HttpResponseMessage response = await server.CreateClient().GetAsync("/health/ready");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenUnhealthyDataStore_WhenGettingReady_Then503()
+    {
+        using TestServer server = BuildServer(HealthStatus.Healthy, HealthStatus.Unhealthy);
+        HttpResponseMessage response = await server.CreateClient().GetAsync("/health/ready");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenAnyState_WhenGettingLive_Then200()
+    {
+        using TestServer server = BuildServer(HealthStatus.Unhealthy, HealthStatus.Unhealthy);
+        HttpResponseMessage response = await server.CreateClient().GetAsync("/health/live");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenInitializingStartup_WhenGettingCheck_ThenStartupGateExcluded_And200()
+    {
+        // /health/check excludes probe:startup, so an initializing pod with a reachable DB is 200.
+        using TestServer server = BuildServer(HealthStatus.Unhealthy, HealthStatus.Healthy);
+        HttpResponseMessage response = await server.CreateClient().GetAsync("/health/check");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}
+```
+
+- [ ] **Step 2: Verify the test project can host a TestServer**
+
+Run: `rg -n "TestHost|Mvc.Testing|Microsoft.AspNetCore.App" src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.csproj`
+Expected: a `FrameworkReference Include="Microsoft.AspNetCore.App"` and a `Microsoft.AspNetCore.TestHost` (or `Mvc.Testing`) reference. If missing: add `<FrameworkReference Include="Microsoft.AspNetCore.App" />` and `<PackageReference Include="Microsoft.AspNetCore.TestHost" />` (version from `Directory.Packages.props`; check with `rg -n "AspNetCore.TestHost" Directory.Packages.props`). If `TestHost` is not pinned anywhere in the repo, DELETE this endpoint-test file and rely on Task 9's predicate tests — note the endpoint-level assertions are then covered by the fhir-paas E2E suite. Do not add a brand-new external dependency without confirming it is already used in the repo.
+
+- [ ] **Step 3: Run the endpoint tests**
+
+Run: `dotnet test src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.csproj --filter FullyQualifiedName~HealthCheckEndpointTests`
+Expected: PASS (6 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckEndpointTests.cs
+git commit -m "test(health): endpoint routing and status-map tests for four probes"
+```
+
+---
+
+## Task 11: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the whole affected solution graph**
+
+Run: `dotnet build src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.csproj -clp:ErrorsOnly`
+Expected: Build succeeded (transitively builds Api, Core, Shared.Api, CosmosDb, SqlServer).
+
+- [ ] **Step 2: Run the two health-check test projects in full**
+
+Run: `dotnet test src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.csproj --filter "FullyQualifiedName~Health"`
+Then: `dotnet test src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.Api.UnitTests.csproj --filter "FullyQualifiedName~Health"`
+Expected: PASS across `StorageInitializedHealthCheckTests`, `ImproperBehaviorHealthCheckTests`, `HealthCheckRegistrationTests`, `HealthCheckEndpointTests`.
+
+- [ ] **Step 3: Grep for stale references to the removed knob / dropped dependency**
+
+Run: `rg -n "StartupDegradedDelay" src`
+Expected: zero hits (the config knob is fully removed).
+Run: `rg -n "IDatabaseStatusReporter" src/Microsoft.Health.Fhir.Api/Features/Health`
+Expected: zero hits (the CMK dependency is removed from the startup gate; it may still exist elsewhere).
+
+- [ ] **Step 4: Confirm all four routes are wired**
+
+Run: `rg -n "HealthCheck(Startup|Ready|Live)?\b" src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs`
+Expected: four constants defined; four `MapHealthChecks` calls.
+
+- [ ] **Step 5: Final commit if any residual fixes were needed**
+
+```bash
+git add -A
+git commit -m "chore(health): finalize separate-probe verification" || echo "nothing to commit"
+```
+
+---
+
+## Post-Plan Notes (out of scope for this plan)
+
+- **fhir-paas companion (REQUIRED, separate subsession):** three distinct `ExecAction`s pointing at `/health/startup`, `/health/ready`, `/health/live`; suspended-account + private-link allowlists widened to all four health paths; ingress suspension rule widened; startup budget raised above the 5-minute app timeout (`failureThreshold × periodSeconds` > `StorageInitializationTimeout` + margin, e.g. `6×7 × 10s ≈ 7:00`). Suspended pods crash-loop until the middleware allowlists accept the new probes, so this must ship atomically. See spec "Deferred" section.
+- **K8s budget invariant:** `legit-init-p99 (≈5m) < StorageInitializationTimeout (5m) < k8s-startup-budget`. fhir-server keeps the app timeout at 5 minutes; the K8s budget bump lives in fhir-paas and cannot be enforced from this repo.

--- a/docs/superpowers/specs/2026-07-13-fhir-separate-health-probes-design.md
+++ b/docs/superpowers/specs/2026-07-13-fhir-separate-health-probes-design.md
@@ -1,0 +1,211 @@
+# Separate Kubernetes Health Probes for the FHIR Server
+
+- **Date:** 2026-07-13
+- **Status:** Approved design (pre-implementation)
+- **Repos in scope:** `microsoft/fhir-server`, `microsoft/healthcare-shared-components`
+- **Deferred (separate subsession):** `fhir-paas` probe configuration
+- **Supersedes:** the two-tier `StorageInitializedHealthCheck` logic committed in PR #5669
+
+## Problem
+
+The FHIR server exposes a single health endpoint, `/health/check`, that every
+Kubernetes probe (startup, readiness, liveness) targets. ASP.NET Core maps a
+`Degraded` health result to HTTP 200 by default, so during startup the pod is
+marked ready and receives client traffic before storage initialization
+completes. Work item AB#197936 captured the resulting window of HTTP 503
+responses to real requests.
+
+PR #5669 mitigated this by turning `/health/check` into a two-tier state machine
+(Unhealthy for the first minute, Degraded until a five-minute timeout, then a
+CMK-aware result). That change overloads a single diagnostic endpoint with probe
+semantics, and it cannot satisfy two conflicting requirements at once:
+
+1. The pod must **not** accept traffic until storage is initialized.
+2. The pod must **not** crash-loop when a failure is persistent — most
+   importantly a customer-managed key (CMK) problem, where the pod must stay
+   routable so clients receive their HTTP 403 `OperationOutcome` rather than
+   being pulled from rotation.
+
+A single endpoint cannot express "don't route yet" and "stay alive / stay
+routable" independently. The fix is to split the probes.
+
+## Goals
+
+- Separate startup, readiness, and liveness concerns into distinct endpoints,
+  each with its own set of checks and HTTP status mapping.
+- Prevent traffic before initialization completes (startup gate).
+- Never crash-loop the pod on a persistent failure (CMK or DB inaccessible):
+  startup completes and hands off to readiness instead of failing forever.
+- Keep CMK-failed pods routable so customers receive their 403 `OperationOutcome`.
+- Keep `/health/check` unchanged as the existing diagnostic endpoint.
+- Revert PR #5669's Degraded-tier logic; move steady-state CMK/Degraded routing
+  to the data-store check on the readiness route.
+
+## Non-Goals
+
+- Changing `fhir-paas` probe configuration. That is a documented companion
+  change handled in a later subsession once this work merges upstream.
+- Introducing health-check response caching for the new endpoints.
+- Altering CMK detection semantics in the data-store checks themselves.
+
+## Design Overview
+
+Four routes are mapped in
+`FhirServerApplicationBuilderExtensions.UseFhirServer`, each filtered by a
+health-check **tag** and given an explicit `ResultStatusCodes` map. Check-to-probe
+membership is declared at registration time via tags, following the existing
+`datastore:sqlServer` tag convention already present in
+healthcare-shared-components.
+
+### Endpoints
+
+| Route | Checks (tag predicate) | HTTP mapping | Purpose |
+|---|---|---|---|
+| `/health/check` | all checks (existing caller predicate) | Healthy/Degraded → 200, Unhealthy → 503 | Existing diagnostic endpoint — unchanged |
+| `/health/startup` | `probe:startup` → `StorageInitializedHealthCheck` only | Healthy → 200, Degraded → 503, Unhealthy → 503 | Gate: 503 while initializing; 200 once init done or terminal failure/backstop |
+| `/health/ready` | `probe:readiness` → `DataStoreHealthCheck` + `BehaviorHealthCheck` | Healthy/Degraded → 200, Unhealthy → 503 | Routing decision; CMK `Degraded` stays routable |
+| `/health/live` | none (predicate → `false`) | always 200 (no checks → Healthy) | Process-alive |
+
+New route constants in `KnownRoutes.cs`: `HealthCheckStartup` (`/health/startup`),
+`HealthCheckReady` (`/health/ready`), `HealthCheckLive` (`/health/live`).
+
+The `UseFhirServer` signature is unchanged: the startup/readiness/liveness
+predicates are internal constants; only `/health/check` keeps the caller-supplied
+`healthCheckOptionsPredicate`.
+
+### Startup gate: `StorageInitializedHealthCheck`
+
+The check becomes a pure startup gate. It returns only **Healthy** (startup done
+or handoff) or **Unhealthy** (still initializing) — never Degraded. All
+Degraded/CMK routing behavior moves to `DataStoreHealthCheck` on the readiness
+route.
+
+Configuration (`StorageInitializedHealthCheckConfiguration`, bound from
+`HealthChecks:StorageInitialization`, repurposed from PR #5669):
+
+- `TerminalFailureGracePeriod` — default **1 minute**. Minimum time to wait
+  before a detected terminal failure is honored, allowing the CMK health cache to
+  populate and transient boot states to clear (prevents a false early handoff).
+- `StartupTimeout` — default **5 minutes**. Absolute backstop; after this the
+  gate hands off regardless of state.
+- Validation: both non-negative; `TerminalFailureGracePeriod` ≤ `StartupTimeout`.
+
+State machine in `CheckHealthAsync` (uses the existing `Clock` abstraction and the
+`SearchParametersInitializedNotification` handler that sets `_storageReady`):
+
+1. `_storageReady` → **Healthy** ("Successfully initialized.").
+2. `waited < TerminalFailureGracePeriod` → **Unhealthy** ("initializing").
+3. `waited ≥ TerminalFailureGracePeriod` **and** terminal failure detected
+   (`IDatabaseStatusReporter.IsCustomerManagerKeyProperlySetAsync` returns false)
+   → **Healthy** ("startup complete: storage inaccessible, handing off to
+   readiness").
+4. `waited < StartupTimeout` → **Unhealthy** ("initializing").
+5. `waited ≥ StartupTimeout` → **Healthy** ("startup timeout elapsed, handing
+   off to readiness").
+
+Net behavior: `/health/startup` returns 503 only while genuinely initializing,
+and flips to 200 on init success, terminal CMK failure (after the grace period),
+or the timeout backstop. The pod is never crash-looped by the startup probe;
+once startup succeeds, Kubernetes stops calling it and readiness governs routing.
+
+### Readiness
+
+`/health/ready` mirrors the current `/health/check` mapping: `Healthy`/`Degraded`
+→ 200, `Unhealthy` → 503. A CMK problem surfaces as `Degraded` from
+`DataStoreHealthCheck`, so the pod stays routable (200) and clients receive their
+403 `OperationOutcome`. Only a genuine `Unhealthy` result (for example a SQL
+transport error that clears the connection pools) pulls the pod from rotation.
+
+### Liveness
+
+`/health/live` runs zero checks (predicate returns `false`), so the report is
+empty and resolves to `Healthy` → HTTP 200 whenever the process is up. This gives
+`fhir-paas` the choice of an HTTP liveness probe or a `tcpSocket` probe later.
+
+## Tagging and Registration Changes
+
+Tag convention (plain string literals, matching existing `datastore:sqlServer`):
+`probe:startup`, `probe:readiness`. Liveness uses no tag.
+
+| Check | File | Tag added |
+|---|---|---|
+| `StorageInitializedHealthCheck` | `Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs` (~206) | `probe:startup` |
+| `ImproperBehaviorHealthCheck` | `Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs` (~196) | `probe:readiness` |
+| `CosmosDbHealthCheck` (`DataStoreHealthCheck`) | `Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs` (~317) | `probe:readiness` |
+| SQL `DataStoreHealthCheck` | **shared** `Microsoft.Health.SqlServer.Api/Registration/SqlServerApiRegistrationExtensions.cs` (~19) | add `probe:readiness` to `SqlServerHealthCheckTags` |
+
+The shared-repo change is a single-line tag addition:
+`SqlServerHealthCheckTags = { "datastore:sqlServer", "probe:readiness" }`.
+
+The parallel `.AsService<IHealthCheck>()` DI registrations are untouched;
+ASP.NET's `HealthCheckService` executes only the `AddCheck` registrations, so no
+check runs twice.
+
+## Response Writer
+
+The JSON response writer is currently inlined once in the single `MapHealthChecks`
+call. Extract it to a private `WriteHealthReportAsync(HttpContext, HealthReport)`
+helper in `FhirServerApplicationBuilderExtensions` and reuse it across all four
+routes. The body shape for `/health/check` is unchanged (`overallStatus` +
+per-entry `name`/`status`/`description`/`data`).
+
+## Error Handling and Edge Cases
+
+- **Terminal CMK then recovery before init:** once the gate hands off (Healthy),
+  Kubernetes stops calling the startup probe. Readiness continues to reflect real
+  state and routes or pulls the pod accordingly.
+- **Init completes after handoff:** `_storageReady` becomes true; all checks
+  report Healthy. No special handling needed.
+- **Concurrent probe execution:** each probe runs only its tag-matched checks
+  (startup: one cheap check; readiness: a SQL/Cosmos query plus behavior;
+  liveness: none). Checks are re-entrant; periodic probe cadence makes this
+  inexpensive.
+- **Transient CMK-uninitialized read at boot:** guarded by
+  `TerminalFailureGracePeriod` so an unpopulated CMK cache cannot trigger a false
+  early handoff.
+
+## Testing
+
+Unit tests — `StorageInitializedHealthCheck` (existing test file, fake `Clock`
+with millisecond-scale configuration):
+
+- `_storageReady` → Healthy immediately, even before the grace period.
+- Not ready, `waited < grace`, CMK bad → Unhealthy (grace protects transient state).
+- Not ready, `waited ≥ grace`, CMK not properly set → Healthy (terminal handoff).
+- Not ready, `grace ≤ waited < timeout`, CMK fine → Unhealthy (still initializing).
+- Not ready, `waited ≥ timeout`, CMK fine → Healthy (backstop handoff).
+- Config validation: negative grace or timeout throws; grace > timeout throws.
+
+Endpoint/routing tests (fhir-server, `TestServer` / `WebApplicationFactory` where
+feasible): request `/health/startup`, `/health/ready`, `/health/live` and assert
+the status-code mapping and that only tag-matched checks run — for example
+startup 503 while initializing then 200 after handoff, readiness 200 on a
+CMK-`Degraded` data store, and liveness 200 with zero checks.
+
+Shared repo: the tag addition needs no new test; existing SQL health-check tests
+must still pass. Optionally assert the registration carries `probe:readiness`.
+
+## Configuration Migration
+
+Replace PR #5669's field names `StartupDegradedDelay` and
+`StorageInitializationTimeout` with `TerminalFailureGracePeriod` and
+`StartupTimeout`. Update any `appsettings.json` entries under
+`HealthChecks:StorageInitialization`. Risk is low because PR #5669 is not merged.
+
+## Deferred: fhir-paas Probe Configuration
+
+Handled in a later subsession after this work merges upstream. In
+`fhiroperator/controllers/fhir_controller.go`, repoint the probes:
+
+- Startup probe → `/health/startup`, `failureThreshold` sized to the ~5-minute
+  `StartupTimeout` backstop.
+- Readiness probe → `/health/ready`.
+- Liveness probe → `/health/live` (or a `tcpSocket` probe).
+
+## Rollout Considerations
+
+While the new endpoints exist but `fhir-paas` still points every probe at
+`/health/check`, behavior is unchanged from the (reverted-to-simple) baseline —
+the new routes are additive and unused until `fhir-paas` is updated. This lets
+the fhir-server and healthcare-shared-components changes merge and release
+independently of the probe-configuration change.

--- a/docs/superpowers/specs/2026-07-13-fhir-separate-health-probes-design.md
+++ b/docs/superpowers/specs/2026-07-13-fhir-separate-health-probes-design.md
@@ -1,9 +1,9 @@
 # Separate Kubernetes Health Probes for the FHIR Server
 
 - **Date:** 2026-07-13
-- **Status:** Approved design (pre-implementation)
-- **Repos in scope:** `microsoft/fhir-server`, `microsoft/healthcare-shared-components`
-- **Deferred (separate subsession):** `fhir-paas` probe configuration
+- **Status:** Approved design (pre-implementation) — amended after external review
+- **Repos in scope:** `microsoft/fhir-server` **only** (no shared-components change required)
+- **Deferred (separate subsession, REQUIRED companion):** `fhir-paas` probe + middleware configuration
 - **Supersedes:** the two-tier `StorageInitializedHealthCheck` logic committed in PR #5669
 
 ## Problem
@@ -35,111 +35,184 @@ routable" independently. The fix is to split the probes.
   each with its own set of checks and HTTP status mapping.
 - Prevent traffic before initialization completes (startup gate).
 - Never crash-loop the pod on a persistent failure (CMK or DB inaccessible):
-  startup completes and hands off to readiness instead of failing forever.
-- Keep CMK-failed pods routable so customers receive their 403 `OperationOutcome`.
-- Keep `/health/check` unchanged as the existing diagnostic endpoint.
-- Revert PR #5669's Degraded-tier logic; move steady-state CMK/Degraded routing
-  to the data-store check on the readiness route.
+  startup hands off to readiness at a timeout backstop instead of failing forever.
+- Keep CMK-failed pods routable so customers receive their 403 `OperationOutcome`
+  (CMK routability lives on the readiness data-store check, not the startup gate).
+- Keep `/health/check`'s **steady-state** contract unchanged; relocate the
+  startup-window gating semantics onto `/health/startup`.
+- Revert PR #5669's Degraded-tier logic on the startup check.
 
 ## Non-Goals
 
-- Changing `fhir-paas` probe configuration. That is a documented companion
-  change handled in a later subsession once this work merges upstream.
+- Changing `fhir-paas` probe configuration or middleware allowlists in this
+  session. That is a **required** companion change (see "Deferred") handled in a
+  later subsession once this work merges upstream.
 - Introducing health-check response caching for the new endpoints.
 - Altering CMK detection semantics in the data-store checks themselves.
+- Any change to `healthcare-shared-components` (an earlier draft added a tag
+  there; the amended design removes that dependency entirely).
 
 ## Design Overview
 
 Four routes are mapped in
 `FhirServerApplicationBuilderExtensions.UseFhirServer`, each filtered by a
-health-check **tag** and given an explicit `ResultStatusCodes` map. Check-to-probe
-membership is declared at registration time via tags, following the existing
-`datastore:sqlServer` tag convention already present in
-healthcare-shared-components.
+health-check **tag predicate** and given an explicit `ResultStatusCodes` map.
+Check-to-probe membership is declared at registration time via tags, following
+the existing `datastore:sqlServer` tag convention already present in the consumed
+healthcare-shared-components package.
+
+Two new fhir-server-owned tags are introduced: `probe:startup` and
+`probe:readiness`. The readiness predicate additionally reuses the **existing**
+shared `datastore:sqlServer` tag so that the SQL data-store check — registered
+inside the shared package — is selected **without modifying the shared repo**.
 
 ### Endpoints
 
 | Route | Checks (tag predicate) | HTTP mapping | Purpose |
 |---|---|---|---|
-| `/health/check` | all checks (existing caller predicate) | Healthy/Degraded → 200, Unhealthy → 503 | Existing diagnostic endpoint — unchanged |
-| `/health/startup` | `probe:startup` → `StorageInitializedHealthCheck` only | Healthy → 200, Degraded → 503, Unhealthy → 503 | Gate: 503 while initializing; 200 once init done or terminal failure/backstop |
-| `/health/ready` | `probe:readiness` → `DataStoreHealthCheck` + `BehaviorHealthCheck` | Healthy/Degraded → 200, Unhealthy → 503 | Routing decision; CMK `Degraded` stays routable |
-| `/health/live` | none (predicate → `false`) | always 200 (no checks → Healthy) | Process-alive |
+| `/health/check` | caller predicate **AND NOT** `probe:startup` | Healthy/Degraded → 200, Unhealthy → 503 | Diagnostic endpoint — steady-state unchanged |
+| `/health/startup` | `probe:startup` → `StorageInitializedHealthCheck` only | Healthy → 200, Unhealthy → 503 | Gate: 503 while initializing; 200 once init done or timeout backstop |
+| `/health/ready` | `datastore:sqlServer` **OR** `probe:readiness` → `DataStoreHealthCheck` + `BehaviorHealthCheck` | Healthy/Degraded → 200, Unhealthy → 503 | Routing decision; CMK `Degraded` stays routable |
+| `/health/live` | none (predicate → `false`) | always 200 (no checks → Healthy) | Dependency-free HTTP liveness |
 
 New route constants in `KnownRoutes.cs`: `HealthCheckStartup` (`/health/startup`),
 `HealthCheckReady` (`/health/ready`), `HealthCheckLive` (`/health/live`).
 
 The `UseFhirServer` signature is unchanged: the startup/readiness/liveness
 predicates are internal constants; only `/health/check` keeps the caller-supplied
-`healthCheckOptionsPredicate`.
+`healthCheckOptionsPredicate` (now **AND**-combined with `NOT probe:startup`).
+
+### Tag constants and predicates
+
+Introduce a single `HealthCheckTags` static class (fhir-server) so tag strings are
+never duplicated as inline literals (a typo silently fails open — see Edge Cases):
+
+- `HealthCheckTags.ProbeStartup = "probe:startup"`
+- `HealthCheckTags.ProbeReadiness = "probe:readiness"`
+- `HealthCheckTags.DataStoreSqlServer = "datastore:sqlServer"` — mirrors the shared
+  package's tag string; a startup assertion (below) fails loudly if the shared
+  value ever drifts.
+
+Predicates:
+
+- Startup: `reg => reg.Tags.Contains(ProbeStartup)`
+- Readiness: `reg => reg.Tags.Contains(DataStoreSqlServer) || reg.Tags.Contains(ProbeReadiness)`
+- `/health/check`: `reg => (caller?.Invoke(reg) ?? true) && !reg.Tags.Contains(ProbeStartup)`
+- Liveness: `_ => false`
+
+Only one data store is active per deployment (SQL **or** Cosmos), so the readiness
+predicate resolves to exactly one `DataStoreHealthCheck` plus the behavior check.
 
 ### Startup gate: `StorageInitializedHealthCheck`
 
-The check becomes a pure startup gate. It returns only **Healthy** (startup done
-or handoff) or **Unhealthy** (still initializing) — never Degraded. All
-Degraded/CMK routing behavior moves to `DataStoreHealthCheck` on the readiness
-route.
+The check becomes a **pure** startup gate. It returns only **Healthy** (init done
+or timeout backstop) or **Unhealthy** (still initializing) — never Degraded, and
+it makes **no CMK / Key Vault call at all**. Dropping CMK from the gate removes an
+entire class of bugs found in review: a synchronous `.GetAwaiter().GetResult()`
+over `IDatabaseStatusReporter` could block a request thread on an unpopulated CMK
+`ValueCache` and delay the fail-open backstop. CMK routability is preserved on the
+readiness route instead (a CMK-broken pod simply waits out the timeout, then
+becomes routable and serves 403 `OperationOutcome`s).
 
 Configuration (`StorageInitializedHealthCheckConfiguration`, bound from
-`HealthChecks:StorageInitialization`, repurposed from PR #5669):
+`HealthChecks:StorageInitialization`):
 
-- `TerminalFailureGracePeriod` — default **1 minute**. Minimum time to wait
-  before a detected terminal failure is honored, allowing the CMK health cache to
-  populate and transient boot states to clear (prevents a false early handoff).
-- `StartupTimeout` — default **5 minutes**. Absolute backstop; after this the
-  gate hands off regardless of state.
-- Validation: both non-negative; `TerminalFailureGracePeriod` ≤ `StartupTimeout`.
+- `StorageInitializationTimeout` — default **5 minutes**. Absolute backstop; after
+  this the gate hands off (Healthy) regardless of state. This is the only knob;
+  PR #5669's `StartupDegradedDelay` is **removed**.
+- Validation registered with `.Validate(...).ValidateOnStart()` (not constructor-
+  only, which fired late): timeout must be non-negative.
 
 State machine in `CheckHealthAsync` (uses the existing `Clock` abstraction and the
 `SearchParametersInitializedNotification` handler that sets `_storageReady`):
 
 1. `_storageReady` → **Healthy** ("Successfully initialized.").
-2. `waited < TerminalFailureGracePeriod` → **Unhealthy** ("initializing").
-3. `waited ≥ TerminalFailureGracePeriod` **and** terminal failure detected
-   (`IDatabaseStatusReporter.IsCustomerManagerKeyProperlySetAsync` returns false)
-   → **Healthy** ("startup complete: storage inaccessible, handing off to
-   readiness").
-4. `waited < StartupTimeout` → **Unhealthy** ("initializing").
-5. `waited ≥ StartupTimeout` → **Healthy** ("startup timeout elapsed, handing
-   off to readiness").
+2. `waited ≥ StorageInitializationTimeout` → **Healthy** ("startup timeout
+   elapsed, handing off to readiness").
+3. otherwise → **Unhealthy** ("Storage is initializing. Waited: Ns.").
 
-Net behavior: `/health/startup` returns 503 only while genuinely initializing,
-and flips to 200 on init success, terminal CMK failure (after the grace period),
-or the timeout backstop. The pod is never crash-looped by the startup probe;
-once startup succeeds, Kubernetes stops calling it and readiness governs routing.
+`_storageReady` is declared `volatile` (written on the notification thread, read
+on probe threads; a single boolean flip needs only a memory barrier).
+
+Net behavior: `/health/startup` returns 503 only while genuinely initializing, and
+flips to 200 on init success or the timeout backstop. The pod is never
+crash-looped by the startup probe; once startup succeeds, Kubernetes stops calling
+it and readiness governs routing.
+
+**Timeout / K8s-budget invariant.** The application timeout and the Kubernetes
+startup-probe budget must satisfy:
+
+```
+legit-init-p99  <  StorageInitializationTimeout  <  k8s-startup-budget
+```
+
+Today all three are ~5 minutes (RBAC-sync p99 ≈ 5 min; app timeout 5 min; startup
+budget `failureThreshold 6×5 × period 10s = 300s`), so the app flips Healthy at
+the same instant Kubernetes exhausts its budget and the fail-open is never
+observed. The app timeout stays at **5 minutes** (aligned to legit init p99); the
+Kubernetes budget **must** be raised above it (see Deferred). This spec documents
+the invariant; fhir-server cannot enforce the K8s side.
 
 ### Readiness
 
 `/health/ready` mirrors the current `/health/check` mapping: `Healthy`/`Degraded`
 → 200, `Unhealthy` → 503. A CMK problem surfaces as `Degraded` from
-`DataStoreHealthCheck`, so the pod stays routable (200) and clients receive their
-403 `OperationOutcome`. Only a genuine `Unhealthy` result (for example a SQL
-transport error that clears the connection pools) pulls the pod from rotation.
+`DataStoreHealthCheck` (verified: `SqlServerHealthCheck` returns `Degraded` for CMK
+and DB-state errors, `Unhealthy` only for SQL transport errors), so the pod stays
+routable (200) and clients receive their 403 `OperationOutcome`. Only a genuine
+`Unhealthy` result pulls the pod from rotation.
+
+Readiness deliberately does **not** include the storage-init gate. The startup
+probe already gates the common case (readiness probes do not run until startup
+succeeds, and startup succeeds only on `_storageReady` or the timeout backstop).
+The one residual case — storage failed to initialize for a **non-CMK** reason for
+longer than the timeout while the DB stays reachable — is an abnormal, alerting
+pod that receives traffic and returns 500s; this matches today's single-endpoint
+behavior and is out of scope to gate further.
 
 ### Liveness
 
 `/health/live` runs zero checks (predicate returns `false`), so the report is
-empty and resolves to `Healthy` → HTTP 200 whenever the process is up. This gives
-`fhir-paas` the choice of an HTTP liveness probe or a `tcpSocket` probe later.
+empty and resolves to `Healthy` → HTTP 200 whenever the request reaches the health
+middleware. This is **dependency-free HTTP liveness**, not an unconditional
+process-alive signal: upstream middleware (suspended-account, private-link) can
+still short-circuit with 403/500. `fhir-paas` may later choose a `tcpSocket` probe
+to bypass the application pipeline entirely.
 
-## Tagging and Registration Changes
+## Tagging and Registration Changes (fhir-server only)
 
-Tag convention (plain string literals, matching existing `datastore:sqlServer`):
-`probe:startup`, `probe:readiness`. Liveness uses no tag.
+Tag convention: `HealthCheckTags` constants (above). Liveness uses no tag.
 
-| Check | File | Tag added |
+| Check | File | Change |
 |---|---|---|
-| `StorageInitializedHealthCheck` | `Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs` (~206) | `probe:startup` |
-| `ImproperBehaviorHealthCheck` | `Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs` (~196) | `probe:readiness` |
-| `CosmosDbHealthCheck` (`DataStoreHealthCheck`) | `Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs` (~317) | `probe:readiness` |
-| SQL `DataStoreHealthCheck` | **shared** `Microsoft.Health.SqlServer.Api/Registration/SqlServerApiRegistrationExtensions.cs` (~19) | add `probe:readiness` to `SqlServerHealthCheckTags` |
-
-The shared-repo change is a single-line tag addition:
-`SqlServerHealthCheckTags = { "datastore:sqlServer", "probe:readiness" }`.
+| `StorageInitializedHealthCheck` | `Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs` (~206) | add tag `probe:startup` |
+| `ImproperBehaviorHealthCheck` (`BehaviorHealthCheck`) | `Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs` (~196) | add tag `probe:readiness` |
+| `CosmosDbHealthCheck` (`DataStoreHealthCheck`) | `Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs` (~317) | add tag `probe:readiness` |
+| SQL `DataStoreHealthCheck` | shared `SqlServerApiRegistrationExtensions.cs` | **no change** — selected via its pre-existing `datastore:sqlServer` tag |
 
 The parallel `.AsService<IHealthCheck>()` DI registrations are untouched;
 ASP.NET's `HealthCheckService` executes only the `AddCheck` registrations, so no
-check runs twice.
+check runs twice (verified in review).
+
+### Startup registration assertion
+
+Because an empty tag selection resolves to `Healthy` → 200 (a typo or a shared-side
+tag rename would silently fail open), add a fail-fast startup validation (hosted
+service or invoked in `UseFhirServer`) asserting:
+
+- the readiness predicate resolves **exactly one** registration named
+  `DataStoreHealthCheck`, and
+- the startup predicate resolves **exactly one** registration.
+
+A zero/duplicate count throws at startup rather than serving a false 200.
+
+### Thread-safety fixes
+
+- `StorageInitializedHealthCheck._storageReady` → `volatile bool`.
+- `ImproperBehaviorHealthCheck` currently mutates two coupled fields
+  (`_isHealthy`, `_message`) with no synchronization. Replace them with a single
+  `volatile` reference to an immutable state record so the health flag and message
+  are published together atomically.
 
 ## Response Writer
 
@@ -151,61 +224,108 @@ per-entry `name`/`status`/`description`/`data`).
 
 ## Error Handling and Edge Cases
 
-- **Terminal CMK then recovery before init:** once the gate hands off (Healthy),
-  Kubernetes stops calling the startup probe. Readiness continues to reflect real
-  state and routes or pulls the pod accordingly.
-- **Init completes after handoff:** `_storageReady` becomes true; all checks
-  report Healthy. No special handling needed.
-- **Concurrent probe execution:** each probe runs only its tag-matched checks
-  (startup: one cheap check; readiness: a SQL/Cosmos query plus behavior;
-  liveness: none). Checks are re-entrant; periodic probe cadence makes this
-  inexpensive.
-- **Transient CMK-uninitialized read at boot:** guarded by
-  `TerminalFailureGracePeriod` so an unpopulated CMK cache cannot trigger a false
-  early handoff.
+- **Terminal CMK failure:** the startup gate ignores CMK entirely and hands off at
+  the timeout backstop; the pod becomes routable and readiness returns `Degraded`
+  → 200 so clients receive their 403 `OperationOutcome`.
+- **CMK failure then recovery before init completes:** the readiness data-store
+  check reflects live state — `Degraded` → 200 while CMK is broken, and it can
+  return `Healthy` → 200 once the DB is reachable again. (This corrects the prior
+  draft's claim that readiness stayed protected here; it does not, and that is
+  acceptable because a reachable DB is a routable pod.)
+- **Init completes after handoff:** `_storageReady` becomes true; all checks report
+  Healthy. No special handling needed.
+- **Empty/typo'd tag selection:** guarded by the startup registration assertion,
+  which fails fast instead of serving a false 200.
+- **Concurrent probe execution + notifications:** `_storageReady` (volatile) and
+  the `ImproperBehaviorHealthCheck` immutable-state swap make cross-thread reads
+  safe; covered by concurrent tests below.
+- **Cosmos CMK:** `CosmosDbStatusReporter` is a stub (always healthy, has a TODO).
+  This no longer matters for startup because the gate makes no CMK call; Cosmos CMK
+  routability, when implemented, lives on the readiness data-store check.
 
 ## Testing
 
 Unit tests — `StorageInitializedHealthCheck` (existing test file, fake `Clock`
 with millisecond-scale configuration):
 
-- `_storageReady` → Healthy immediately, even before the grace period.
-- Not ready, `waited < grace`, CMK bad → Unhealthy (grace protects transient state).
-- Not ready, `waited ≥ grace`, CMK not properly set → Healthy (terminal handoff).
-- Not ready, `grace ≤ waited < timeout`, CMK fine → Unhealthy (still initializing).
-- Not ready, `waited ≥ timeout`, CMK fine → Healthy (backstop handoff).
-- Config validation: negative grace or timeout throws; grace > timeout throws.
+- `_storageReady` → Healthy immediately.
+- Not ready, `waited < timeout` → Unhealthy.
+- Not ready, `waited ≥ timeout` → Healthy (backstop handoff).
+- No `IDatabaseStatusReporter` / CMK interaction is exercised (the dependency is
+  removed from the gate).
+- Config validation via `ValidateOnStart`: negative timeout fails startup; zero and
+  exact-boundary values covered.
+- Concurrency: notification handler flips `_storageReady` while probes read it
+  (no torn reads / lost handoff).
 
-Endpoint/routing tests (fhir-server, `TestServer` / `WebApplicationFactory` where
-feasible): request `/health/startup`, `/health/ready`, `/health/live` and assert
-the status-code mapping and that only tag-matched checks run — for example
-startup 503 while initializing then 200 after handoff, readiness 200 on a
-CMK-`Degraded` data store, and liveness 200 with zero checks.
+`ImproperBehaviorHealthCheck` tests: concurrent notification + probe reads observe a
+consistent `(isHealthy, message)` pair.
 
-Shared repo: the tag addition needs no new test; existing SQL health-check tests
-must still pass. Optionally assert the registration carries `probe:readiness`.
+Registration tests (**mandatory**, not optional):
 
-## Configuration Migration
+- SQL registration path resolves exactly one readiness `DataStoreHealthCheck` via
+  the `datastore:sqlServer` tag.
+- Cosmos registration path resolves exactly one readiness `DataStoreHealthCheck`
+  via the `probe:readiness` tag.
+- The startup assertion throws when the data-store tag is missing/duplicated
+  (package-skew / rename detection).
 
-Replace PR #5669's field names `StartupDegradedDelay` and
-`StorageInitializationTimeout` with `TerminalFailureGracePeriod` and
-`StartupTimeout`. Update any `appsettings.json` entries under
-`HealthChecks:StorageInitialization`. Risk is low because PR #5669 is not merged.
+Endpoint/routing tests (fhir-server, `TestServer` / `WebApplicationFactory`):
 
-## Deferred: fhir-paas Probe Configuration
+- `/health/startup` → 503 while initializing, 200 after `_storageReady`, 200 after
+  timeout backstop.
+- `/health/ready` → 200 on a CMK-`Degraded` data store, 503 on `Unhealthy`.
+- `/health/live` → 200 with zero checks.
+- `/health/check` → does **not** include the startup gate (still 200 when DB
+  reachable during the startup window; steady-state body unchanged).
+- Probe-budget documentation test: assert the default `StorageInitializationTimeout`
+  matches the documented invariant value.
 
-Handled in a later subsession after this work merges upstream. In
-`fhiroperator/controllers/fhir_controller.go`, repoint the probes:
+Deferred to the fhir-paas subsession (see below): suspended-account and
+private-link middleware tests for all four health paths, and "liveness reaches 200
+through the production middleware pipeline."
 
-- Startup probe → `/health/startup`, `failureThreshold` sized to the ~5-minute
-  `StartupTimeout` backstop.
-- Readiness probe → `/health/ready`.
-- Liveness probe → `/health/live` (or a `tcpSocket` probe).
+## Configuration Change
+
+This is a **property/API rename**, not a deployment-config migration — no
+`HealthChecks:StorageInitialization` values were found in the fhir-server or
+fhir-paas trees, so defaults apply. Remove PR #5669's `StartupDegradedDelay`; keep
+`StorageInitializationTimeout` (default 5 min) as the single knob.
+
+## Deferred: fhir-paas Probe + Middleware Configuration (REQUIRED companion)
+
+Handled in a later subsession after this work merges upstream. This is **not**
+optional cosmetic repointing: the new endpoints are unusable in fhir-paas until the
+middleware allowlists accept them (suspended pods would otherwise 403 the new
+probes and crash-loop). The companion change is an atomic set:
+
+1. **Probes** in `fhiroperator/controllers/fhir_controller.go`: create **three
+   distinct** `ExecAction` instances (today all probes share one pointer):
+   - Startup → `/health/startup`, with `failureThreshold × periodSeconds`
+     **strictly greater** than `StorageInitializationTimeout` plus one probe
+     timeout plus scheduling margin (e.g. `6×7 = 42 × 10s ≈ 7:00` vs the 5-min app
+     timeout).
+   - Readiness → `/health/ready`.
+   - Liveness → `/health/live` (or a `tcpSocket` probe).
+2. **Suspended-account allowlist** (`SuspendedAccountMiddleware`): currently allows
+   only paths ending `/health/check`; must allow all four health paths.
+3. **Private-link skip paths** (`PrivateLinkValidationSettings__SkipValidationPaths`
+   env in `fhir_controller.go`, and the common private-link middleware): add the
+   three new paths.
+4. **Ingress suspension rule** (nginx `server-snippet` `^/(?!health/check)`): widen
+   to permit the new health paths (external-facing; lower priority since in-pod
+   exec probes bypass ingress, but keep consistent).
+5. **Provisioning defaults + middleware tests** for suspended / private-link
+   accounts across all four health paths.
 
 ## Rollout Considerations
 
-While the new endpoints exist but `fhir-paas` still points every probe at
-`/health/check`, behavior is unchanged from the (reverted-to-simple) baseline —
-the new routes are additive and unused until `fhir-paas` is updated. This lets
-the fhir-server and healthcare-shared-components changes merge and release
-independently of the probe-configuration change.
+- fhir-server change is self-contained: no `healthcare-shared-components` change and
+  no package-version bump are required (readiness reuses the already-shipped
+  `datastore:sqlServer` tag). fhir-server can merge and release independently.
+- While the new endpoints exist but `fhir-paas` still points every probe at
+  `/health/check`, behavior is unchanged — the new routes are additive and unused
+  until the fhir-paas companion lands.
+- The fhir-paas companion must ship as one atomic change (probes + middleware
+  allowlists together) to avoid crash-looping suspended pods, and must raise the
+  startup budget above the 5-minute app timeout per the invariant.

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/HealthCheckTags.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/HealthCheckTags.cs
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// Health-check tag constants used to select which checks each Kubernetes probe runs.
+    /// A tag typo silently fails open (an empty selection resolves to Healthy => HTTP 200),
+    /// so every registration and predicate MUST reference these constants rather than literals.
+    /// </summary>
+    public static class HealthCheckTags
+    {
+        /// <summary>Tag for the startup gate check (<see cref="StorageInitializedHealthCheck"/>).</summary>
+        public const string ProbeStartup = "probe:startup";
+
+        /// <summary>Tag for checks that participate in the readiness/routing decision.</summary>
+        public const string ProbeReadiness = "probe:readiness";
+
+        /// <summary>
+        /// Mirrors the tag applied by the healthcare-shared-components SQL registration.
+        /// A startup assertion fails loudly if the shared value ever drifts from this literal.
+        /// </summary>
+        public const string DataStoreSqlServer = "datastore:sqlServer";
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/HealthCheckTags.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/HealthCheckTags.cs
@@ -23,5 +23,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Health
         /// A startup assertion fails loudly if the shared value ever drifts from this literal.
         /// </summary>
         public const string DataStoreSqlServer = "datastore:sqlServer";
+
+        /// <summary>
+        /// Registration name of the data-store health check. This is a check name (not a tag),
+        /// shared between the in-repo Cosmos registration and the readiness startup assertion so
+        /// that the load-bearing name filter cannot silently drift. The healthcare-shared-components
+        /// SQL registration uses the same literal; the assertion fails loudly if that ever changes.
+        /// </summary>
+        public const string DataStoreHealthCheckName = "DataStoreHealthCheck";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/HealthProbePredicates.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/HealthProbePredicates.cs
@@ -1,0 +1,44 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// The single source of truth for the health-check selection predicates behind each Kubernetes
+    /// probe endpoint. <c>UseFhirServer</c> maps these onto <c>/health/check</c>, <c>/health/startup</c>,
+    /// <c>/health/ready</c> and <c>/health/live</c>, and the startup registration assertion reuses
+    /// <see cref="Readiness"/> and <see cref="Startup"/>. Keeping the predicates here (rather than as
+    /// inline lambdas) lets unit tests exercise the exact production logic, so a change to probe
+    /// routing cannot silently drift away from its regression coverage.
+    /// </summary>
+    internal static class HealthProbePredicates
+    {
+        /// <summary>
+        /// Diagnostic endpoint (<c>/health/check</c>): honors the caller-supplied predicate but always
+        /// excludes the startup gate, so a still-initializing pod is not reported as failed here.
+        /// </summary>
+        /// <param name="callerPredicate">Optional additional filter supplied by the host. When null, all non-startup checks run.</param>
+        internal static Func<HealthCheckRegistration, bool> Diagnostic(Func<HealthCheckRegistration, bool> callerPredicate) =>
+            reg => (callerPredicate?.Invoke(reg) ?? true) && !reg.Tags.Contains(HealthCheckTags.ProbeStartup);
+
+        /// <summary>Startup gate (<c>/health/startup</c>): only the storage-init check runs.</summary>
+        internal static bool Startup(HealthCheckRegistration reg) =>
+            reg.Tags.Contains(HealthCheckTags.ProbeStartup);
+
+        /// <summary>
+        /// Readiness/routing (<c>/health/ready</c>): the data-store check plus any readiness-tagged
+        /// checks. Degraded (e.g. a CMK failure) maps to HTTP 200 so the pod stays routable.
+        /// </summary>
+        internal static bool Readiness(HealthCheckRegistration reg) =>
+            reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+
+        /// <summary>Dependency-free HTTP liveness (<c>/health/live</c>): run no checks so an empty report is Healthy => 200.</summary>
+        internal static bool Live(HealthCheckRegistration reg) => false;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -13,23 +13,27 @@ namespace Microsoft.Health.Fhir.Api.Features.Health
 {
     public class ImproperBehaviorHealthCheck : IHealthCheck, INotificationHandler<ImproperBehaviorNotification>
     {
-        private bool _isHealthy = true;
-        private string _message = string.Empty;
+        private readonly object _lock = new();
+        private volatile ImproperBehaviorHealthCheckState _state = ImproperBehaviorHealthCheckState.Healthy;
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            if (_isHealthy)
+            ImproperBehaviorHealthCheckState state = _state;
+            if (state.IsHealthy)
             {
                 return Task.FromResult(HealthCheckResult.Healthy());
             }
 
-            return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, "Improper server behavior has been detected." + _message));
+            return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, "Improper server behavior has been detected." + state.Message));
         }
 
         public Task Handle(ImproperBehaviorNotification notification, CancellationToken cancellationToken)
         {
-            _isHealthy = false;
-            _message += " " + notification.Message;
+            lock (_lock)
+            {
+                _state = new ImproperBehaviorHealthCheckState(false, _state.Message + " " + notification.Message);
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheckState.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheckState.cs
@@ -1,0 +1,16 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// Immutable snapshot of the improper-behavior health state so the health flag and its
+    /// accompanying message are always published together atomically.
+    /// </summary>
+    internal sealed record ImproperBehaviorHealthCheckState(bool IsHealthy, string Message)
+    {
+        public static readonly ImproperBehaviorHealthCheckState Healthy = new(true, string.Empty);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -10,81 +10,46 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Messages.Search;
-using Microsoft.Health.Fhir.Core.Messages.Storage;
 
 namespace Microsoft.Health.Fhir.Api.Features.Health
 {
+    /// <summary>
+    /// Pure startup gate. Returns Healthy once storage initialization completes or the configured
+    /// timeout backstop elapses (hand off to readiness); otherwise Unhealthy. It makes no CMK /
+    /// Key Vault call — CMK routability is handled by the readiness data-store check.
+    /// </summary>
     public class StorageInitializedHealthCheck : IHealthCheck, INotificationHandler<SearchParametersInitializedNotification>
     {
-        private readonly IDatabaseStatusReporter _databaseStatusReporter;
         private readonly StorageInitializedHealthCheckConfiguration _configuration;
-        private bool _storageReady;
         private readonly DateTimeOffset _started = Clock.UtcNow;
+        private volatile bool _storageReady;
 
         private const string SuccessfullyInitializedMessage = "Successfully initialized.";
-        private const string DegradedCMKMessage = "The health of the store has degraded. Customer-managed key is not properly set.";
 
-        public StorageInitializedHealthCheck(
-            IDatabaseStatusReporter databaseStatusReporter,
-            IOptions<StorageInitializedHealthCheckConfiguration> configuration)
+        public StorageInitializedHealthCheck(IOptions<StorageInitializedHealthCheckConfiguration> configuration)
         {
-            _databaseStatusReporter = EnsureArg.IsNotNull(databaseStatusReporter, nameof(databaseStatusReporter));
             _configuration = EnsureArg.IsNotNull(configuration, nameof(configuration)).Value;
-
-            if (_configuration.StartupDegradedDelay < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(configuration),
-                    _configuration.StartupDegradedDelay,
-                    $"{nameof(StorageInitializedHealthCheckConfiguration.StartupDegradedDelay)} must be non-negative.");
-            }
-
-            if (_configuration.StorageInitializationTimeout < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(configuration),
-                    _configuration.StorageInitializationTimeout,
-                    $"{nameof(StorageInitializedHealthCheckConfiguration.StorageInitializationTimeout)} must be non-negative.");
-            }
-
-            if (_configuration.StartupDegradedDelay > _configuration.StorageInitializationTimeout)
-            {
-                throw new ArgumentException(
-                    $"{nameof(_configuration.StartupDegradedDelay)} cannot exceed {nameof(_configuration.StorageInitializationTimeout)}.",
-                    nameof(configuration));
-            }
         }
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            // If the storage is ready, we can return a healthy status immediately.
             if (_storageReady)
             {
                 return Task.FromResult(HealthCheckResult.Healthy(SuccessfullyInitializedMessage));
             }
 
             TimeSpan waited = Clock.UtcNow - _started;
-            if (waited < _configuration.StartupDegradedDelay)
+            if (waited >= _configuration.StorageInitializationTimeout)
             {
-                return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
+                return Task.FromResult(HealthCheckResult.Healthy(
+                    $"Startup timeout elapsed after {(int)waited.TotalSeconds}s; handing off to readiness."));
             }
 
-            if (waited < _configuration.StorageInitializationTimeout)
-            {
-                return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded, $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
-            }
-
-            // Check if customer-managed key (CMK) is properly set.
-            var isCMKProperlySet = _databaseStatusReporter.IsCustomerManagerKeyProperlySetAsync(cancellationToken).GetAwaiter().GetResult();
-            if (!isCMKProperlySet)
-            {
-                return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded, DegradedCMKMessage));
-            }
-
-            return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, $"Storage has not been initialized. Waited: {(int)waited.TotalSeconds}s."));
+            return Task.FromResult(new HealthCheckResult(
+                HealthStatus.Unhealthy,
+                $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
         }
 
         public Task Handle(SearchParametersInitializedNotification notification, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Messages.Search;
@@ -19,15 +20,42 @@ namespace Microsoft.Health.Fhir.Api.Features.Health
     public class StorageInitializedHealthCheck : IHealthCheck, INotificationHandler<SearchParametersInitializedNotification>
     {
         private readonly IDatabaseStatusReporter _databaseStatusReporter;
+        private readonly StorageInitializedHealthCheckConfiguration _configuration;
         private bool _storageReady;
         private readonly DateTimeOffset _started = Clock.UtcNow;
 
         private const string SuccessfullyInitializedMessage = "Successfully initialized.";
         private const string DegradedCMKMessage = "The health of the store has degraded. Customer-managed key is not properly set.";
 
-        public StorageInitializedHealthCheck(IDatabaseStatusReporter databaseStatusReporter)
+        public StorageInitializedHealthCheck(
+            IDatabaseStatusReporter databaseStatusReporter,
+            IOptions<StorageInitializedHealthCheckConfiguration> configuration)
         {
             _databaseStatusReporter = EnsureArg.IsNotNull(databaseStatusReporter, nameof(databaseStatusReporter));
+            _configuration = EnsureArg.IsNotNull(configuration, nameof(configuration)).Value;
+
+            if (_configuration.StartupDegradedDelay < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(configuration),
+                    _configuration.StartupDegradedDelay,
+                    $"{nameof(StorageInitializedHealthCheckConfiguration.StartupDegradedDelay)} must be non-negative.");
+            }
+
+            if (_configuration.StorageInitializationTimeout < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(configuration),
+                    _configuration.StorageInitializationTimeout,
+                    $"{nameof(StorageInitializedHealthCheckConfiguration.StorageInitializationTimeout)} must be non-negative.");
+            }
+
+            if (_configuration.StartupDegradedDelay > _configuration.StorageInitializationTimeout)
+            {
+                throw new ArgumentException(
+                    $"{nameof(_configuration.StartupDegradedDelay)} cannot exceed {nameof(_configuration.StorageInitializationTimeout)}.",
+                    nameof(configuration));
+            }
         }
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
@@ -39,9 +67,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Health
             }
 
             TimeSpan waited = Clock.UtcNow - _started;
-            if (waited < TimeSpan.FromMinutes(5))
+            if (waited < _configuration.StartupDegradedDelay)
             {
                 return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
+            }
+
+            if (waited < _configuration.StorageInitializationTimeout)
+            {
+                return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded, $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
             }
 
             // Check if customer-managed key (CMK) is properly set.

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheck.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Health
             TimeSpan waited = Clock.UtcNow - _started;
             if (waited < TimeSpan.FromMinutes(5))
             {
-                return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded, $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
+                return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, $"Storage is initializing. Waited: {(int)waited.TotalSeconds}s."));
             }
 
             // Check if customer-managed key (CMK) is properly set.

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheckConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheckConfiguration.cs
@@ -1,0 +1,30 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    /// <summary>
+    /// Configures the startup health check's transition from unhealthy to degraded.
+    /// </summary>
+    public class StorageInitializedHealthCheckConfiguration
+    {
+        /// <summary>
+        /// The configuration section name.
+        /// </summary>
+        public const string SectionName = "HealthChecks:StorageInitialization";
+
+        /// <summary>
+        /// Gets or sets the time to report an unhealthy status while storage initializes.
+        /// </summary>
+        public TimeSpan StartupDegradedDelay { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Gets or sets the maximum time to wait for storage initialization before checking CMK health.
+        /// </summary>
+        public TimeSpan StorageInitializationTimeout { get; set; } = TimeSpan.FromMinutes(5);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheckConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/StorageInitializedHealthCheckConfiguration.cs
@@ -8,7 +8,7 @@ using System;
 namespace Microsoft.Health.Fhir.Api.Features.Health
 {
     /// <summary>
-    /// Configures the startup health check's transition from unhealthy to degraded.
+    /// Configures the startup health-check gate.
     /// </summary>
     public class StorageInitializedHealthCheckConfiguration
     {
@@ -18,12 +18,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Health
         public const string SectionName = "HealthChecks:StorageInitialization";
 
         /// <summary>
-        /// Gets or sets the time to report an unhealthy status while storage initializes.
-        /// </summary>
-        public TimeSpan StartupDegradedDelay { get; set; } = TimeSpan.FromMinutes(1);
-
-        /// <summary>
-        /// Gets or sets the maximum time to wait for storage initialization before checking CMK health.
+        /// Gets or sets the absolute backstop after which the startup gate hands off to
+        /// readiness (returns Healthy) regardless of initialization state. Must satisfy the
+        /// invariant: legit-init-p99 &lt; StorageInitializationTimeout &lt; k8s-startup-budget.
         /// </summary>
         public TimeSpan StorageInitializationTimeout { get; set; } = TimeSpan.FromMinutes(5);
     }

--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
@@ -68,8 +68,7 @@ namespace Microsoft.AspNetCore.Builder
                         new PathString(KnownRoutes.HealthCheck),
                         new HealthCheckOptions
                         {
-                            Predicate = reg => (healthCheckOptionsPredicate?.Invoke(reg) ?? true)
-                                && !reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                            Predicate = HealthProbePredicates.Diagnostic(healthCheckOptionsPredicate),
                             ResponseWriter = WriteHealthReportAsync,
                         });
 
@@ -78,7 +77,7 @@ namespace Microsoft.AspNetCore.Builder
                         new PathString(KnownRoutes.HealthCheckStartup),
                         new HealthCheckOptions
                         {
-                            Predicate = reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                            Predicate = HealthProbePredicates.Startup,
                             ResponseWriter = WriteHealthReportAsync,
                         });
 
@@ -87,8 +86,7 @@ namespace Microsoft.AspNetCore.Builder
                         new PathString(KnownRoutes.HealthCheckReady),
                         new HealthCheckOptions
                         {
-                            Predicate = reg => reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer)
-                                || reg.Tags.Contains(HealthCheckTags.ProbeReadiness),
+                            Predicate = HealthProbePredicates.Readiness,
                             ResponseWriter = WriteHealthReportAsync,
                         });
 
@@ -97,7 +95,7 @@ namespace Microsoft.AspNetCore.Builder
                         new PathString(KnownRoutes.HealthCheckLive),
                         new HealthCheckOptions
                         {
-                            Predicate = _ => false,
+                            Predicate = HealthProbePredicates.Live,
                             ResponseWriter = WriteHealthReportAsync,
                         });
 
@@ -129,11 +127,8 @@ namespace Microsoft.AspNetCore.Builder
         {
             var options = services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
 
-            bool ReadinessPredicate(HealthCheckRegistration reg) =>
-                reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
-
             int dataStoreCount = options.Registrations.Count(
-                reg => ReadinessPredicate(reg) && string.Equals(reg.Name, HealthCheckTags.DataStoreHealthCheckName, StringComparison.Ordinal));
+                reg => HealthProbePredicates.Readiness(reg) && string.Equals(reg.Name, HealthCheckTags.DataStoreHealthCheckName, StringComparison.Ordinal));
             if (dataStoreCount != 1)
             {
                 throw new InvalidOperationException(
@@ -141,7 +136,7 @@ namespace Microsoft.AspNetCore.Builder
                     "This usually indicates a health-check tag typo or a healthcare-shared-components tag rename/package skew.");
             }
 
-            int startupCount = options.Registrations.Count(reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup));
+            int startupCount = options.Registrations.Count(HealthProbePredicates.Startup);
             if (startupCount != 1)
             {
                 throw new InvalidOperationException(

--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Builder
                 reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
 
             int dataStoreCount = options.Registrations.Count(
-                reg => ReadinessPredicate(reg) && string.Equals(reg.Name, "DataStoreHealthCheck", StringComparison.Ordinal));
+                reg => ReadinessPredicate(reg) && string.Equals(reg.Name, HealthCheckTags.DataStoreHealthCheckName, StringComparison.Ordinal));
             if (dataStoreCount != 1)
             {
                 throw new InvalidOperationException(
@@ -145,7 +145,9 @@ namespace Microsoft.AspNetCore.Builder
             if (startupCount != 1)
             {
                 throw new InvalidOperationException(
-                    $"Startup probe must resolve exactly one registration but resolved {startupCount}.");
+                    $"Startup probe must resolve exactly one '{HealthCheckTags.ProbeStartup}'-tagged registration " +
+                    $"(expected 'StorageInitializedHealthCheck') but resolved {startupCount}. " +
+                    "This usually indicates a health-check tag typo or a missing/duplicate startup registration.");
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Api.Features.Health;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Newtonsoft.Json;
 
@@ -48,6 +49,8 @@ namespace Microsoft.AspNetCore.Builder
                 app.UseMiddleware<PathBaseMiddleware>(pathString);
             }
 
+            ValidateHealthCheckRegistrations(app.ApplicationServices);
+
             app.UseHttpsRedirection();
             app.UseStaticFiles();
 
@@ -59,33 +62,91 @@ namespace Microsoft.AspNetCore.Builder
                 endpoints =>
                 {
                     endpoints.MapControllers();
+
+                    // Diagnostic endpoint: everything except the startup gate. Degraded => 200.
                     endpoints.MapHealthChecks(
                         new PathString(KnownRoutes.HealthCheck),
                         new HealthCheckOptions
                         {
-                            Predicate = healthCheckOptionsPredicate,
-                            ResponseWriter = async (httpContext, healthReport) =>
-                            {
-                                var response = JsonConvert.SerializeObject(
-                                    new
-                                    {
-                                        overallStatus = healthReport.Status.ToString(),
-                                        details = healthReport.Entries.Select(entry => new
-                                        {
-                                            name = entry.Key,
-                                            status = Enum.GetName<HealthStatus>(entry.Value.Status),
-                                            description = entry.Value.Description,
-                                            data = entry.Value.Data,
-                                        }),
-                                    });
-                                httpContext.Response.ContentType = MediaTypeNames.Application.Json;
-                                await httpContext.Response.WriteAsync(response).ConfigureAwait(false);
-                            },
+                            Predicate = reg => (healthCheckOptionsPredicate?.Invoke(reg) ?? true)
+                                && !reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                            ResponseWriter = WriteHealthReportAsync,
                         });
+
+                    // Startup gate: only the storage-init check. Unhealthy => 503 while initializing.
+                    endpoints.MapHealthChecks(
+                        new PathString(KnownRoutes.HealthCheckStartup),
+                        new HealthCheckOptions
+                        {
+                            Predicate = reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup),
+                            ResponseWriter = WriteHealthReportAsync,
+                        });
+
+                    // Readiness/routing: data-store + behavior. Degraded (e.g. CMK) => 200 stays routable.
+                    endpoints.MapHealthChecks(
+                        new PathString(KnownRoutes.HealthCheckReady),
+                        new HealthCheckOptions
+                        {
+                            Predicate = reg => reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer)
+                                || reg.Tags.Contains(HealthCheckTags.ProbeReadiness),
+                            ResponseWriter = WriteHealthReportAsync,
+                        });
+
+                    // Dependency-free HTTP liveness: run no checks => empty report => Healthy => 200.
+                    endpoints.MapHealthChecks(
+                        new PathString(KnownRoutes.HealthCheckLive),
+                        new HealthCheckOptions
+                        {
+                            Predicate = _ => false,
+                            ResponseWriter = WriteHealthReportAsync,
+                        });
+
                     mapAdditionalEndpoints?.Invoke(endpoints);
                 });
 
             return app;
+        }
+
+        private static async Task WriteHealthReportAsync(HttpContext httpContext, HealthReport healthReport)
+        {
+            var response = JsonConvert.SerializeObject(
+                new
+                {
+                    overallStatus = healthReport.Status.ToString(),
+                    details = healthReport.Entries.Select(entry => new
+                    {
+                        name = entry.Key,
+                        status = Enum.GetName<HealthStatus>(entry.Value.Status),
+                        description = entry.Value.Description,
+                        data = entry.Value.Data,
+                    }),
+                });
+            httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+            await httpContext.Response.WriteAsync(response).ConfigureAwait(false);
+        }
+
+        private static void ValidateHealthCheckRegistrations(IServiceProvider services)
+        {
+            var options = services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+            bool ReadinessPredicate(HealthCheckRegistration reg) =>
+                reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+
+            int dataStoreCount = options.Registrations.Count(
+                reg => ReadinessPredicate(reg) && string.Equals(reg.Name, "DataStoreHealthCheck", StringComparison.Ordinal));
+            if (dataStoreCount != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Readiness probe must resolve exactly one 'DataStoreHealthCheck' registration but resolved {dataStoreCount}. " +
+                    "This usually indicates a health-check tag typo or a healthcare-shared-components tag rename/package skew.");
+            }
+
+            int startupCount = options.Registrations.Count(reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup));
+            if (startupCount != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Startup probe must resolve exactly one registration but resolved {startupCount}.");
+            }
         }
 
         private class PathBaseMiddleware

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs
@@ -78,6 +78,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         public const string Versions = "$versions";
 
         public const string HealthCheck = "/health/check";
+        public const string HealthCheckStartup = "/health/startup";
+        public const string HealthCheckReady = "/health/ready";
+        public const string HealthCheckLive = "/health/live";
         public const string CustomError = "/CustomError";
 
         public const string SearchParameters = "SearchParameter/";

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             fhirServerBuilder.Services.AddHealthChecks()
                 .AddCheck<CosmosDbHealthCheck>(
-                    name: "DataStoreHealthCheck",
+                    name: HealthCheckTags.DataStoreHealthCheckName,
                     tags: new[] { HealthCheckTags.ProbeReadiness });
 
             fhirServerBuilder.Services.Add<CosmosDbStatusReporter>()

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -314,7 +314,9 @@ namespace Microsoft.Extensions.DependencyInjection
         private static IFhirServerBuilder AddCosmosDbHealthCheck(this IFhirServerBuilder fhirServerBuilder)
         {
             fhirServerBuilder.Services.AddHealthChecks()
-                .AddCheck<CosmosDbHealthCheck>(name: "DataStoreHealthCheck");
+                .AddCheck<CosmosDbHealthCheck>(
+                    name: "DataStoreHealthCheck",
+                    tags: new[] { HealthCheckTags.ProbeReadiness });
 
             fhirServerBuilder.Services.Add<CosmosDbStatusReporter>()
                 .Singleton()

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/ImproperBehaviorHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/ImproperBehaviorHealthCheckTests.cs
@@ -50,5 +50,32 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Health
                 Assert.Contains(message, result.Description);
             }
         }
+
+        [Fact]
+        public async Task GivenConcurrentNotificationsAndProbes_WhenCheckingHealth_ThenStateIsConsistent()
+        {
+            using var cts = new System.Threading.CancellationTokenSource();
+
+            Task reader = Task.Run(async () =>
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    HealthCheckResult result = await _healthCheck.CheckHealthAsync(null, CancellationToken.None);
+                    if (result.Status == HealthStatus.Unhealthy)
+                    {
+                        // An unhealthy result must always carry the appended message (no torn read).
+                        Assert.Contains("boom", result.Description);
+                    }
+                }
+            });
+
+            await _healthCheck.Handle(new ImproperBehaviorNotification("boom"), CancellationToken.None);
+            cts.Cancel();
+            await reader;
+
+            HealthCheckResult final = await _healthCheck.CheckHealthAsync(null, CancellationToken.None);
+            Assert.Equal(HealthStatus.Unhealthy, final.Status);
+            Assert.Contains("boom", final.Description);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
@@ -28,7 +29,7 @@ public class StorageInitializedHealthCheckTests
     {
         _databaseStatusReporter = Substitute.For<IDatabaseStatusReporter>();
         _databaseStatusReporter.IsCustomerManagerKeyProperlySetAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
-        _sut = new StorageInitializedHealthCheck(_databaseStatusReporter);
+        _sut = CreateSut();
     }
 
     [Fact]
@@ -61,6 +62,56 @@ public class StorageInitializedHealthCheckTests
     }
 
     [Fact]
+    public async Task GivenStartupDegradedDelayHasElapsed_WhenCheckHealthAsync_ThenReturnsDegraded()
+    {
+        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.UtcNow);
+        using (Mock.Property(() => ClockResolver.TimeProvider, timeProvider))
+        {
+            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+
+            HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("Storage is initializing", result.Description);
+        }
+    }
+
+    [Fact]
+    public async Task GivenStorageInitializationTimeoutHasElapsed_WhenCheckHealthAsync_ThenReturnsUnhealthy()
+    {
+        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.UtcNow);
+        using (Mock.Property(() => ClockResolver.TimeProvider, timeProvider))
+        {
+            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(2));
+
+            HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("Storage has not been initialized", result.Description);
+        }
+    }
+
+    [Fact]
+    public void GivenStartupDegradedDelayExceedsStorageInitializationTimeout_WhenCreatingHealthCheck_ThenThrows()
+    {
+        Assert.Throws<ArgumentException>(() => CreateSut(TimeSpan.FromMilliseconds(2), TimeSpan.FromMilliseconds(1)));
+    }
+
+    [Fact]
+    public void GivenStartupDegradedDelayIsNegative_WhenCreatingHealthCheck_ThenThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateSut(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(1)));
+    }
+
+    [Fact]
+    public void GivenStorageInitializationTimeoutIsNegative_WhenCreatingHealthCheck_ThenThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateSut(TimeSpan.Zero, TimeSpan.FromMilliseconds(-1)));
+    }
+
+    [Fact]
     public async Task GivenUnhealthyCMK_WhenCheckHealthAsyncAfter5Minutes_ThenChangedToDegraded()
     {
         using (Mock.Property(() => ClockResolver.TimeProvider, new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.Now.AddMinutes(5).AddSeconds(1))))
@@ -72,5 +123,19 @@ public class StorageInitializedHealthCheckTests
             Assert.Equal(HealthStatus.Degraded, result.Status);
             Assert.Contains("The health of the store has degraded. Customer-managed key is not properly set.", result.Description);
         }
+    }
+
+    private StorageInitializedHealthCheck CreateSut(
+        TimeSpan? startupDegradedDelay = null,
+        TimeSpan? storageInitializationTimeout = null)
+    {
+        return new StorageInitializedHealthCheck(
+            _databaseStatusReporter,
+            Options.Create(
+                new StorageInitializedHealthCheckConfiguration
+                {
+                    StartupDegradedDelay = startupDegradedDelay ?? TimeSpan.FromMinutes(1),
+                    StorageInitializationTimeout = storageInitializationTimeout ?? TimeSpan.FromMinutes(5),
+                }));
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs
@@ -42,10 +42,10 @@ public class StorageInitializedHealthCheckTests
     }
 
     [Fact]
-    public async Task GivenStorageInitializedHealthCheck_WhenCheckHealthAsync_ThenStartsAsDegraded()
+    public async Task GivenStorageInitializedHealthCheck_WhenCheckHealthAsync_ThenStartsAsUnhealthy()
     {
         HealthCheckResult result = await _sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
-        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
     }
 
     [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Health/StorageInitializedHealthCheckTests.cs
@@ -10,10 +10,8 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Messages.Search;
-using Microsoft.Health.Fhir.Core.Messages.Storage;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
-using NSubstitute;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Api.Features.Health;
@@ -22,119 +20,95 @@ namespace Microsoft.Health.Fhir.Api.Features.Health;
 [Trait(Traits.Category, Categories.DataSourceValidation)]
 public class StorageInitializedHealthCheckTests
 {
-    private readonly StorageInitializedHealthCheck _sut;
-    private readonly IDatabaseStatusReporter _databaseStatusReporter;
-
-    public StorageInitializedHealthCheckTests()
-    {
-        _databaseStatusReporter = Substitute.For<IDatabaseStatusReporter>();
-        _databaseStatusReporter.IsCustomerManagerKeyProperlySetAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
-        _sut = CreateSut();
-    }
-
     [Fact]
     public async Task GivenStorageInitialized_WhenCheckHealthAsync_ThenReturnsHealthy()
     {
-        await _sut.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+        StorageInitializedHealthCheck sut = CreateSut();
 
-        HealthCheckResult result = await _sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+        await sut.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+
+        HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
 
         Assert.Equal(HealthStatus.Healthy, result.Status);
     }
 
     [Fact]
-    public async Task GivenStorageInitializedHealthCheck_WhenCheckHealthAsync_ThenStartsAsUnhealthy()
+    public async Task GivenNotInitialized_WhenCheckHealthAsyncBeforeTimeout_ThenReturnsUnhealthy()
     {
-        HealthCheckResult result = await _sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+        StorageInitializedHealthCheck sut = CreateSut();
+
+        HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
         Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("Storage is initializing", result.Description);
     }
 
     [Fact]
-    public async Task GivenStorageInitializedHealthCheck_WhenCheckHealthAsync_ThenChangedToUnhealthyAfter5Minutes()
-    {
-        using (Mock.Property(() => ClockResolver.TimeProvider, new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.Now.AddMinutes(5).AddSeconds(1))))
-        {
-            HealthCheckResult result = await _sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
-
-            Assert.Equal(HealthStatus.Unhealthy, result.Status);
-            Assert.Contains("Storage has not been initialized", result.Description);
-        }
-    }
-
-    [Fact]
-    public async Task GivenStartupDegradedDelayHasElapsed_WhenCheckHealthAsync_ThenReturnsDegraded()
+    public async Task GivenNotInitializedAndTimeoutElapsed_WhenCheckHealthAsync_ThenReturnsHealthyBackstop()
     {
         var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.UtcNow);
         using (Mock.Property(() => ClockResolver.TimeProvider, timeProvider))
         {
-            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2));
-            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
-
-            HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
-
-            Assert.Equal(HealthStatus.Degraded, result.Status);
-            Assert.Contains("Storage is initializing", result.Description);
-        }
-    }
-
-    [Fact]
-    public async Task GivenStorageInitializationTimeoutHasElapsed_WhenCheckHealthAsync_ThenReturnsUnhealthy()
-    {
-        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.UtcNow);
-        using (Mock.Property(() => ClockResolver.TimeProvider, timeProvider))
-        {
-            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2));
+            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(1));
             timeProvider.Advance(TimeSpan.FromMilliseconds(2));
 
             HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
 
-            Assert.Equal(HealthStatus.Unhealthy, result.Status);
-            Assert.Contains("Storage has not been initialized", result.Description);
+            Assert.Equal(HealthStatus.Healthy, result.Status);
         }
     }
 
     [Fact]
-    public void GivenStartupDegradedDelayExceedsStorageInitializationTimeout_WhenCreatingHealthCheck_ThenThrows()
+    public async Task GivenNotInitializedAtExactBoundary_WhenCheckHealthAsync_ThenReturnsHealthyBackstop()
     {
-        Assert.Throws<ArgumentException>(() => CreateSut(TimeSpan.FromMilliseconds(2), TimeSpan.FromMilliseconds(1)));
-    }
-
-    [Fact]
-    public void GivenStartupDegradedDelayIsNegative_WhenCreatingHealthCheck_ThenThrows()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => CreateSut(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(1)));
-    }
-
-    [Fact]
-    public void GivenStorageInitializationTimeoutIsNegative_WhenCreatingHealthCheck_ThenThrows()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => CreateSut(TimeSpan.Zero, TimeSpan.FromMilliseconds(-1)));
-    }
-
-    [Fact]
-    public async Task GivenUnhealthyCMK_WhenCheckHealthAsyncAfter5Minutes_ThenChangedToDegraded()
-    {
-        using (Mock.Property(() => ClockResolver.TimeProvider, new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.Now.AddMinutes(5).AddSeconds(1))))
+        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.UtcNow);
+        using (Mock.Property(() => ClockResolver.TimeProvider, timeProvider))
         {
-            // Arrange
-            _databaseStatusReporter.IsCustomerManagerKeyProperlySetAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+            StorageInitializedHealthCheck sut = CreateSut(TimeSpan.FromMilliseconds(2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(2));
 
-            HealthCheckResult result = await _sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
-            Assert.Equal(HealthStatus.Degraded, result.Status);
-            Assert.Contains("The health of the store has degraded. Customer-managed key is not properly set.", result.Description);
+            HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
         }
     }
 
-    private StorageInitializedHealthCheck CreateSut(
-        TimeSpan? startupDegradedDelay = null,
-        TimeSpan? storageInitializationTimeout = null)
+    [Fact]
+    public async Task GivenConcurrentNotificationAndProbes_WhenCheckHealthAsync_ThenHandoffIsObserved()
+    {
+        StorageInitializedHealthCheck sut = CreateSut();
+        using var cts = new CancellationTokenSource();
+
+        Task reader = Task.Run(async () =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+            }
+        });
+
+        await sut.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+        HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+        cts.Cancel();
+        await reader;
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public void GivenDefaultConfiguration_ThenStorageInitializationTimeoutMatchesDocumentedInvariant()
+    {
+        // Guards the K8s-budget invariant: the documented app timeout is 5 minutes.
+        // If this default changes, the fhir-paas startup budget must be re-checked (must stay strictly greater).
+        Assert.Equal(TimeSpan.FromMinutes(5), new StorageInitializedHealthCheckConfiguration().StorageInitializationTimeout);
+    }
+
+    private static StorageInitializedHealthCheck CreateSut(TimeSpan? storageInitializationTimeout = null)
     {
         return new StorageInitializedHealthCheck(
-            _databaseStatusReporter,
             Options.Create(
                 new StorageInitializedHealthCheckConfiguration
                 {
-                    StartupDegradedDelay = startupDegradedDelay ?? TimeSpan.FromMinutes(1),
                     StorageInitializationTimeout = storageInitializationTimeout ?? TimeSpan.FromMinutes(5),
                 }));
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -97,6 +97,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\SecurityProviderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\SMART\SmartClinicalScopesMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Throttling\ThrottlingMiddlewareTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Registration\HealthCheckRegistrationTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Controllers\openid-configuration.json">

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -97,6 +97,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\SecurityProviderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\SMART\SmartClinicalScopesMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Throttling\ThrottlingMiddlewareTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Registration\HealthCheckEndpointTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Registration\HealthCheckRegistrationTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckEndpointTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckEndpointTests.cs
@@ -1,0 +1,107 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Api.Features.Health;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Registration;
+
+// These tests assert the aggregate HealthStatus each probe endpoint's predicate produces, using
+// HealthCheckService directly (no web host). ASP.NET Core's default status-code map then yields
+// Healthy/Degraded => HTTP 200 and Unhealthy => HTTP 503; the HTTP mapping itself is framework
+// behavior. The endpoint predicates below mirror UseFhirServer exactly.
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.Web)]
+public class HealthCheckEndpointTests
+{
+    private static readonly Func<HealthCheckRegistration, bool> CheckPredicate =
+        reg => !reg.Tags.Contains(HealthCheckTags.ProbeStartup);
+
+    private static readonly Func<HealthCheckRegistration, bool> StartupPredicate =
+        reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup);
+
+    private static readonly Func<HealthCheckRegistration, bool> ReadyPredicate =
+        reg => reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+
+    private static readonly Func<HealthCheckRegistration, bool> LivePredicate = _ => false;
+
+    private static async Task<HealthStatus> EvaluateAsync(
+        Func<HealthCheckRegistration, bool> predicate,
+        HealthStatus startupStatus,
+        HealthStatus dataStoreStatus)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHealthChecks()
+            .AddCheck("StorageInitializedHealthCheck", new FixedCheck(startupStatus), tags: new[] { HealthCheckTags.ProbeStartup })
+            .AddCheck(HealthCheckTags.DataStoreHealthCheckName, new FixedCheck(dataStoreStatus), tags: new[] { HealthCheckTags.ProbeReadiness })
+            .AddCheck("BehaviorHealthCheck", new FixedCheck(HealthStatus.Healthy), tags: new[] { HealthCheckTags.ProbeReadiness });
+
+        HealthCheckService service = services.BuildServiceProvider().GetRequiredService<HealthCheckService>();
+        HealthReport report = await service.CheckHealthAsync(predicate, CancellationToken.None);
+        return report.Status;
+    }
+
+    [Fact]
+    public async Task GivenInitializingStartup_WhenEvaluatingStartup_ThenUnhealthy_MapsTo503()
+    {
+        HealthStatus status = await EvaluateAsync(StartupPredicate, HealthStatus.Unhealthy, HealthStatus.Healthy);
+        Assert.Equal(HealthStatus.Unhealthy, status);
+    }
+
+    [Fact]
+    public async Task GivenInitializedStartup_WhenEvaluatingStartup_ThenHealthy_MapsTo200()
+    {
+        HealthStatus status = await EvaluateAsync(StartupPredicate, HealthStatus.Healthy, HealthStatus.Healthy);
+        Assert.Equal(HealthStatus.Healthy, status);
+    }
+
+    [Fact]
+    public async Task GivenDegradedDataStore_WhenEvaluatingReady_ThenDegraded_MapsTo200_StaysRoutable()
+    {
+        HealthStatus status = await EvaluateAsync(ReadyPredicate, HealthStatus.Healthy, HealthStatus.Degraded);
+        Assert.Equal(HealthStatus.Degraded, status);
+    }
+
+    [Fact]
+    public async Task GivenUnhealthyDataStore_WhenEvaluatingReady_ThenUnhealthy_MapsTo503()
+    {
+        HealthStatus status = await EvaluateAsync(ReadyPredicate, HealthStatus.Healthy, HealthStatus.Unhealthy);
+        Assert.Equal(HealthStatus.Unhealthy, status);
+    }
+
+    [Fact]
+    public async Task GivenAnyState_WhenEvaluatingLive_ThenHealthy_MapsTo200()
+    {
+        HealthStatus status = await EvaluateAsync(LivePredicate, HealthStatus.Unhealthy, HealthStatus.Unhealthy);
+        Assert.Equal(HealthStatus.Healthy, status);
+    }
+
+    [Fact]
+    public async Task GivenInitializingStartup_WhenEvaluatingCheck_ThenStartupExcluded_Healthy_MapsTo200()
+    {
+        // /health/check excludes probe:startup, so an initializing pod with a reachable DB is Healthy => 200.
+        HealthStatus status = await EvaluateAsync(CheckPredicate, HealthStatus.Unhealthy, HealthStatus.Healthy);
+        Assert.Equal(HealthStatus.Healthy, status);
+    }
+
+    private sealed class FixedCheck : IHealthCheck
+    {
+        private readonly HealthStatus _status;
+
+        public FixedCheck(HealthStatus status) => _status = status;
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(new HealthCheckResult(_status));
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckEndpointTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckEndpointTests.cs
@@ -19,21 +19,19 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Registration;
 // These tests assert the aggregate HealthStatus each probe endpoint's predicate produces, using
 // HealthCheckService directly (no web host). ASP.NET Core's default status-code map then yields
 // Healthy/Degraded => HTTP 200 and Unhealthy => HTTP 503; the HTTP mapping itself is framework
-// behavior. The endpoint predicates below mirror UseFhirServer exactly.
+// behavior. The predicates below are the SAME production delegates UseFhirServer maps onto the
+// endpoints, so a routing change in HealthProbePredicates cannot drift away from this coverage.
 [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
 [Trait(Traits.Category, Categories.Web)]
 public class HealthCheckEndpointTests
 {
-    private static readonly Func<HealthCheckRegistration, bool> CheckPredicate =
-        reg => !reg.Tags.Contains(HealthCheckTags.ProbeStartup);
+    private static readonly Func<HealthCheckRegistration, bool> CheckPredicate = HealthProbePredicates.Diagnostic(null);
 
-    private static readonly Func<HealthCheckRegistration, bool> StartupPredicate =
-        reg => reg.Tags.Contains(HealthCheckTags.ProbeStartup);
+    private static readonly Func<HealthCheckRegistration, bool> StartupPredicate = HealthProbePredicates.Startup;
 
-    private static readonly Func<HealthCheckRegistration, bool> ReadyPredicate =
-        reg => reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+    private static readonly Func<HealthCheckRegistration, bool> ReadyPredicate = HealthProbePredicates.Readiness;
 
-    private static readonly Func<HealthCheckRegistration, bool> LivePredicate = _ => false;
+    private static readonly Func<HealthCheckRegistration, bool> LivePredicate = HealthProbePredicates.Live;
 
     private static async Task<HealthStatus> EvaluateAsync(
         Func<HealthCheckRegistration, bool> predicate,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckRegistrationTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckRegistrationTests.cs
@@ -1,0 +1,74 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Api.Features.Health;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Registration;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.Web)]
+public class HealthCheckRegistrationTests
+{
+    private static bool Readiness(HealthCheckRegistration reg) =>
+        reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+
+    [Fact]
+    public void GivenSqlDataStoreTag_WhenResolvingReadiness_ThenExactlyOneDataStoreCheck()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddCheck<StubCheck>(HealthCheckTags.DataStoreHealthCheckName, tags: new[] { HealthCheckTags.DataStoreSqlServer })
+            .AddCheck<StubCheck>("BehaviorHealthCheck", tags: new[] { HealthCheckTags.ProbeReadiness })
+            .AddCheck<StubCheck>("StorageInitializedHealthCheck", tags: new[] { HealthCheckTags.ProbeStartup });
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        int dataStoreCount = options.Registrations.Count(r => Readiness(r) && r.Name == HealthCheckTags.DataStoreHealthCheckName);
+        Assert.Equal(1, dataStoreCount);
+        Assert.Equal(1, options.Registrations.Count(r => r.Tags.Contains(HealthCheckTags.ProbeStartup)));
+    }
+
+    [Fact]
+    public void GivenCosmosReadinessTag_WhenResolvingReadiness_ThenExactlyOneDataStoreCheck()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddCheck<StubCheck>(HealthCheckTags.DataStoreHealthCheckName, tags: new[] { HealthCheckTags.ProbeReadiness })
+            .AddCheck<StubCheck>("BehaviorHealthCheck", tags: new[] { HealthCheckTags.ProbeReadiness })
+            .AddCheck<StubCheck>("StorageInitializedHealthCheck", tags: new[] { HealthCheckTags.ProbeStartup });
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Equal(1, options.Registrations.Count(r => Readiness(r) && r.Name == HealthCheckTags.DataStoreHealthCheckName));
+    }
+
+    [Fact]
+    public void GivenMissingDataStoreTag_WhenResolvingReadiness_ThenZeroDataStoreChecks()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks()
+            .AddCheck<StubCheck>(HealthCheckTags.DataStoreHealthCheckName) // no tag => package-skew simulation
+            .AddCheck<StubCheck>("StorageInitializedHealthCheck", tags: new[] { HealthCheckTags.ProbeStartup });
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Equal(0, options.Registrations.Count(r => Readiness(r) && r.Name == HealthCheckTags.DataStoreHealthCheckName));
+    }
+
+    private sealed class StubCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(HealthCheckResult.Healthy());
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckRegistrationTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Registration/HealthCheckRegistrationTests.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Registration;
 [Trait(Traits.Category, Categories.Web)]
 public class HealthCheckRegistrationTests
 {
-    private static bool Readiness(HealthCheckRegistration reg) =>
-        reg.Tags.Contains(HealthCheckTags.DataStoreSqlServer) || reg.Tags.Contains(HealthCheckTags.ProbeReadiness);
+    // Uses the production readiness predicate so this coverage tracks UseFhirServer / the startup assertion.
+    private static bool Readiness(HealthCheckRegistration reg) => HealthProbePredicates.Readiness(reg);
 
     [Fact]
     public void GivenSqlDataStoreTag_WhenResolvingReadiness_ThenExactlyOneDataStoreCheck()

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -193,7 +193,9 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .AsService<IHealthCheck>()
                 .AsService<INotificationHandler<ImproperBehaviorNotification>>();
 
-            services.AddHealthChecks().AddCheck<ImproperBehaviorHealthCheck>(name: "BehaviorHealthCheck");
+            services.AddHealthChecks().AddCheck<ImproperBehaviorHealthCheck>(
+                name: "BehaviorHealthCheck",
+                tags: new[] { HealthCheckTags.ProbeReadiness });
 
             // Registers a health check to ensure storage gets initialized
             services.RemoveServiceTypeExact<StorageInitializedHealthCheck, INotificationHandler<SearchParametersInitializedNotification>>()
@@ -203,7 +205,9 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .AsService<IHealthCheck>()
                 .AsService<INotificationHandler<SearchParametersInitializedNotification>>();
 
-            services.AddHealthChecks().AddCheck<StorageInitializedHealthCheck>(name: "StorageInitializedHealthCheck");
+            services.AddHealthChecks().AddCheck<StorageInitializedHealthCheck>(
+                name: "StorageInitializedHealthCheck",
+                tags: new[] { HealthCheckTags.ProbeStartup });
 
             services.AddLazy();
             services.AddScoped();

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -81,8 +81,12 @@ namespace Microsoft.Health.Fhir.Web
                 .AddMemberMatch();
 
             services.AddDevelopmentIdentityProvider(Configuration);
-            services.Configure<StorageInitializedHealthCheckConfiguration>(
-                Configuration.GetSection(StorageInitializedHealthCheckConfiguration.SectionName));
+            services.AddOptions<StorageInitializedHealthCheckConfiguration>()
+                .Bind(Configuration.GetSection(StorageInitializedHealthCheckConfiguration.SectionName))
+                .Validate(
+                    c => c.StorageInitializationTimeout >= TimeSpan.Zero,
+                    $"{nameof(StorageInitializedHealthCheckConfiguration.StorageInitializationTimeout)} must be non-negative.")
+                .ValidateOnStart();
 
             // Set the runtime configuration for the up and running service.
             IFhirRuntimeConfiguration runtimeConfiguration = AddRuntimeConfiguration(Configuration, fhirServerBuilder);

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.BackgroundJobService;
+using Microsoft.Health.Fhir.Api.Features.Health;
 using Microsoft.Health.Fhir.Api.Modules;
 using Microsoft.Health.Fhir.Api.OpenIddict.Extensions;
 using Microsoft.Health.Fhir.Api.OpenIddict.FeatureProviders;
@@ -80,6 +81,8 @@ namespace Microsoft.Health.Fhir.Web
                 .AddMemberMatch();
 
             services.AddDevelopmentIdentityProvider(Configuration);
+            services.Configure<StorageInitializedHealthCheckConfiguration>(
+                Configuration.GetSection(StorageInitializedHealthCheckConfiguration.SectionName));
 
             // Set the runtime configuration for the up and running service.
             IFhirRuntimeConfiguration runtimeConfiguration = AddRuntimeConfiguration(Configuration, fhirServerBuilder);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchParameterInitializationTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Theory]
         [InlineData(DataStore.SqlServer)]
         [InlineData(DataStore.CosmosDb)]
-        public async Task GivenDefinitionStageFailure_WhenServerStarts_ThenHealthCheckReportsDegraded(DataStore dataStore)
+        public async Task GivenDefinitionStageFailure_WhenServerStarts_ThenHealthCheckReportsUnhealthy(DataStore dataStore)
         {
             await ExecuteAsync<StartupWithDefinitionInitializationFailure>(
                 dataStore,
@@ -46,18 +46,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 {
                     (HttpStatusCode statusCode, string responseContent) = await WaitForNonHealthyStatusAsync(httpClient, PollTimeout, PollInterval);
 
-                    Assert.Equal(HttpStatusCode.OK, statusCode);
+                    Assert.Equal(HttpStatusCode.ServiceUnavailable, statusCode);
 
                     string detailStatus = GetDetailStatus(responseContent, "StorageInitializedHealthCheck");
                     Assert.NotNull(detailStatus);
-                    Assert.Equal("Degraded", detailStatus);
+                    Assert.Equal("Unhealthy", detailStatus);
                 });
         }
 
         [Theory]
         [InlineData(DataStore.SqlServer)]
         [InlineData(DataStore.CosmosDb)]
-        public async Task GivenStatusStageFailure_WhenServerStarts_ThenHealthCheckReportsDegraded(DataStore dataStore)
+        public async Task GivenStatusStageFailure_WhenServerStarts_ThenHealthCheckReportsUnhealthy(DataStore dataStore)
         {
             await ExecuteAsync<StartupWithStatusInitializationFailure>(
                 dataStore,
@@ -65,11 +65,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 {
                     (HttpStatusCode statusCode, string responseContent) = await WaitForNonHealthyStatusAsync(httpClient, PollTimeout, PollInterval);
 
-                    Assert.Equal(HttpStatusCode.OK, statusCode);
+                    Assert.Equal(HttpStatusCode.ServiceUnavailable, statusCode);
 
                     string detailStatus = GetDetailStatus(responseContent, "StorageInitializedHealthCheck");
                     Assert.NotNull(detailStatus);
-                    Assert.Equal("Degraded", detailStatus);
+                    Assert.Equal("Unhealthy", detailStatus);
                 });
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchParameterInitializationTests.cs
@@ -19,12 +19,14 @@ using Xunit;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
     /// <summary>
-    /// E2E tests that validate the server health check correctly reflects search parameter
-    /// initialization failures. The initialization chain is:
+    /// E2E tests that validate the startup probe (<c>health/startup</c>) correctly reflects search
+    /// parameter initialization failures. The initialization chain is:
     /// 1. StorageInitializedNotification → SearchParameterDefinitionManager.EnsureInitializedAsync
     /// 2. SearchParameterDefinitionManagerInitialized → SearchParameterStatusManager.EnsureInitializedAsync
     /// 3. SearchParametersInitializedNotification → StorageInitializedHealthCheck sets healthy
     ///
+    /// StorageInitializedHealthCheck is tagged <c>probe:startup</c> and is only surfaced by the
+    /// <c>health/startup</c> endpoint (it is explicitly excluded from <c>health/check</c>).
     /// Success-path health check validation is already covered by <see cref="Rest.HealthTests"/>.
     /// These tests focus on verifying that initialization failures are externally observable.
     /// </summary>
@@ -82,7 +84,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             while (stopwatch.Elapsed < timeout)
             {
-                using HttpResponseMessage response = await httpClient.GetAsync("health/check");
+                using HttpResponseMessage response = await httpClient.GetAsync("health/startup");
                 string content = await response.Content.ReadAsStringAsync();
                 string overallStatus = GetOverallStatus(content);
 
@@ -95,7 +97,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
 
             // Final attempt after timeout
-            using HttpResponseMessage finalResponse = await httpClient.GetAsync("health/check");
+            using HttpResponseMessage finalResponse = await httpClient.GetAsync("health/startup");
             string finalContent = await finalResponse.Content.ReadAsStringAsync();
             return (finalResponse.StatusCode, finalContent);
         }


### PR DESCRIPTION
## Description
Returns an unhealthy health check while storage initialization is incomplete, preventing Kubernetes from routing traffic before search parameters and the SQL FHIR model are ready.

## Related issues
[AB#197936](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/197936)

## Testing
- `dotnet test src\Microsoft.Health.Fhir.Api.UnitTests\Microsoft.Health.Fhir.R4.Api.UnitTests.csproj --no-restore --filter FullyQualifiedName~StorageInitializedHealthCheckTests`
- E2E readiness validation is delegated to the PR pipeline.

## FHIR Team Checklist
- [x] CI is green before merge

### Semver Change
Patch