### PR TITLE
Fix MSRC-128308: default ErrorOnMissingFhirUserClaim to true

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
 
         public string ExtensionFhirUserClaim { get; set; } = "extension_fhirUser";
 
-        public bool ErrorOnMissingFhirUserClaim { get; set; } = false;
+        // Default is true: a missing or invalid fhirUser claim for patient/user-context SMART scopes
+        // results in a 400 Bad Request rather than silently omitting the patient compartment filter.
+        // This prevents a token with patient/* scope but no fhirUser from behaving as a broader user/* scope.
+        // Set to false only when a deployment explicitly needs the legacy permissive behaviour.
+        public bool ErrorOnMissingFhirUserClaim { get; set; } = true;
 
         public bool EnableSmartWithoutAuth { get; set; } = false;
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -450,6 +450,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             fhirConfiguration.Security.Enabled = true;
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
             authorizationConfiguration.Enabled = true;
+
             // ErrorOnMissingFhirUserClaim is true by default — no explicit assignment needed.
             await LoadRoles(authorizationConfiguration);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             fhirConfiguration.Security.Enabled = true;
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
             authorizationConfiguration.Enabled = true;
-            authorizationConfiguration.ErrorOnMissingFhirUserClaim = true;
+            // ErrorOnMissingFhirUserClaim is true by default — no explicit assignment needed.
             await LoadRoles(authorizationConfiguration);
 
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");


### PR DESCRIPTION
## Description

A SMART token carrying a patient/ or user/ scope but no fhirUser claim previously bypassed patient-compartment enforcement because ErrorOnMissingFhirUserClaim defaulted to false.  SmartClinicalScopesMiddleware would silently skip compartment setup, leaving SearchOptionsFactory with ApplyFineGrainedAccessControl=true but no CompartmentId/CompartmentResourceType. The request was then evaluated by resource-type filter only, allowing cross-patient access to PHI.

Fix: change the default to true so that any deployment using the OSS server gets the secure behaviour without requiring explicit configuration.  The 400 Bad Request thrown by FhirUserClaimParser.ParseFhirUserClaim blocks the request before any resource data is accessed.

Deployments that intentionally rely on the permissive behaviour can restore it by setting FhirServer:Security:Authorization:ErrorOnMissingFhirUserClaim=false in their configuration.

The existing unit test GivenSmartDataAction_WhenFhirUserNotProvided_ThenBadRequest ExceptionThrown already covered the true-branch; the explicit assignment is removed since it now duplicates the default.

## Related issues
Addresses [AB198672](https://microsofthealth.visualstudio.com/Health/_workitems/edit/198672)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
