### PR TITLE
Update CreateBulkDeleteHandler to fix _lastUpdated parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/Handlers/CreateBulkDeleteHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/Handlers/CreateBulkDeleteHandler.cs
@@ -65,8 +65,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete.Handlers
             var searchParameters = new List<Tuple<string, string>>(request.ConditionalParameters);
 
             // Temporarily add _lastUpdated to the search parameters to mimic the behavior of the processing job. Conditional search will also fail if there are no search criteria.
-            var dateCurrent = new PartialDateTime(Clock.UtcNow);
-            searchParameters.Add(Tuple.Create("_lastUpdated", $"lt{dateCurrent}"));
+            var utcNowPlusOneDay = Clock.UtcNow.AddDays(1);
+            var lastUpdated = "lt" + utcNowPlusOneDay.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
+            searchParameters.Add(Tuple.Create("_lastUpdated", lastUpdated));
 
             // Should not run bulk delete if any of the search parameters are invalid as it can lead to unpredicatable results
             await _searchService.ConditionalSearchAsync(request.ResourceType, searchParameters, cancellationToken, count: 1, logger: _logger);


### PR DESCRIPTION
## Description
Update the value used for _lastUpdated to one compatible with the FHIR API allowing $bulk-delete endpoints to work with no parameters supplied per the [documentation](https://learn.microsoft.com/en-us/azure/healthcare-apis/fhir/fhir-bulk-delete).

## Related issues
Addresses [Bug 195219](https://microsofthealth.visualstudio.com/Health/_workitems/edit/195219): $bulk-delete doesn't work with no search parameters
Builds on code added in [PR #5609](https://github.com/microsoft/fhir-server/pull/5609)

## Testing
Comparing the API response when populating "_lastUpdated" with the value produced by original code versus the proposed code.

<img width="1122" height="491" alt="image" src="https://github.com/user-attachments/assets/9675664b-6255-47f6-9dad-cbb064c7638f" />

Before:
<img width="1216" height="729" alt="image" src="https://github.com/user-attachments/assets/3bb4b173-a95c-4595-9beb-97ab216c373c" />

After:
<img width="1445" height="816" alt="image" src="https://github.com/user-attachments/assets/707c563d-46df-480d-95c9-51ce697411d8" />

<img width="1453" height="575" alt="image" src="https://github.com/user-attachments/assets/ce43cb66-c3ef-4cdc-bbb8-5d5840cab62b" />




## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
