### PR TITLE
Return 400 for bulk-delete when no search criteria is specified

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
@@ -225,6 +225,36 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await _searchParameterOperations.DidNotReceive().EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>());
         }
 
+        [Fact]
+        public async Task GivenBulkDeleteWithNoSearchParameters_WhenRequested_ThenBadRequestIsReturned()
+        {
+            _httpRequest.QueryString.Returns(new QueryString(null));
+            var hardDeleteModel = new HardDeleteModel() { HardDelete = false };
+
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _controller.BulkDelete(hardDeleteModel, false, false));
+            await _mediator.DidNotReceiveWithAnyArgs().SendAsync<CreateBulkDeleteResponse>(default, default);
+        }
+
+        [Fact]
+        public async Task GivenBulkDeleteByResourceTypeWithNoSearchParameters_WhenRequested_ThenBadRequestIsReturned()
+        {
+            _httpRequest.QueryString.Returns(new QueryString(null));
+            var hardDeleteModel = new HardDeleteModel() { HardDelete = false };
+
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _controller.BulkDeleteByResourceType(KnownResourceTypes.Patient, hardDeleteModel, false, false));
+            await _mediator.DidNotReceiveWithAnyArgs().SendAsync<CreateBulkDeleteResponse>(default, default);
+        }
+
+        [Fact]
+        public async Task GivenBulkDeleteWithOnlyExcludedParameters_WhenRequested_ThenBadRequestIsReturned()
+        {
+            _httpRequest.QueryString.Returns(new QueryString("?hardDelete=true&purgeHistory=true"));
+            var hardDeleteModel = new HardDeleteModel() { HardDelete = true };
+
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _controller.BulkDelete(hardDeleteModel, false, false));
+            await _mediator.DidNotReceiveWithAnyArgs().SendAsync<CreateBulkDeleteResponse>(default, default);
+        }
+
         [Theory]
         [InlineData(0, HttpStatusCode.Accepted)]
         [InlineData(1, HttpStatusCode.OK)]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
@@ -140,6 +140,11 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             searchParameters = searchParameters.Where(param => !_excludedParameters.Contains(param.Item1)).ToList();
 
+            if (searchParameters.Count == 0)
+            {
+                throw new RequestNotValidException(Resources.ConditionalOperationNotSelectiveEnough);
+            }
+
             if (softDeleteCleanup && searchParameters.Any(param => param.Item1 != KnownQueryParameterNames.LastUpdated))
             {
                 throw new RequestNotValidException(string.Format(Resources.UnsupportedParameter, searchParameters.Where(param => param.Item1 != KnownQueryParameterNames.LastUpdated).Select(param => param.Item1).Aggregate((param, next) => param += ", " + next)));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -100,6 +100,23 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [SkippableFact]
+        [Trait(Traits.Category, Categories.IndexAndReindex)]
+        public async Task GivenBulkDeleteRequestWithNoSearchParameters_WhenRequested_ThenBadRequestIsReturned()
+        {
+            CheckBulkDeleteEnabled();
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Delete,
+                RequestUri = new Uri(_httpClient.BaseAddress, "$bulk-delete"),
+            };
+            request.Headers.Add(KnownHeaders.Prefer, "respond-async");
+
+            var response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [SkippableFact]
         [Trait(Traits.Category, Categories.IndexAndReindex)] // temporarily moved till reindex conflict is moved to the storage layer
         public async Task GivenSoftBulkDeleteRequest_WhenCompleted_ThenHistoricalRecordsExist()
         {


### PR DESCRIPTION
## Description
Bulk delete with no selective search criteria is returning 500 instead of 400.
This PR validates the request and returns 400 in the absence of selective search criteria.

## Related issues
Addresses [issue #[198935](https://microsofthealth.visualstudio.com/Health/_workitems/edit/198935)].

## Testing
Unit tests and E2E tests
## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
