### PR TITLE
Fix to $bulk-update and $bulk-delete

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/Handlers/CreateBulkDeleteHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/Handlers/CreateBulkDeleteHandler.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete.Handlers
             var searchParameters = new List<Tuple<string, string>>(request.ConditionalParameters);
 
             // Temporarily add _lastUpdated to the search parameters to mimic the behavior of the processing job. Conditional search will also fail if there are no search criteria.
-            var dateCurrent = new PartialDateTime(Clock.UtcNow);
-            searchParameters.Add(Tuple.Create("_lastUpdated", $"lt{dateCurrent}"));
+            var dateCurrent = "lt" + Clock.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
+            searchParameters.Add(Tuple.Create("_lastUpdated", dateCurrent));
 
             // Should not run bulk delete if any of the search parameters are invalid as it can lead to unpredicatable results
             await _searchService.ConditionalSearchAsync(request.ResourceType, searchParameters, cancellationToken, count: 1, logger: _logger);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkUpdate/Handlers/CreateBulkUpdateHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkUpdate/Handlers/CreateBulkUpdateHandler.cs
@@ -89,8 +89,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkUpdate.Handlers
             var searchParameterCopy = searchParameters.Select(t => Tuple.Create(t.Item1, t.Item2)).ToList();
 
             // Temporarily add _lastUpdated to the search parameters to mimic the behavior of the processing job. Conditional search will also fail if there are no search criteria.
-            var dateCurrent = new PartialDateTime(Clock.UtcNow);
-            searchParameters.Add(Tuple.Create("_lastUpdated", $"lt{dateCurrent}"));
+            var dateCurrent = "lt" + Clock.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
+            searchParameters.Add(Tuple.Create("_lastUpdated", dateCurrent));
 
             // Should not run bulk Update if any of the search parameters are invalid as it can lead to unpredicatable results
             await _searchService.ConditionalSearchAsync(request.ResourceType, searchParameters, cancellationToken, count: 1, logger: _logger);


### PR DESCRIPTION
## Description
Updates the value used for _lastUpdated (when no parameters are supplied) to one compatible with the FHIR API allowing $bulk-delete endpoints to work as per the [documentation](https://learn.microsoft.com/en-us/azure/healthcare-apis/fhir/fhir-bulk-delete).

Applies same update to $bulk-update job creation.

## Related issues
Addresses [Bug 195219](https://microsofthealth.visualstudio.com/Health/_workitems/edit/195219): $bulk-delete does not work without search parameters present
Builds on code added in [PR #5609](https://github.com/microsoft/fhir-server/pull/5609)

## Testing
Comparing the API response when populating "_lastUpdated" with the value produced by original code versus the proposed code.

<img width="1310" height="367" alt="image" src="https://github.com/user-attachments/assets/7b1ec5b6-f551-4e6a-abf0-473c1c1e7663" />


Before:
<img width="1442" height="775" alt="image" src="https://github.com/user-attachments/assets/a8c0a94a-12db-4c1d-9e2a-9f173120aeae" />



After:
<img width="1423" height="636" alt="image" src="https://github.com/user-attachments/assets/5bcc3b63-4343-45c7-b4f5-34c4d2a95e6f" />

<img width="1424" height="761" alt="image" src="https://github.com/user-attachments/assets/f73bfc3a-cbab-44a2-89eb-27fbfa62934d" />

This approach was taken instead of changing PartialDateTime directly as that class is referenced in quite a few places.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
