### PR TITLE
Enable federated ACR convert-data E2E tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.5.0" />
+    <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.3.2" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -56,6 +56,7 @@ steps:
       'AllStorageAccounts': $(AllStorageAccounts)
       'TestExportStoreUri': $(TestExportStoreUri)
       'TestIntegrationStoreUri': $(TestIntegrationStoreUri)
+      'TestContainerRegistryServer': $(TestContainerRegistryServer)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
       'tenant-admin-service-principal-password': $(tenant-admin-service-principal-password)
       'tenant-admin-user-name': $(tenant-admin-user-name)

--- a/build/tasks/e2e-set-variables.yml
+++ b/build/tasks/e2e-set-variables.yml
@@ -124,6 +124,9 @@ steps:
             Write-Host "ACA convert-data registry server: $acrLoginServer"
             Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$acrLoginServer"
         }
+        else {
+            Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]"
+        }
 
         Write-Host "##vso[task.setvariable variable=Resource]$(TestApplicationResource)"
         Write-Host "##vso[task.setvariable variable=TestTokenEndpoint]https://login.microsoftonline.com/$(tenant-id-guid)/oauth2/token"

--- a/build/tasks/e2e-set-variables.yml
+++ b/build/tasks/e2e-set-variables.yml
@@ -122,6 +122,7 @@ steps:
 
         if (-not [string]::IsNullOrEmpty($acrLoginServer) -and $acrLoginServer -ne "null") {
             Write-Host "ACA convert-data registry server: $acrLoginServer"
+            Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$acrLoginServer"
         }
 
         Write-Host "##vso[task.setvariable variable=Resource]$(TestApplicationResource)"

--- a/samples/templates/aca/modules/fhir-common.bicep
+++ b/samples/templates/aca/modules/fhir-common.bicep
@@ -270,7 +270,7 @@ resource convertDataContainerRegistry 'Microsoft.ContainerRegistry/registries@20
 }
 
 resource convertDataAcrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (enableConvertData) {
-  name: guid(uniqueString('${convertDataAcrName}/AcrPull/${normalizedAppName}', resourceGroup().id))
+  name: guid(uniqueString('${convertDataAcrName}/AcrPull/${normalizedAppName}/${fhirVersion}', resourceGroup().id))
   scope: convertDataContainerRegistry
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')

--- a/samples/templates/aca/modules/fhir-common.bicep
+++ b/samples/templates/aca/modules/fhir-common.bicep
@@ -92,6 +92,11 @@ var keyVaultEndpoint = isMAG
 
 var enableIntegrationStore = enableExport || enableImport
 
+// Convert-data ACR naming: normalized app name (hyphens removed, max 11 chars) + uniqueString
+var convertDataAcrPrefix = substring(replace(normalizedAppName, '-', ''), 0, min(11, length(replace(normalizedAppName, '-', ''))))
+var convertDataAcrName = '${convertDataAcrPrefix}${uniqueString(resourceGroup().id, normalizedAppName)}'
+var acrUri = isMAG ? '.azurecr.us' : '.azurecr.io'
+
 var sharedEnvVars = [
   { name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED', value: 'true' }
   { name: 'KeyVault__Endpoint', value: keyVaultEndpoint }
@@ -106,7 +111,7 @@ var sharedEnvVars = [
   { name: 'FhirServer__Operations__Import__Enabled', value: enableImport ? 'true' : 'false' }
   { name: 'FhirServer__Operations__IntegrationDataStore__StorageAccountUri', value: enableImport ? storageAccountUri : 'null' }
   { name: 'FhirServer__Operations__ConvertData__Enabled', value: enableConvertData ? 'true' : 'false' }
-  { name: 'FhirServer__Operations__ConvertData__ContainerRegistryServers__0', value: enableConvertData ? registryName : 'null' }
+  { name: 'FhirServer__Operations__ConvertData__ContainerRegistryServers__0', value: enableConvertData ? '${convertDataAcrName}${acrUri}' : 'null' }
   { name: 'FhirServer__Operations__Reindex__Enabled', value: enableReindex ? 'true' : 'false' }
 ]
 
@@ -248,6 +253,27 @@ resource storageBlobDataContributorRole 'Microsoft.Authorization/roleAssignments
   scope: storageAccount
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+    principalId: containerApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource convertDataContainerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = if (enableConvertData) {
+  name: convertDataAcrName
+  location: resourceGroup().location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: false
+  }
+}
+
+resource convertDataAcrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (enableConvertData) {
+  name: guid(uniqueString('${convertDataAcrName}/AcrPull/${normalizedAppName}', resourceGroup().id))
+  scope: convertDataContainerRegistry
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
     principalId: containerApp.identity.principalId
     principalType: 'ServicePrincipal'
   }

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -17,6 +17,8 @@
   <ItemGroup>
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\Export\AnonymizedExportUsingAcrTests.cs" Link="Rest\Export\AnonymizedExportUsingAcrTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\Export\AnonymizedExportTests.cs" Link="Rest\Export\AnonymizedExportTests.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ConvertDataTestMode.cs" Link="Rest\ConvertDataTestMode.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ConvertDataTestModeTests.cs" Link="Rest\ConvertDataTestModeTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ConvertDataTests.cs" Link="Rest\ConvertDataTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ContainerRegistryTemplateUploader.cs" Link="Rest\ContainerRegistryTemplateUploader.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ContainerRegistryTemplateUploaderTests.cs" Link="Rest\ContainerRegistryTemplateUploaderTests.cs" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -18,6 +18,8 @@
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\Export\AnonymizedExportUsingAcrTests.cs" Link="Rest\Export\AnonymizedExportUsingAcrTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\Export\AnonymizedExportTests.cs" Link="Rest\Export\AnonymizedExportTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ConvertDataTests.cs" Link="Rest\ConvertDataTests.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ContainerRegistryTemplateUploader.cs" Link="Rest\ContainerRegistryTemplateUploader.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ContainerRegistryTemplateUploaderTests.cs" Link="Rest\ContainerRegistryTemplateUploaderTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\CustomConvertDataTests.cs" Link="Rest\CustomConvertDataTests.cs" />
   </ItemGroup>
 

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Containers.ContainerRegistry" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Azure.ContainerRegistry" />
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploader.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploader.cs
@@ -56,7 +56,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string configDigest = configResult.Value.Digest;
             long configSize = configResult.Value.SizeInBytes;
 
-            // Upload template layer blob
+            // Upload template layer blob — reset seekable streams to avoid silently truncated artifacts
+            if (templateLayer.CanSeek)
+            {
+                templateLayer.Position = 0;
+            }
+
             var layerResult = await _client.UploadBlobAsync(templateLayer, cancellationToken);
             string layerDigest = layerResult.Value.Digest;
             long layerSize = layerResult.Value.SizeInBytes;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploader.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploader.cs
@@ -1,0 +1,106 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Containers.ContainerRegistry;
+using Azure.Identity;
+using Microsoft.Health.Fhir.Tests.Common;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    internal sealed class ContainerRegistryTemplateUploader
+    {
+        private readonly ContainerRegistryContentClient _client;
+
+        public ContainerRegistryTemplateUploader(ContainerRegistryContentClient client, string registryServer)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentException.ThrowIfNullOrWhiteSpace(registryServer);
+
+            _client = client;
+            RegistryServer = registryServer;
+        }
+
+        public string RegistryServer { get; }
+
+        public static ContainerRegistryTemplateUploader CreateFromEnvironment(string repository, Func<string, string> getEnvironmentVariable = null)
+        {
+            getEnvironmentVariable ??= name => EnvironmentVariables.GetEnvironmentVariable(name);
+
+            string registryServer = GetRequiredVariable(getEnvironmentVariable, KnownEnvironmentVariableNames.TestContainerRegistryServer);
+            string tenantId = GetRequiredVariable(getEnvironmentVariable, KnownEnvironmentVariableNames.AzureSubscriptionTenantId);
+            string clientId = GetRequiredVariable(getEnvironmentVariable, KnownEnvironmentVariableNames.AzureSubscriptionClientId);
+            string serviceConnectionId = GetRequiredVariable(getEnvironmentVariable, KnownEnvironmentVariableNames.AzureSubscriptionServiceConnectionId);
+            string systemAccessToken = GetRequiredVariable(getEnvironmentVariable, KnownEnvironmentVariableNames.SystemAccessToken);
+
+            var credential = new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken);
+            var client = new ContainerRegistryContentClient(new Uri($"https://{registryServer}"), repository, credential);
+
+            return new ContainerRegistryTemplateUploader(client, registryServer);
+        }
+
+        public async Task UploadTemplateSetAsync(Stream templateLayer, string tag, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(templateLayer);
+            ArgumentException.ThrowIfNullOrWhiteSpace(tag);
+
+            // Upload empty config blob
+            using var configStream = new MemoryStream("{}"u8.ToArray());
+            var configResult = await _client.UploadBlobAsync(configStream, cancellationToken);
+            string configDigest = configResult.Value.Digest;
+            long configSize = configResult.Value.SizeInBytes;
+
+            // Upload template layer blob
+            var layerResult = await _client.UploadBlobAsync(templateLayer, cancellationToken);
+            string layerDigest = layerResult.Value.Digest;
+            long layerSize = layerResult.Value.SizeInBytes;
+
+            // Build and set manifest
+            BinaryData manifest = CreateManifest(configDigest, configSize, layerDigest, layerSize);
+            await _client.SetManifestAsync(manifest, tag, ManifestMediaType.OciImageManifest, cancellationToken);
+        }
+
+        internal static BinaryData CreateManifest(string configDigest, long configSize, string layerDigest, long layerSize)
+        {
+            var manifest = new
+            {
+                schemaVersion = 2,
+                config = new
+                {
+                    mediaType = "application/vnd.oci.image.config.v1+json",
+                    digest = configDigest,
+                    size = configSize,
+                },
+                layers = new[]
+                {
+                    new
+                    {
+                        mediaType = "application/vnd.oci.image.layer.v1.tar",
+                        digest = layerDigest,
+                        size = layerSize,
+                    },
+                },
+            };
+
+            string json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = false });
+            return BinaryData.FromString(json);
+        }
+
+        private static string GetRequiredVariable(Func<string, string> getEnvironmentVariable, string variableName)
+        {
+            string value = getEnvironmentVariable(variableName);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"Required environment variable '{variableName}' is not set or is empty.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploaderTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploaderTests.cs
@@ -90,9 +90,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var mockClient = Substitute.For<ContainerRegistryContentClient>();
             var uploader = new ContainerRegistryTemplateUploader(mockClient, "test.azurecr.io");
+            using var stream = new MemoryStream();
 
             await Assert.ThrowsAsync<ArgumentException>(
-                () => uploader.UploadTemplateSetAsync(new MemoryStream(), tag));
+                () => uploader.UploadTemplateSetAsync(stream, tag));
         }
 
         [Fact]
@@ -100,9 +101,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var mockClient = Substitute.For<ContainerRegistryContentClient>();
             var uploader = new ContainerRegistryTemplateUploader(mockClient, "test.azurecr.io");
+            using var stream = new MemoryStream();
 
             await Assert.ThrowsAsync<ArgumentNullException>(
-                () => uploader.UploadTemplateSetAsync(new MemoryStream(), null));
+                () => uploader.UploadTemplateSetAsync(stream, null));
         }
 
         [Fact]
@@ -176,7 +178,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 });
 
             // Act
-            await uploader.UploadTemplateSetAsync(new MemoryStream([1, 2, 3]), "v1");
+            using var stream = new MemoryStream([1, 2, 3]);
+            await uploader.UploadTemplateSetAsync(stream, "v1");
 
             // Assert
             Assert.NotNull(capturedManifest);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploaderTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploaderTests.cs
@@ -1,0 +1,115 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Containers.ContainerRegistry;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.CustomConvertData)]
+    public sealed class ContainerRegistryTemplateUploaderTests
+    {
+        public static IEnumerable<object[]> RequiredVariables =>
+            new List<object[]>
+            {
+                new object[] { KnownEnvironmentVariableNames.TestContainerRegistryServer },
+                new object[] { KnownEnvironmentVariableNames.AzureSubscriptionTenantId },
+                new object[] { KnownEnvironmentVariableNames.AzureSubscriptionClientId },
+                new object[] { KnownEnvironmentVariableNames.AzureSubscriptionServiceConnectionId },
+                new object[] { KnownEnvironmentVariableNames.SystemAccessToken },
+            };
+
+        [Theory]
+        [MemberData(nameof(RequiredVariables))]
+        public void CreateFromEnvironment_WhenRequiredVariableIsMissing_ThrowsInvalidOperationException(string missingVariable)
+        {
+            Func<string, string> getEnvVar = name =>
+                name == missingVariable ? string.Empty : "valid-value";
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => ContainerRegistryTemplateUploader.CreateFromEnvironment("test-repo", getEnvVar));
+
+            Assert.Contains(missingVariable, ex.Message);
+        }
+
+        [Fact]
+        public void CreateManifest_ReturnsValidOciManifestJson()
+        {
+            BinaryData result = ContainerRegistryTemplateUploader.CreateManifest("sha256:abc", 10L, "sha256:def", 500L);
+
+            using JsonDocument doc = JsonDocument.Parse(result.ToString());
+            JsonElement root = doc.RootElement;
+
+            Assert.Equal(2, root.GetProperty("schemaVersion").GetInt32());
+            Assert.Equal("application/vnd.oci.image.config.v1+json", root.GetProperty("config").GetProperty("mediaType").GetString());
+            Assert.Equal("sha256:abc", root.GetProperty("config").GetProperty("digest").GetString());
+            Assert.Equal(10, root.GetProperty("config").GetProperty("size").GetInt64());
+            Assert.Equal("application/vnd.oci.image.layer.v1.tar", root.GetProperty("layers")[0].GetProperty("mediaType").GetString());
+            Assert.Equal("sha256:def", root.GetProperty("layers")[0].GetProperty("digest").GetString());
+            Assert.Equal(500, root.GetProperty("layers")[0].GetProperty("size").GetInt64());
+        }
+
+        [Fact]
+        public void CreateManifest_ReturnsExactlyOneLayer()
+        {
+            BinaryData result = ContainerRegistryTemplateUploader.CreateManifest("sha256:abc", 10L, "sha256:def", 500L);
+
+            using JsonDocument doc = JsonDocument.Parse(result.ToString());
+            JsonElement layers = doc.RootElement.GetProperty("layers");
+
+            Assert.Equal(1, layers.GetArrayLength());
+        }
+
+        [Fact]
+        public async Task UploadTemplateSetAsync_WhenStreamIsNull_ThrowsArgumentNullException()
+        {
+            var mockClient = Substitute.For<ContainerRegistryContentClient>();
+            var uploader = new ContainerRegistryTemplateUploader(mockClient, "test.azurecr.io");
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => uploader.UploadTemplateSetAsync(null, "v1"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task UploadTemplateSetAsync_WhenTagIsNullOrEmpty_ThrowsArgumentException(string tag)
+        {
+            var mockClient = Substitute.For<ContainerRegistryContentClient>();
+            var uploader = new ContainerRegistryTemplateUploader(mockClient, "test.azurecr.io");
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => uploader.UploadTemplateSetAsync(new MemoryStream(), tag));
+        }
+
+        [Fact]
+        public async Task UploadTemplateSetAsync_WhenTagIsNull_ThrowsArgumentNullException()
+        {
+            var mockClient = Substitute.For<ContainerRegistryContentClient>();
+            var uploader = new ContainerRegistryTemplateUploader(mockClient, "test.azurecr.io");
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => uploader.UploadTemplateSetAsync(new MemoryStream(), null));
+        }
+
+        [Fact]
+        public void RegistryServer_ReturnsValuePassedToConstructor()
+        {
+            var mockClient = Substitute.For<ContainerRegistryContentClient>();
+            var uploader = new ContainerRegistryTemplateUploader(mockClient, "myregistry.azurecr.io");
+
+            Assert.Equal("myregistry.azurecr.io", uploader.RegistryServer);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploaderTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ContainerRegistryTemplateUploaderTests.cs
@@ -7,7 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Containers.ContainerRegistry;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
@@ -110,6 +112,80 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var uploader = new ContainerRegistryTemplateUploader(mockClient, "myregistry.azurecr.io");
 
             Assert.Equal("myregistry.azurecr.io", uploader.RegistryServer);
+        }
+
+        [Fact]
+        public async Task UploadTemplateSetAsync_WhenSeekableStreamPositionedAtEnd_ResetsPositionToZeroBeforeUpload()
+        {
+            // Arrange
+            var mockClient = Substitute.For<ContainerRegistryContentClient>();
+            var uploader = new ContainerRegistryTemplateUploader(mockClient, "test.azurecr.io");
+
+            byte[] data = [1, 2, 3, 4, 5];
+            using var stream = new MemoryStream(data);
+            stream.Position = data.Length; // deliberately positioned at end
+
+            long capturedLayerPosition = -1;
+            int uploadCallCount = 0;
+
+            mockClient.UploadBlobAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    uploadCallCount++;
+                    if (uploadCallCount == 2) // second call is the template layer
+                    {
+                        capturedLayerPosition = callInfo.Arg<Stream>().Position;
+                    }
+
+                    var result = ContainerRegistryModelFactory.UploadRegistryBlobResult("sha256:test", data.Length);
+                    return Task.FromResult(Response.FromValue(result, Substitute.For<Response>()));
+                });
+
+            // Act
+            await uploader.UploadTemplateSetAsync(stream, "v1");
+
+            // Assert
+            Assert.Equal(0L, capturedLayerPosition);
+        }
+
+        [Fact]
+        public async Task UploadTemplateSetAsync_PassesUploadResultDigestsAndSizesToSetManifest()
+        {
+            // Arrange
+            var mockClient = Substitute.For<ContainerRegistryContentClient>();
+            var uploader = new ContainerRegistryTemplateUploader(mockClient, "test.azurecr.io");
+
+            int uploadCallCount = 0;
+            mockClient.UploadBlobAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    uploadCallCount++;
+                    string digest = uploadCallCount == 1 ? "sha256:configdigest" : "sha256:layerdigest";
+                    long size = uploadCallCount == 1 ? 2L : 500L;
+                    var result = ContainerRegistryModelFactory.UploadRegistryBlobResult(digest, size);
+                    return Task.FromResult(Response.FromValue(result, Substitute.For<Response>()));
+                });
+
+            BinaryData capturedManifest = null;
+            mockClient.SetManifestAsync(Arg.Any<BinaryData>(), Arg.Any<string>(), Arg.Any<ManifestMediaType?>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    capturedManifest = callInfo.Arg<BinaryData>();
+                    var setResult = ContainerRegistryModelFactory.SetManifestResult("sha256:manifest");
+                    return Task.FromResult(Response.FromValue(setResult, Substitute.For<Response>()));
+                });
+
+            // Act
+            await uploader.UploadTemplateSetAsync(new MemoryStream([1, 2, 3]), "v1");
+
+            // Assert
+            Assert.NotNull(capturedManifest);
+            using JsonDocument doc = JsonDocument.Parse(capturedManifest.ToString());
+            JsonElement root = doc.RootElement;
+            Assert.Equal("sha256:configdigest", root.GetProperty("config").GetProperty("digest").GetString());
+            Assert.Equal(2L, root.GetProperty("config").GetProperty("size").GetInt64());
+            Assert.Equal("sha256:layerdigest", root.GetProperty("layers")[0].GetProperty("digest").GetString());
+            Assert.Equal(500L, root.GetProperty("layers")[0].GetProperty("size").GetInt64());
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTestMode.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTestMode.cs
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// Helper that determines whether convert-data tests should run given the current test environment.
+    /// </summary>
+    internal static class ConvertDataTestMode
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> when convert-data tests should execute.
+        /// Remote (deployed) servers always expose the feature, so tests run unconditionally.
+        /// In-process servers only run when the feature is explicitly enabled in configuration.
+        /// </summary>
+        /// <param name="isUsingInProcTestServer"><see langword="true"/> when the test is running against an in-process test server.</param>
+        /// <param name="configuredEnabled">The <c>Enabled</c> flag from <see cref="Microsoft.Health.Fhir.Core.Configs.ConvertDataConfiguration"/>.</param>
+        public static bool IsEnabled(bool isUsingInProcTestServer, bool configuredEnabled)
+            => !isUsingInProcTestServer || configuredEnabled;
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTestModeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTestModeTests.cs
@@ -1,0 +1,72 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.ConvertData)]
+    public sealed class ConvertDataTestModeTests
+    {
+        [Fact]
+        public void IsEnabled_WhenRemoteServer_ReturnsTrue_EvenIfConfiguredEnabledFalse()
+        {
+            // Arrange
+            bool isUsingInProcTestServer = false;
+            bool configuredEnabled = false;
+
+            // Act
+            bool result = ConvertDataTestMode.IsEnabled(isUsingInProcTestServer, configuredEnabled);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsEnabled_WhenRemoteServer_ReturnsTrue_WhenConfiguredEnabledTrue()
+        {
+            // Arrange
+            bool isUsingInProcTestServer = false;
+            bool configuredEnabled = true;
+
+            // Act
+            bool result = ConvertDataTestMode.IsEnabled(isUsingInProcTestServer, configuredEnabled);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsEnabled_WhenInProcServer_ReturnsFalse_WhenConfiguredEnabledFalse()
+        {
+            // Arrange
+            bool isUsingInProcTestServer = true;
+            bool configuredEnabled = false;
+
+            // Act
+            bool result = ConvertDataTestMode.IsEnabled(isUsingInProcTestServer, configuredEnabled);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsEnabled_WhenInProcServer_ReturnsTrue_WhenConfiguredEnabledTrue()
+        {
+            // Arrange
+            bool isUsingInProcTestServer = true;
+            bool configuredEnabled = true;
+
+            // Act
+            bool result = ConvertDataTestMode.IsEnabled(isUsingInProcTestServer, configuredEnabled);
+
+            // Assert
+            Assert.True(result);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             _testFhirClient = fixture.TestFhirClient;
             var convertDataConfiguration = ((IOptions<ConvertDataConfiguration>)(fixture.TestFhirServer as InProcTestFhirServer)?.Server?.Services?.GetService(typeof(IOptions<ConvertDataConfiguration>)))?.Value;
-            _convertDataEnabled = convertDataConfiguration?.Enabled ?? false;
+            _convertDataEnabled = ConvertDataTestMode.IsEnabled(fixture.IsUsingInProcTestServer, convertDataConfiguration?.Enabled ?? false);
         }
 
         [SkippableTheory]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             Skip.IfNot(_convertDataEnabled);
 
-            var parameters = GetConvertDataParams(Samples.SampleJsonMessage, "Json", JsonDefaultTemplateSetReference, "ExamplePatient");
+            var parameters = GetConvertDataParams(Samples.SampleJsonMessage, "Json", JsonDefaultTemplateSetReference, "ExamplePatient", treatDatesAsStrings: true);
             var requestMessage = GenerateConvertDataRequest(parameters);
             HttpResponseMessage response = await _testFhirClient.HttpClient.SendAsync(requestMessage);
 
@@ -331,7 +331,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             return request;
         }
 
-        private static Parameters GetConvertDataParams(string inputData, string inputDataType, string templateSetReference, string rootTemplate)
+        private static Parameters GetConvertDataParams(
+            string inputData,
+            string inputDataType,
+            string templateSetReference,
+            string rootTemplate,
+            bool? treatDatesAsStrings = null)
         {
             var parametersResource = new Parameters();
             parametersResource.Parameter = new List<Parameters.ParameterComponent>();
@@ -340,6 +345,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.InputDataType, Value = new FhirString(inputDataType) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.TemplateCollectionReference, Value = new FhirString(templateSetReference) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.RootTemplate, Value = new FhirString(rootTemplate) });
+
+            if (treatDatesAsStrings.HasValue)
+            {
+                parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.JsonDeserializationTreatDatesAsStrings, Value = new FhirBoolean(treatDatesAsStrings) });
+            }
 
             return parametersResource;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CustomConvertDataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CustomConvertDataTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -9,15 +9,10 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Serialization;
-using Microsoft.Azure.ContainerRegistry;
-using Microsoft.Azure.ContainerRegistry.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -26,7 +21,6 @@ using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Test.Utilities;
-using Microsoft.Rest;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -45,26 +39,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         private const string TestRepositoryTag = "test1.0";
 
         private readonly TestFhirClient _testFhirClient;
-        private readonly ConvertDataConfiguration _convertDataConfiguration;
+        private readonly bool _isUsingInProcTestServer;
 
         public CustomConvertDataTests(HttpIntegrationTestFixture fixture)
         {
             _testFhirClient = fixture.TestFhirClient;
-            _convertDataConfiguration = ((IOptions<ConvertDataConfiguration>)(fixture.TestFhirServer as InProcTestFhirServer)?.Server?.Services?.GetService(typeof(IOptions<ConvertDataConfiguration>)))?.Value;
+            _isUsingInProcTestServer = fixture.IsUsingInProcTestServer;
         }
 
         [SkippableFact]
         public async Task GivenAValidRequestWithCustomizedTemplateSet_WhenConvertData_CorrectResponseShouldReturn()
         {
-            var registry = GetTestContainerRegistryInfo();
+            // Here we skip local E2E test since there is no ACR emulator for in-process tests.
+            Skip.If(_isUsingInProcTestServer);
 
-            // Here we skip local E2E test since we need Managed Identity for container registry token.
-            // We also skip the case when environmental variable is not provided (not able to upload templates)
-            Skip.If(_convertDataConfiguration != null || registry == null);
+            var uploader = ContainerRegistryTemplateUploader.CreateFromEnvironment(TestRepositoryName);
+            await PushTemplateSet(uploader, TestRepositoryTag);
 
-            await PushTemplateSet(registry, TestRepositoryName, TestRepositoryTag);
-
-            var parameters = GetConvertDataParams(Samples.SampleHl7v2Message, "hl7v2", $"{registry.Server}/{TestRepositoryName}:{TestRepositoryTag}", "ADT_A01");
+            var imageReference = $"{uploader.RegistryServer}/{TestRepositoryName}:{TestRepositoryTag}";
+            var parameters = GetConvertDataParams(Samples.SampleHl7v2Message, "hl7v2", imageReference, "ADT_A01");
             var requestMessage = GenerateConvertDataRequest(parameters);
             HttpResponseMessage response = await _testFhirClient.HttpClient.SendAsync(requestMessage);
 
@@ -87,15 +80,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [InlineData("template@sha256:592535ef52d742f81e35f4d87b43d9b535ed56cf58c90a14fc5fd7ea0fbb8695")]
         public async Task GivenAValidRequest_ButTemplateSetIsNotFound_WhenConvertData_ShouldReturnError(string imageReference)
         {
-            var registry = GetTestContainerRegistryInfo();
+            // Here we skip local E2E test since there is no ACR emulator for in-process tests.
+            Skip.If(_isUsingInProcTestServer);
 
-            // Here we skip local E2E test since we need Managed Identity for container registry token.
-            // We also skip the case when environmental variable is not provided (not able to upload templates)
-            Skip.If(_convertDataConfiguration != null || registry == null);
+            var uploader = ContainerRegistryTemplateUploader.CreateFromEnvironment(TestRepositoryName);
+            await PushTemplateSet(uploader, TestRepositoryTag);
 
-            await PushTemplateSet(registry, TestRepositoryName, TestRepositoryTag);
-
-            var parameters = GetConvertDataParams(Samples.SampleHl7v2Message, "hl7v2", $"{registry.Server}/{imageReference}", "ADT_A01");
+            var parameters = GetConvertDataParams(Samples.SampleHl7v2Message, "hl7v2", $"{uploader.RegistryServer}/{imageReference}", "ADT_A01");
 
             var requestMessage = GenerateConvertDataRequest(parameters);
             HttpResponseMessage response = await _testFhirClient.HttpClient.SendAsync(requestMessage);
@@ -105,77 +96,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Contains($"Image Not Found.", responseContent);
         }
 
-        private ContainerRegistryInfo GetTestContainerRegistryInfo()
+        private static async Task PushTemplateSet(ContainerRegistryTemplateUploader uploader, string tag)
         {
-            var containerRegistry = new ContainerRegistryInfo
-            {
-                Server = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer),
-                Username = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer)?.Split('.')[0],
-                Password = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryPassword),
-            };
-
-            if (string.IsNullOrEmpty(containerRegistry.Server) || string.IsNullOrEmpty(containerRegistry.Password))
-            {
-                return null;
-            }
-
-            return containerRegistry;
-        }
-
-        private async Task PushTemplateSet(ContainerRegistryInfo registry, string repository, string tag)
-        {
-            AzureContainerRegistryClient acrClient = new AzureContainerRegistryClient(registry.Server, new AcrBasicToken(registry));
-
-            int schemaV2 = 2;
-            string mediatypeV2Manifest = "application/vnd.docker.distribution.manifest.v2+json";
-            string mediatypeV1Manifest = "application/vnd.oci.image.config.v1+json";
-            string emptyConfigStr = "{}";
-
-            // Upload config blob
-            byte[] originalConfigBytes = Encoding.UTF8.GetBytes(emptyConfigStr);
-            using var originalConfigStream = new MemoryStream(originalConfigBytes);
-            string originalConfigDigest = ComputeDigest(originalConfigStream);
-            await UploadBlob(acrClient, originalConfigStream, repository, originalConfigDigest);
-
-            // Upload memory blob
-            var defaultTemplateResourceName = $"{typeof(OciFileManager).Namespace}.Hl7v2DefaultTemplates.tar.gz";
-            using Stream byteStream = typeof(OciFileManager).Assembly.GetManifestResourceStream(defaultTemplateResourceName);
-            var blobLength = byteStream.Length;
-            string blobDigest = ComputeDigest(byteStream);
-            await UploadBlob(acrClient, byteStream, repository, blobDigest);
-
-            // Push manifest
-            List<Descriptor> layers = new List<Descriptor>
-            {
-                new Descriptor("application/vnd.oci.image.layer.v1.tar", blobLength, blobDigest),
-            };
-            var v2Manifest = new V2Manifest(schemaV2, mediatypeV2Manifest, new Descriptor(mediatypeV1Manifest, originalConfigBytes.Length, originalConfigDigest), layers);
-            await acrClient.Manifests.CreateAsync(repository, tag, v2Manifest);
-        }
-
-        private async Task UploadBlob(AzureContainerRegistryClient acrClient, Stream stream, string repository, string digest)
-        {
-            stream.Position = 0;
-            var uploadInfo = await acrClient.Blob.StartUploadAsync(repository);
-            var uploadedLayer = await acrClient.Blob.UploadAsync(stream, uploadInfo.Location);
-            await acrClient.Blob.EndUploadAsync(digest, uploadedLayer.Location);
-        }
-
-        private static string ComputeDigest(Stream s)
-        {
-            s.Position = 0;
-            StringBuilder sb = new StringBuilder();
-
-            using (var hash = SHA256.Create())
-            {
-                byte[] result = hash.ComputeHash(s);
-                foreach (byte b in result)
-                {
-                    sb.Append(b.ToString("x2"));
-                }
-            }
-
-            return "sha256:" + sb.ToString();
+            var resourceName = $"{typeof(OciFileManager).Namespace}.Hl7v2DefaultTemplates.tar.gz";
+            using Stream stream = typeof(OciFileManager).Assembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found.");
+            await uploader.UploadTemplateSetAsync(stream, tag);
         }
 
         private HttpRequestMessage GenerateConvertDataRequest(
@@ -207,37 +133,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.RootTemplate, Value = new FhirString(rootTemplate) });
 
             return parametersResource;
-        }
-
-        internal class ContainerRegistryInfo
-        {
-            public string Server { get; set; }
-
-            public string Username { get; set; }
-
-            public string Password { get; set; }
-        }
-
-        internal class AcrBasicToken : ServiceClientCredentials
-        {
-            private ContainerRegistryInfo _registry;
-
-            public AcrBasicToken(ContainerRegistryInfo registry)
-            {
-                _registry = registry;
-            }
-
-            public override void InitializeServiceClient<T>(ServiceClient<T> client)
-            {
-                base.InitializeServiceClient(client);
-            }
-
-            public override Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                var basicToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_registry.Username}:{_registry.Password}"));
-                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicToken);
-                return base.ProcessHttpRequestAsync(request, cancellationToken);
-            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CustomConvertDataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CustomConvertDataTests.cs
@@ -9,12 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Serialization;
-using Microsoft.Extensions.Options;
-using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.TemplateManagement;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -27,8 +24,11 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     /// <summary>
-    /// Tests using customized template set will not run without extra container registry info
-    /// since there is no acr emulator.
+    /// Tests using a customized template set uploaded to Azure Container Registry.
+    /// Remote runs require federated ACR configuration via environment variables consumed by
+    /// <see cref="ContainerRegistryTemplateUploader.CreateFromEnvironment"/>; missing configuration
+    /// is a hard failure, not a skip.  Tests are skipped only when running against an in-process
+    /// test server because no ACR emulator is available in that environment.
     /// </summary>
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.CustomConvertData)]


### PR DESCRIPTION
## Summary
- restore the admin-disabled per-environment ACR for ACA convert-data test artifacts while keeping the shared application-image registry pull-only
- upload custom template artifacts with Azure Pipelines workload identity and the modern ACR SDK
- re-enable R4 SQL/Cosmos `$convert-data` E2E coverage and pass the deployed registry server through the shared pipeline

## Validation
- ACA SQL and Cosmos Bicep templates compile
- R4 E2E project builds with 0 warnings/errors
- 18 focused uploader and test-mode tests pass

[AB#194418](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/194418)

Addresses the OSS portion of the user story. PaaS changes are out of scope.