### PR TITLE
Enable remote SMART export tests

### DIFF
--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -52,6 +52,8 @@ steps:
       'TestEnvironmentUrl_Sql': $(TestEnvironmentUrl_Sql)
       'TestEnvironmentUrl_${{ parameters.version }}_Sql': $(TestEnvironmentUrl_${{ parameters.version }}_Sql)
       'TestTokenEndpoint': $(TestTokenEndpoint)
+      'TestSmartTokenIssuer': $(TestSmartTokenIssuer)
+      'TestSmartTokenPrivateKey': $(TestSmartTokenPrivateKey)
       'Resource': $(Resource)
       'AllStorageAccounts': $(AllStorageAccounts)
       'TestExportStoreUri': $(TestExportStoreUri)

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -64,6 +64,7 @@ jobs:
         -AcaEnvironmentName "${{ parameters.acaEnvironmentName }}"
         -ResourceGroup "${{ parameters.resourceGroup }}"
         -KeyVaultName "${{ parameters.keyVaultName }}"
+        -TestKeyVaultName "$(KeyVaultBaseName)-ts"
         -ImageTag "${{ parameters.imageTag }}"
         -TestEnvironmentUrl "${{ parameters.testEnvironmentUrl }}"
         -WorkingDirectory "$(System.DefaultWorkingDirectory)"

--- a/build/jobs/run-export-tests.yml
+++ b/build/jobs/run-export-tests.yml
@@ -64,7 +64,8 @@ jobs:
             {
                 throw "$($secret.Name) is empty"
             }
-            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($plainValue)"
+            $secretFlag = if ($secret.Name -in @('TestSmartTokenPrivateKey', 'TestSmartTokenIssuer')) { ';issecret=true' } else { '' }
+            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)$secretFlag]$($plainValue)"
         }
 
 
@@ -83,7 +84,8 @@ jobs:
             {
                 throw "$($secret.Name) is empty"
             }
-            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($plainValue)"
+            $secretFlag = if ($secret.Name -in @('TestSmartTokenPrivateKey', 'TestSmartTokenIssuer')) { ';issecret=true' } else { '' }
+            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)$secretFlag]$($plainValue)"
         }
         # ----------------------------------------
 
@@ -114,6 +116,8 @@ jobs:
     env:
       'TestEnvironmentUrl': $(TestEnvironmentUrl)
       'TestEnvironmentUrl_${{ parameters.version }}': $(TestEnvironmentUrl_${{ parameters.version }})
+      'TestSmartTokenIssuer': $(TestSmartTokenIssuer)
+      'TestSmartTokenPrivateKey': $(TestSmartTokenPrivateKey)
       'Resource': $(Resource)
       'AllStorageAccounts': $(AllStorageAccounts)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
@@ -256,6 +260,8 @@ jobs:
     env:
       'TestEnvironmentUrl_Sql': $(TestEnvironmentUrl_Sql)
       'TestEnvironmentUrl_${{ parameters.version }}_Sql': $(TestEnvironmentUrl_${{ parameters.version }}_Sql)
+      'TestSmartTokenIssuer': $(TestSmartTokenIssuer)
+      'TestSmartTokenPrivateKey': $(TestSmartTokenPrivateKey)
       'Resource': $(Resource)
       'AllStorageAccounts': $(AllStorageAccounts)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)

--- a/build/jobs/scripts/Provision-AcaDeploy.ps1
+++ b/build/jobs/scripts/Provision-AcaDeploy.ps1
@@ -62,7 +62,7 @@ $testConfig = ConvertFrom-Json (Get-Content -Raw "$deployPath/testconfiguration.
 $flattenedTestConfig = & "$WorkingDirectory/release/scripts/PowerShell/ConvertTo-FlattenedConfigurationHashtable.ps1" -InputObject $testConfig
 
 $smartIdpDeployment = New-AzResourceGroupDeployment `
-    -Name 'test-smart-idp' `
+    -Name "test-smart-idp-$WebAppName" `
     -ResourceGroupName $ResourceGroup `
     -TemplateFile "$WorkingDirectory/samples/templates/aca/test-smart-idp.bicep" `
     -ErrorAction Stop

--- a/build/jobs/scripts/Provision-AcaDeploy.ps1
+++ b/build/jobs/scripts/Provision-AcaDeploy.ps1
@@ -69,7 +69,7 @@ $smartIdpDeployment = New-AzResourceGroupDeployment `
 
 $smartIdpIssuer = & "$WorkingDirectory/build/jobs/scripts/Provision-TestSmartIdp.ps1" `
     -KeyVaultName $TestKeyVaultName `
-    -Issuer $smartIdpDeployment.Outputs.issuer.Value `
+    -ResourceGroupName $ResourceGroup `
     -StorageAccountName $smartIdpDeployment.Outputs.storageAccountName.Value
 
 if ([string]::IsNullOrWhiteSpace($smartIdpIssuer)) {

--- a/build/jobs/scripts/Provision-AcaDeploy.ps1
+++ b/build/jobs/scripts/Provision-AcaDeploy.ps1
@@ -19,6 +19,7 @@ param(
     [Parameter(Mandatory = $true)] [string] $AcaEnvironmentName,
     [Parameter(Mandatory = $true)] [string] $ResourceGroup,
     [Parameter(Mandatory = $true)] [string] $KeyVaultName,
+    [Parameter(Mandatory = $true)] [string] $TestKeyVaultName,
     [Parameter(Mandatory = $true)] [string] $ImageTag,
     [Parameter(Mandatory = $true)] [string] $TestEnvironmentUrl,
     [Parameter(Mandatory = $true)] [string] $WorkingDirectory,                   # repo root ($(System.DefaultWorkingDirectory))
@@ -60,6 +61,16 @@ $deployPath = "$WorkingDirectory/test/Configuration"
 $testConfig = ConvertFrom-Json (Get-Content -Raw "$deployPath/testconfiguration.json")
 $flattenedTestConfig = & "$WorkingDirectory/release/scripts/PowerShell/ConvertTo-FlattenedConfigurationHashtable.ps1" -InputObject $testConfig
 
+$resourceGroupLocation = (Get-AzResourceGroup -Name $ResourceGroup -ErrorAction Stop).Location
+$smartIdpIssuer = & "$WorkingDirectory/build/jobs/scripts/Provision-TestSmartIdp.ps1" `
+    -ResourceGroup $ResourceGroup `
+    -KeyVaultName $TestKeyVaultName `
+    -Location $resourceGroupLocation
+
+if ([string]::IsNullOrWhiteSpace($smartIdpIssuer)) {
+    throw 'SMART test identity provider did not return an issuer URL.'
+}
+
 $additionalProperties = $flattenedTestConfig
 $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = $TaskHostingPollingFrequencyInSeconds
 $additionalProperties["TaskHosting__MaxRunningTaskCount"] = $TaskHostingMaxRunningTaskCount
@@ -67,6 +78,7 @@ $additionalProperties["FhirServer__CoreFeatures__SearchParameterCacheRefreshInte
 $additionalProperties["FhirServer__CoreFeatures__SystemConformanceProviderRefreshIntervalSeconds"] = $SystemConformanceProviderRefreshIntervalSeconds
 $additionalProperties["FhirServer__Operations__Reindex__CacheRefreshWaitMultiplier"] = $ReindexCacheRefreshWaitMultiplier
 $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
+$additionalProperties["FhirServer__Security__AdditionalAuthenticationAuthorities__0"] = $smartIdpIssuer
 
 $staticEnvNames = @(
     "ASPNETCORE_FORWARDEDHEADERS_ENABLED",

--- a/build/jobs/scripts/Provision-AcaDeploy.ps1
+++ b/build/jobs/scripts/Provision-AcaDeploy.ps1
@@ -61,11 +61,16 @@ $deployPath = "$WorkingDirectory/test/Configuration"
 $testConfig = ConvertFrom-Json (Get-Content -Raw "$deployPath/testconfiguration.json")
 $flattenedTestConfig = & "$WorkingDirectory/release/scripts/PowerShell/ConvertTo-FlattenedConfigurationHashtable.ps1" -InputObject $testConfig
 
-$resourceGroupLocation = (Get-AzResourceGroup -Name $ResourceGroup -ErrorAction Stop).Location
+$smartIdpDeployment = New-AzResourceGroupDeployment `
+    -Name 'test-smart-idp' `
+    -ResourceGroupName $ResourceGroup `
+    -TemplateFile "$WorkingDirectory/samples/templates/aca/test-smart-idp.bicep" `
+    -ErrorAction Stop
+
 $smartIdpIssuer = & "$WorkingDirectory/build/jobs/scripts/Provision-TestSmartIdp.ps1" `
-    -ResourceGroup $ResourceGroup `
     -KeyVaultName $TestKeyVaultName `
-    -Location $resourceGroupLocation
+    -Issuer $smartIdpDeployment.Outputs.issuer.Value `
+    -StorageAccountName $smartIdpDeployment.Outputs.storageAccountName.Value
 
 if ([string]::IsNullOrWhiteSpace($smartIdpIssuer)) {
     throw 'SMART test identity provider did not return an issuer URL.'

--- a/build/jobs/scripts/Provision-TestSmartIdp.ps1
+++ b/build/jobs/scripts/Provision-TestSmartIdp.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Provisions the static OIDC discovery and JWKS endpoints used by remote SMART E2E tests.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $ResourceGroup,
+    [Parameter(Mandatory = $true)] [string] $KeyVaultName,
+    [Parameter(Mandatory = $true)] [string] $Location
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-StorageAccountName {
+    param([string] $ResourceGroupName)
+
+    $hash = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($ResourceGroupName.ToLowerInvariant()))
+    $suffix = ([System.BitConverter]::ToString($hash) -replace '-', '').Substring(0, 15).ToLowerInvariant()
+    return "fhirsmart$suffix"
+}
+
+function ConvertTo-Base64Url {
+    param([byte[]] $Bytes)
+
+    return [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function Get-Jwks {
+    param([System.Security.Cryptography.RSA] $Rsa)
+
+    $parameters = $Rsa.ExportParameters($false)
+    $modulus = ConvertTo-Base64Url $parameters.Modulus
+    $exponent = ConvertTo-Base64Url $parameters.Exponent
+    $thumbprintJson = '{"e":"' + $exponent + '","kty":"RSA","n":"' + $modulus + '"}'
+    $kid = ConvertTo-Base64Url ([System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($thumbprintJson)))
+
+    return @{
+        keys = @(
+            @{
+                alg = 'RS256'
+                e = $exponent
+                kid = $kid
+                kty = 'RSA'
+                n = $modulus
+                use = 'sig'
+            }
+        )
+    }
+}
+
+$storageAccountName = Get-StorageAccountName -ResourceGroupName $ResourceGroup
+$storageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroup -Name $storageAccountName -ErrorAction SilentlyContinue
+if ($null -eq $storageAccount) {
+    Write-Host "Creating SMART test OIDC storage account '$storageAccountName'."
+    try {
+        $storageAccount = New-AzStorageAccount `
+            -ResourceGroupName $ResourceGroup `
+            -Name $storageAccountName `
+            -Location $Location `
+            -SkuName Standard_LRS `
+            -Kind StorageV2 `
+            -AllowBlobPublicAccess $true `
+            -ErrorAction Stop
+    }
+    catch {
+        $storageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroup -Name $storageAccountName -ErrorAction SilentlyContinue
+        if ($null -eq $storageAccount) {
+            throw
+        }
+    }
+}
+
+$issuer = ([string]$storageAccount.PrimaryEndpoints.Web).TrimEnd('/')
+$privateKeySecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -ErrorAction SilentlyContinue
+
+if ($null -eq $privateKeySecret) {
+    Write-Host 'Creating the SMART test token signing key.'
+    $newRsa = [System.Security.Cryptography.RSA]::Create(2048)
+    $privateKey = $newRsa.ExportRSAPrivateKeyPem()
+    $newRsa.Dispose()
+    $securePrivateKey = ConvertTo-SecureString -String $privateKey -AsPlainText -Force
+    Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -SecretValue $securePrivateKey | Out-Null
+}
+else {
+    $privateKey = [System.Net.NetworkCredential]::new('', $privateKeySecret.SecretValue).Password
+}
+
+if ([string]::IsNullOrWhiteSpace($privateKey)) {
+    $privateKeySecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -ErrorAction Stop
+    $privateKey = [System.Net.NetworkCredential]::new('', $privateKeySecret.SecretValue).Password
+}
+
+$secureIssuer = ConvertTo-SecureString -String $issuer -AsPlainText -Force
+Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenIssuer' -SecretValue $secureIssuer | Out-Null
+
+$rsa = [System.Security.Cryptography.RSA]::Create()
+$rsa.ImportFromPem($privateKey)
+$jwks = Get-Jwks -Rsa $rsa | ConvertTo-Json -Depth 4 -Compress
+$rsa.Dispose()
+$oidcConfiguration = @{
+    authorization_endpoint = "$issuer/authorize"
+    issuer = $issuer
+    response_types_supported = @('token', 'id_token')
+    subject_types_supported = @('public')
+    token_endpoint = "$issuer/token"
+    jwks_uri = "$issuer/jwks.json"
+    id_token_signing_alg_values_supported = @('RS256')
+} | ConvertTo-Json -Depth 4 -Compress
+
+$storageKey = (Get-AzStorageAccountKey -ResourceGroupName $ResourceGroup -Name $storageAccountName -ErrorAction Stop | Select-Object -First 1).Value
+$storageContext = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageKey
+Enable-AzStorageStaticWebsite -Context $storageContext -IndexDocument 'index.html' | Out-Null
+
+$temporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "fhir-smart-idp-$storageAccountName"
+New-Item -ItemType Directory -Path (Join-Path $temporaryDirectory '.well-known') -Force | Out-Null
+Set-Content -Path (Join-Path $temporaryDirectory 'jwks.json') -Value $jwks -NoNewline
+Set-Content -Path (Join-Path $temporaryDirectory '.well-known/openid-configuration') -Value $oidcConfiguration -NoNewline
+Set-Content -Path (Join-Path $temporaryDirectory 'index.html') -Value '<html><body>SMART E2E test identity provider</body></html>' -NoNewline
+
+try {
+    Set-AzStorageBlobContent -Context $storageContext -Container '$web' -File (Join-Path $temporaryDirectory 'jwks.json') -Blob 'jwks.json' -Force | Out-Null
+    Set-AzStorageBlobContent -Context $storageContext -Container '$web' -File (Join-Path $temporaryDirectory '.well-known/openid-configuration') -Blob '.well-known/openid-configuration' -Force | Out-Null
+    Set-AzStorageBlobContent -Context $storageContext -Container '$web' -File (Join-Path $temporaryDirectory 'index.html') -Blob 'index.html' -Force | Out-Null
+}
+finally {
+    Remove-Item -Path $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output $issuer

--- a/build/jobs/scripts/Provision-TestSmartIdp.ps1
+++ b/build/jobs/scripts/Provision-TestSmartIdp.ps1
@@ -6,7 +6,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)] [string] $KeyVaultName,
-    [Parameter(Mandatory = $true)] [string] $Issuer,
+    [Parameter(Mandatory = $true)] [string] $ResourceGroupName,
     [Parameter(Mandatory = $true)] [string] $StorageAccountName
 )
 
@@ -41,7 +41,16 @@ function Get-Jwks {
     }
 }
 
-$issuer = $Issuer.TrimEnd('/')
+$storageContext = New-AzStorageContext -StorageAccountName $StorageAccountName -UseConnectedAccount
+Enable-AzStorageStaticWebsite -Context $storageContext -IndexDocument 'index.html' | Out-Null
+
+$storageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -Name $StorageAccountName
+$issuer = $storageAccount.PrimaryEndpoints.Web.TrimEnd('/')
+
+if ([string]::IsNullOrWhiteSpace($issuer)) {
+    throw 'The static website endpoint was not enabled for the SMART test identity provider.'
+}
+
 $privateKeySecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -ErrorAction SilentlyContinue
 
 if ($null -eq $privateKeySecret) {
@@ -53,11 +62,6 @@ if ($null -eq $privateKeySecret) {
     Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -SecretValue $securePrivateKey | Out-Null
 }
 else {
-    $privateKey = [System.Net.NetworkCredential]::new('', $privateKeySecret.SecretValue).Password
-}
-
-if ([string]::IsNullOrWhiteSpace($privateKey)) {
-    $privateKeySecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -ErrorAction Stop
     $privateKey = [System.Net.NetworkCredential]::new('', $privateKeySecret.SecretValue).Password
 }
 
@@ -77,8 +81,6 @@ $oidcConfiguration = @{
     jwks_uri = "$issuer/jwks.json"
     id_token_signing_alg_values_supported = @('RS256')
 } | ConvertTo-Json -Depth 4 -Compress
-
-$storageContext = New-AzStorageContext -StorageAccountName $StorageAccountName -UseConnectedAccount
 
 $temporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "fhir-smart-idp-$StorageAccountName"
 New-Item -ItemType Directory -Path (Join-Path $temporaryDirectory '.well-known') -Force | Out-Null

--- a/build/jobs/scripts/Provision-TestSmartIdp.ps1
+++ b/build/jobs/scripts/Provision-TestSmartIdp.ps1
@@ -58,12 +58,20 @@ if ($null -eq $privateKeySecret) {
     $newRsa = [System.Security.Cryptography.RSA]::Create(2048)
     $privateKey = $newRsa.ExportRSAPrivateKeyPem()
     $newRsa.Dispose()
-    $securePrivateKey = ConvertTo-SecureString -String $privateKey -AsPlainText -Force
-    Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -SecretValue $securePrivateKey | Out-Null
 }
 else {
-    $privateKey = [System.Net.NetworkCredential]::new('', $privateKeySecret.SecretValue).Password
+    $storedPrivateKey = [System.Net.NetworkCredential]::new('', $privateKeySecret.SecretValue).Password
+    $privateKey = if ($storedPrivateKey.StartsWith('-----BEGIN', [System.StringComparison]::Ordinal)) {
+        $storedPrivateKey
+    }
+    else {
+        [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($storedPrivateKey))
+    }
 }
+
+$encodedPrivateKey = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($privateKey))
+$securePrivateKey = ConvertTo-SecureString -String $encodedPrivateKey -AsPlainText -Force
+Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -SecretValue $securePrivateKey | Out-Null
 
 $secureIssuer = ConvertTo-SecureString -String $issuer -AsPlainText -Force
 Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenIssuer' -SecretValue $secureIssuer | Out-Null

--- a/build/jobs/scripts/Provision-TestSmartIdp.ps1
+++ b/build/jobs/scripts/Provision-TestSmartIdp.ps1
@@ -5,20 +5,12 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)] [string] $ResourceGroup,
     [Parameter(Mandatory = $true)] [string] $KeyVaultName,
-    [Parameter(Mandatory = $true)] [string] $Location
+    [Parameter(Mandatory = $true)] [string] $Issuer,
+    [Parameter(Mandatory = $true)] [string] $StorageAccountName
 )
 
 $ErrorActionPreference = 'Stop'
-
-function Get-StorageAccountName {
-    param([string] $ResourceGroupName)
-
-    $hash = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($ResourceGroupName.ToLowerInvariant()))
-    $suffix = ([System.BitConverter]::ToString($hash) -replace '-', '').Substring(0, 15).ToLowerInvariant()
-    return "fhirsmart$suffix"
-}
 
 function ConvertTo-Base64Url {
     param([byte[]] $Bytes)
@@ -49,29 +41,7 @@ function Get-Jwks {
     }
 }
 
-$storageAccountName = Get-StorageAccountName -ResourceGroupName $ResourceGroup
-$storageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroup -Name $storageAccountName -ErrorAction SilentlyContinue
-if ($null -eq $storageAccount) {
-    Write-Host "Creating SMART test OIDC storage account '$storageAccountName'."
-    try {
-        $storageAccount = New-AzStorageAccount `
-            -ResourceGroupName $ResourceGroup `
-            -Name $storageAccountName `
-            -Location $Location `
-            -SkuName Standard_LRS `
-            -Kind StorageV2 `
-            -AllowBlobPublicAccess $true `
-            -ErrorAction Stop
-    }
-    catch {
-        $storageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroup -Name $storageAccountName -ErrorAction SilentlyContinue
-        if ($null -eq $storageAccount) {
-            throw
-        }
-    }
-}
-
-$issuer = ([string]$storageAccount.PrimaryEndpoints.Web).TrimEnd('/')
+$issuer = $Issuer.TrimEnd('/')
 $privateKeySecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'TestSmartTokenPrivateKey' -ErrorAction SilentlyContinue
 
 if ($null -eq $privateKeySecret) {
@@ -108,11 +78,9 @@ $oidcConfiguration = @{
     id_token_signing_alg_values_supported = @('RS256')
 } | ConvertTo-Json -Depth 4 -Compress
 
-$storageKey = (Get-AzStorageAccountKey -ResourceGroupName $ResourceGroup -Name $storageAccountName -ErrorAction Stop | Select-Object -First 1).Value
-$storageContext = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageKey
-Enable-AzStorageStaticWebsite -Context $storageContext -IndexDocument 'index.html' | Out-Null
+$storageContext = New-AzStorageContext -StorageAccountName $StorageAccountName -UseConnectedAccount
 
-$temporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "fhir-smart-idp-$storageAccountName"
+$temporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "fhir-smart-idp-$StorageAccountName"
 New-Item -ItemType Directory -Path (Join-Path $temporaryDirectory '.well-known') -Force | Out-Null
 Set-Content -Path (Join-Path $temporaryDirectory 'jwks.json') -Value $jwks -NoNewline
 Set-Content -Path (Join-Path $temporaryDirectory '.well-known/openid-configuration') -Value $oidcConfiguration -NoNewline

--- a/build/tasks/e2e-set-variables.yml
+++ b/build/tasks/e2e-set-variables.yml
@@ -32,7 +32,8 @@ steps:
                     throw "$($secret.Name) is empty"
                 }
 
-                Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($plainValue)"
+                $secretFlag = if ($secret.Name -in @('TestSmartTokenPrivateKey', 'TestSmartTokenIssuer')) { ';issecret=true' } else { '' }
+                Write-Host "##vso[task.setvariable variable=$($environmentVariableName)$secretFlag]$($plainValue)"
             }
         }
 

--- a/samples/templates/aca/test-smart-idp.bicep
+++ b/samples/templates/aca/test-smart-idp.bicep
@@ -17,7 +17,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   }
 }
 
-// #disable-next-line BCP081
+#disable-next-line BCP081
 resource staticWebsite 'Microsoft.Storage/storageAccounts/staticWebsite@2023-05-01' = {
   parent: storageAccount
   name: 'default'

--- a/samples/templates/aca/test-smart-idp.bicep
+++ b/samples/templates/aca/test-smart-idp.bicep
@@ -1,0 +1,31 @@
+// Static OIDC discovery and JWKS host for remote SMART E2E tests.
+
+var storageAccountName = 'fhirsmart${uniqueString(resourceGroup().id)}'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: resourceGroup().location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    allowBlobPublicAccess: true
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+// #disable-next-line BCP081
+resource staticWebsite 'Microsoft.Storage/storageAccounts/staticWebsite@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    enabled: true
+    indexDocument: 'index.html'
+  }
+}
+
+output issuer string = storageAccount.properties.primaryEndpoints.web
+output storageAccountName string = storageAccount.name

--- a/samples/templates/aca/test-smart-idp.bicep
+++ b/samples/templates/aca/test-smart-idp.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     name: 'Standard_LRS'
   }
   properties: {
-    allowBlobPublicAccess: true
+    allowBlobPublicAccess: false
     allowSharedKeyAccess: false
     minimumTlsVersion: 'TLS1_2'
     supportsHttpsTrafficOnly: true

--- a/samples/templates/aca/test-smart-idp.bicep
+++ b/samples/templates/aca/test-smart-idp.bicep
@@ -17,15 +17,4 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   }
 }
 
-#disable-next-line BCP081
-resource staticWebsite 'Microsoft.Storage/storageAccounts/staticWebsite@2023-05-01' = {
-  parent: storageAccount
-  name: 'default'
-  properties: {
-    enabled: true
-    indexDocument: 'index.html'
-  }
-}
-
-output issuer string = storageAccount.properties.primaryEndpoints.web
 output storageAccountName string = storageAccount.name

--- a/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using EnsureThat;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -56,6 +57,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 services.AddControllers(mvcOptions =>
                 {
                     var policy = new AuthorizationPolicyBuilder()
+                        .AddAuthenticationSchemes(_securityConfiguration.GetAuthenticationSchemes().ToArray())
                         .RequireAuthenticatedUser()
                         .Build();
                     mvcOptions.Filters.Add(new AuthorizeFilter(policy));

--- a/src/Microsoft.Health.Fhir.Core/Configs/SecurityConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/SecurityConfiguration.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Health.Fhir.Core.Configs
 
         public AuthenticationConfiguration Authentication { get; set; } = new AuthenticationConfiguration();
 
+        public IList<string> AdditionalAuthenticationAuthorities { get; set; } = new List<string>();
+
         public virtual HashSet<string> PrincipalClaims { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         public AuthorizationConfiguration Authorization { get; set; } = new AuthorizationConfiguration();
@@ -26,5 +28,20 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public string ServicePrincipalClientId { get; set; }
 
         public AddAuthenticationLibraryMethod AddAuthenticationLibrary { get; set; }
+
+        public IEnumerable<string> GetAuthenticationSchemes()
+        {
+            yield return "Bearer";
+
+            for (int i = 0; i < AdditionalAuthenticationAuthorities.Count; i++)
+            {
+                if (!string.IsNullOrWhiteSpace(AdditionalAuthenticationAuthorities[i]))
+                {
+                    yield return $"{AdditionalAuthenticationSchemePrefix}{i}";
+                }
+            }
+        }
+
+        public const string AdditionalAuthenticationSchemePrefix = "AdditionalBearer";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/SecurityConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/SecurityConfiguration.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Configs
 {
     public class SecurityConfiguration
     {
+        public const string AdditionalAuthenticationSchemePrefix = "AdditionalBearer";
+
         public delegate void AddAuthenticationLibraryMethod(IServiceCollection services, SecurityConfiguration securityConfiguration);
 
         public bool Enabled { get; set; }
@@ -19,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
 
         public AuthenticationConfiguration Authentication { get; set; } = new AuthenticationConfiguration();
 
-        public IList<string> AdditionalAuthenticationAuthorities { get; set; } = new List<string>();
+        public IList<string> AdditionalAuthenticationAuthorities { get; } = new List<string>();
 
         public virtual HashSet<string> PrincipalClaims { get; } = new HashSet<string>(StringComparer.Ordinal);
 
@@ -41,7 +43,5 @@ namespace Microsoft.Health.Fhir.Core.Configs
                 }
             }
         }
-
-        public const string AdditionalAuthenticationSchemePrefix = "AdditionalBearer";
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -275,6 +275,14 @@ namespace Microsoft.Health.Fhir.Web
                         options.TokenValidationParameters.RoleClaimType = securityConfiguration.Authorization.RolesClaim;
                         options.MapInboundClaims = false;
                         options.RequireHttpsMetadata = true;
+                        options.Events = new JwtBearerEvents
+                        {
+                            OnChallenge = context =>
+                            {
+                                context.HandleResponse();
+                                return System.Threading.Tasks.Task.CompletedTask;
+                            },
+                        };
                     });
             }
         }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -258,6 +258,25 @@ namespace Microsoft.Health.Fhir.Web
                 options.RequireHttpsMetadata = true;
                 options.Challenge = $"Bearer authorization_uri=\"{securityConfiguration.Authentication.Authority}\", resource_id=\"{securityConfiguration.Authentication.Audience}\", realm=\"{securityConfiguration.Authentication.Audience}\"";
             });
+
+            for (int i = 0; i < securityConfiguration.AdditionalAuthenticationAuthorities.Count; i++)
+            {
+                string authority = securityConfiguration.AdditionalAuthenticationAuthorities[i];
+                if (string.IsNullOrWhiteSpace(authority))
+                {
+                    continue;
+                }
+
+                services.AddAuthentication()
+                    .AddJwtBearer($"{SecurityConfiguration.AdditionalAuthenticationSchemePrefix}{i}", options =>
+                    {
+                        options.Authority = authority;
+                        options.Audience = securityConfiguration.Authentication.Audience;
+                        options.TokenValidationParameters.RoleClaimType = securityConfiguration.Authorization.RolesClaim;
+                        options.MapInboundClaims = false;
+                        options.RequireHttpsMetadata = true;
+                    });
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Tests.Common/KnownEnvironmentVariableNames.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/KnownEnvironmentVariableNames.cs
@@ -28,5 +28,7 @@ namespace Microsoft.Health.Fhir.Tests.Common
         public const string TestIntegrationStoreUri = "TestIntegrationStoreUri";
         public const string TestProxyForwardedHost = "TestProxyForwardedHost";
         public const string TestProxyForwardedPrefix = "TestProxyForwardedPrefix";
+        public const string TestSmartTokenIssuer = "TestSmartTokenIssuer";
+        public const string TestSmartTokenPrivateKey = "TestSmartTokenPrivateKey";
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
@@ -4,8 +4,11 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
 using Microsoft.Health.Fhir.Api.OpenIddict.Configuration;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.IdentityModel.Tokens;
 using static Microsoft.Health.Fhir.Tests.Common.EnvironmentVariables;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Common
@@ -23,6 +26,63 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
         /// Gets the token endpoint used by remote E2E client-credential authentication.
         /// </summary>
         public static Uri TestTokenEndpoint => ParseTestTokenEndpoint(GetEnvironmentVariable(KnownEnvironmentVariableNames.TestTokenEndpoint));
+
+        public static bool IsThirdPartySmartTokenConfigured =>
+            !string.IsNullOrWhiteSpace(GetEnvironmentVariable(KnownEnvironmentVariableNames.TestSmartTokenIssuer, null)) &&
+            !string.IsNullOrWhiteSpace(GetEnvironmentVariable(KnownEnvironmentVariableNames.TestSmartTokenPrivateKey, null));
+
+        public static string CreateThirdPartySmartToken(string clientId, string scope)
+        {
+            if (!IsThirdPartySmartTokenConfigured)
+            {
+                throw new InvalidOperationException("Third-party SMART token settings must be configured for remote SMART tests.");
+            }
+
+            using RSA rsa = RSA.Create();
+            rsa.ImportFromPem(GetEnvironmentVariable(KnownEnvironmentVariableNames.TestSmartTokenPrivateKey, null));
+
+            var signingKey = new RsaSecurityKey(rsa)
+            {
+                KeyId = GetKeyId(rsa),
+            };
+            var signingCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256);
+            var claims = new[]
+            {
+                new System.Security.Claims.Claim("appid", clientId),
+                new System.Security.Claims.Claim("scp", scope),
+                new System.Security.Claims.Claim("scope", scope),
+                new System.Security.Claims.Claim("roles", "smartUser"),
+            };
+
+            var additionalClaims = new System.Collections.Generic.List<System.Security.Claims.Claim>(claims);
+            if (scope.Contains("patient/", StringComparison.Ordinal))
+            {
+                additionalClaims.Add(new System.Security.Claims.Claim("fhirUser", "Patient/1234567890"));
+            }
+            else if (scope.Contains("user/", StringComparison.Ordinal))
+            {
+                additionalClaims.Add(new System.Security.Claims.Claim("fhirUser", "Practitioner/1234567890"));
+            }
+
+            var token = new JwtSecurityToken(
+                issuer: GetEnvironmentVariable(KnownEnvironmentVariableNames.TestSmartTokenIssuer, null),
+                audience: Resource,
+                claims: additionalClaims,
+                notBefore: DateTime.UtcNow,
+                expires: DateTime.UtcNow.AddHours(1),
+                signingCredentials: signingCredentials);
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+
+        private static string GetKeyId(RSA rsa)
+        {
+            RSAParameters parameters = rsa.ExportParameters(false);
+            string exponent = Base64UrlEncoder.Encode(parameters.Exponent);
+            string modulus = Base64UrlEncoder.Encode(parameters.Modulus);
+            string jwkThumbprint = $"{{\"e\":\"{exponent}\",\"kty\":\"RSA\",\"n\":\"{modulus}\"}}";
+            return Base64UrlEncoder.Encode(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(jwkThumbprint)));
+        }
 
         internal static Uri ParseTestTokenEndpoint(string tokenEndpoint)
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
             }
 
             using RSA rsa = RSA.Create();
-            rsa.ImportFromPem(GetEnvironmentVariable(KnownEnvironmentVariableNames.TestSmartTokenPrivateKey, null));
+            string encodedPrivateKey = GetEnvironmentVariable(KnownEnvironmentVariableNames.TestSmartTokenPrivateKey, null);
+            string privateKey = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedPrivateKey));
+            rsa.ImportFromPem(privateKey);
 
             var signingKey = new RsaSecurityKey(rsa)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
 
             var signingKey = new RsaSecurityKey(rsa)
             {
+                CryptoProviderFactory = new CryptoProviderFactory { CacheSignatureProviders = false },
                 KeyId = GetKeyId(rsa),
             };
             var signingCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256);
@@ -53,6 +54,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
                 new System.Security.Claims.Claim("appid", clientId),
                 new System.Security.Claims.Claim("scp", scope),
                 new System.Security.Claims.Claim("scope", scope),
+                new System.Security.Claims.Claim(JwtRegisteredClaimNames.Sub, clientId),
                 new System.Security.Claims.Claim("roles", "smartUser"),
             };
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/AuthenticationSettings.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
             var claims = new[]
             {
                 new System.Security.Claims.Claim("appid", clientId),
+                new System.Security.Claims.Claim("raw_scope", scope),
                 new System.Security.Claims.Claim("scp", scope),
                 new System.Security.Claims.Claim("scope", scope),
                 new System.Security.Claims.Claim(JwtRegisteredClaimNames.Sub, clientId),

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportTests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenPatientSmartScope_WhenCreatingExport_ThenServerShouldReturnForbidden()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient patientClient = await CreateSmartHttpClientAsync(TestApplications.SmartPatientA, "patient/Patient.read");
             using HttpRequestMessage exportRequest = GenerateExportRequest(
@@ -171,7 +171,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenUserSmartScope_WhenCreatingExport_ThenServerShouldReturnForbidden()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient userClient = await CreateSmartHttpClientAsync(TestApplications.SmartPractitionerA, "user/Patient.read");
             using HttpRequestMessage exportRequest = GenerateExportRequest(
@@ -185,7 +185,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenPatientOrUserSmartScope_WhenRequestingSystemExportStatusOrCancel_ThenServerShouldReturnNotFound()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient systemClient = await CreateSmartHttpClientAsync(TestApplications.SmartUserClient, "system/*.read");
             Uri contentLocation = await CreateExportJobAsync(systemClient, "Patient");
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenSystemWildcardScope_WhenCreatingExportWithoutType_ThenServerShouldReturnAccepted()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient systemClient = await CreateSmartHttpClientAsync(TestApplications.SmartUserClient, "system/*.read");
             Uri contentLocation = await CreateExportJobAsync(systemClient);
@@ -222,7 +222,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenPartialSystemScope_WhenCreatingExportWithoutType_ThenServerShouldReturnAcceptedWithInferredType()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient systemClient = await CreateSmartHttpClientAsync(TestApplications.SmartUserClient, "system/Patient.read");
 
@@ -238,7 +238,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenPartialSystemScope_WhenCreatingMatchingOrMismatchingTypeExport_ThenServerShouldAuthorizeEveryRequestedType()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient systemClient = await CreateSmartHttpClientAsync(TestApplications.SmartUserClient, "system/Patient.read");
             Uri contentLocation = await CreateExportJobAsync(systemClient, "Patient");
@@ -257,7 +257,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenExplicitTypeJob_WhenSystemScopeMatchesOrMismatches_ThenStatusAndCancelShouldAuthorizeEveryType()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient matchingClient = await CreateSmartHttpClientAsync(TestApplications.SmartUserClient, "system/Patient.read");
             Uri contentLocation = await CreateExportJobAsync(matchingClient, "Patient");
@@ -279,7 +279,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenJobWithoutExplicitType_WhenSystemScopeIsPartialOrWildcard_ThenWildcardAccessIsRequired()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             using HttpClient wildcardClient = await CreateSmartHttpClientAsync(TestApplications.SmartUserClient, "system/*.read");
             Uri contentLocation = await CreateExportJobAsync(wildcardClient);
@@ -300,7 +300,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenPatientRouteWithoutPatientSelectionAccess_WhenCreatingExportWithExplicitType_ThenServerShouldReturnForbidden()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             // Patient/$export requires system/Patient selection access in addition to the explicit output type,
             // independently of whether the output type itself is covered.
@@ -317,7 +317,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenGroupRouteWithoutGroupSelectionAccess_WhenCreatingExportWithExplicitType_ThenServerShouldReturnForbidden()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             // Group/{id}/$export requires both system/Group and system/Patient selection access; Patient plus the
             // explicit output type alone is not sufficient.
@@ -336,7 +336,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         public async Task GivenGroupRouteWithGroupAndPatientSelectionAccess_WhenCreatingExportWithExplicitType_ThenServerShouldReturnAccepted()
         {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Requires in-proc development identity provider to issue SMART scopes.");
+            Skip.If(!CanIssueSmartTokens(), "Requires the in-proc identity provider or the remote third-party SMART token configuration.");
 
             // Job creation does not synchronously validate that the referenced Group exists, so a nonexistent
             // group id is sufficient to exercise the route authorization requirements in isolation.
@@ -478,6 +478,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
 
         private async Task<string> GetSmartAccessTokenAsync(TestApplication application, string scope)
         {
+            if (!_fixture.IsUsingInProcTestServer)
+            {
+                return AuthenticationSettings.CreateThirdPartySmartToken(application.ClientId, scope);
+            }
+
             using var content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 { "grant_type", application.GrantType },
@@ -494,6 +499,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
             var responseJson = await response.Content.ReadAsStringAsync();
             var tokenResponse = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(responseJson);
             return tokenResponse["access_token"].GetString();
+        }
+
+        private bool CanIssueSmartTokens()
+        {
+            return _fixture.IsUsingInProcTestServer || AuthenticationSettings.IsThirdPartySmartTokenConfigured;
         }
 
         private async Task<Uri> CreateExportJobAsync(HttpClient client, string resourceType = null)


### PR DESCRIPTION
## Summary\n- deploy a static OIDC/JWKS test issuer for ACA PR and CI deployments\n- retain Entra authentication while accepting scoped test tokens from the issuer\n- enable remote SQL SMART export authorization coverage\n\n## Validation\n- local PowerShell syntax and whitespace checks\n- local build blocked because the required .NET SDK 10.0.302 is not installed