### PR TITLE
Fix SQL unsupported search parameter initialization

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -419,7 +419,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 _logger,
                 cancellationToken);
 
-            fileStatuses.RemoveAll((fs) => existingParams.Any((param) => param.Uri == fs.Uri && (param.Status != SearchParameterStatus.Initialized)));
+            fileStatuses.RemoveAll((fs) => fs.Status != SearchParameterStatus.Unsupported && existingParams.Any((param) => param.Uri == fs.Uri && (param.Status != SearchParameterStatus.Initialized)));
+            DateTimeOffset? latestLastUpdated = existingParams.Count == 0 ? null : existingParams.Max(p => p.LastUpdated);
 
             if (fileStatuses.Count == 0)
             {
@@ -442,7 +443,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     fs.Status = hasResources ? SearchParameterStatus.Supported : SearchParameterStatus.Enabled;
                 }
 
-                fs.LastUpdated = existingParams.FirstOrDefault(p => p.Uri == fs.Uri)?.LastUpdated ?? fs.LastUpdated;
+                fs.LastUpdated = latestLastUpdated ?? fs.LastUpdated;
             });
 
             using var cmd = new SqlCommand();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
@@ -45,22 +45,23 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
     {
         // Arrange
         var defaultSearchParameterStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
-        List<ResourceSearchParameterStatus> updatedSearchparameterStatuses = [];
-
-        // Disable every 5th search parameter
-        for (int i = 0; i < defaultSearchParameterStatuses.Count; i++)
+        var unsupportedSearchParameterUris = (await _fixture.FilebasedSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+            .Where(s => s.Status == SearchParameterStatus.Unsupported)
+            .Select(s => s.Uri)
+            .ToHashSet();
+        var searchParameterToDisable = defaultSearchParameterStatuses.First(s => !unsupportedSearchParameterUris.Contains(s.Uri));
+        searchParameterToDisable.Status = SearchParameterStatus.Disabled;
+        var latestSearchParameter = defaultSearchParameterStatuses.MaxBy(s => s.LastUpdated);
+        List<ResourceSearchParameterStatus> updatedSearchparameterStatuses = [searchParameterToDisable];
+        if (latestSearchParameter.Uri != searchParameterToDisable.Uri)
         {
-            if ((i + 1) % 5 == 0)
-            {
-                defaultSearchParameterStatuses[i].Status = SearchParameterStatus.Disabled;
-                updatedSearchparameterStatuses.Add(defaultSearchParameterStatuses[i]);
-            }
+            updatedSearchparameterStatuses.Add(latestSearchParameter);
         }
 
         await _fixture.SqlServerSearchParameterStatusDataStore.UpsertStatuses(updatedSearchparameterStatuses, CancellationToken.None);
 
         // Act - exception will be thrown when getting status if any are null.
-        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+        await ReinitializeSearchParameterStatuses();
         var reInitializedSearchParameterStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
 
         // Assert
@@ -90,7 +91,7 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
 
         // Act - re-run the initializer. This exercises the code path that previously overwrote
         // Unsupported with Enabled/Supported on every startup.
-        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+        await ReinitializeSearchParameterStatuses();
 
         // Assert - every URI that came from the file as Unsupported is still Unsupported in SQL.
         var dbStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
@@ -101,6 +102,32 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
             Assert.True(dbStatuses.TryGetValue(uri, out var dbStatus), $"Expected search parameter '{uri}' to exist in the SQL SearchParam table.");
             Assert.Equal(SearchParameterStatus.Unsupported, dbStatus.Status);
         }
+    }
+
+    [Fact]
+    public async Task GivenASearchParameterMarkedUnsupportedInTheFileButSupportedInTheDatabase_WhenInitializing_ThenItIsMarkedUnsupportedInTheDatabase()
+    {
+        // Arrange
+        var unsupportedSearchParameterUri = (await _fixture.FilebasedSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+            .First(s => s.Status == SearchParameterStatus.Unsupported);
+        var databaseSearchParameter = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+            .Single(s => s.Uri == unsupportedSearchParameterUri.Uri);
+        databaseSearchParameter.Status = SearchParameterStatus.Supported;
+        await _fixture.SqlServerSearchParameterStatusDataStore.UpsertStatuses([databaseSearchParameter], CancellationToken.None);
+
+        // Act
+        await ReinitializeSearchParameterStatuses();
+
+        // Assert
+        var reinitializedSearchParameter = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+            .Single(s => s.Uri == unsupportedSearchParameterUri.Uri);
+        Assert.Equal(SearchParameterStatus.Unsupported, reinitializedSearchParameter.Status);
+    }
+
+    private async Task ReinitializeSearchParameterStatuses()
+    {
+        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Min, CancellationToken.None);
+        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max, CancellationToken.None);
     }
 
     private async Task CheckSearchParametersForInvalid()


### PR DESCRIPTION
## Summary
- preserve file-defined Unsupported statuses during SQL model initialization
- provide the current table-wide search parameter timestamp to MergeSearchParams
- cover persisted Supported-to-Unsupported migration and persisted Disabled overrides

## Validation
- dotnet build src\Microsoft.Health.Fhir.SqlServer\Microsoft.Health.Fhir.SqlServer.csproj --no-restore
- SqlServerSearchParameterInitializationTests: R4, R5, STU3 (4 passed each)