### PR TITLE
Fix stored XSS bypass in narrative scheme checks

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/Narratives/NarrativeHtmlSanitizer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/Narratives/NarrativeHtmlSanitizer.cs
@@ -332,7 +332,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation.Narratives
 
                 if (string.Equals("src", attr.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (!AllowedSrcSchemes.Any(x => attr.Value.StartsWith(x, StringComparison.OrdinalIgnoreCase)))
+                    string normalizedSrc = NormalizeUrlSchemeValue(attr.Value);
+                    if (!AllowedSrcSchemes.Any(x => normalizedSrc.StartsWith(x, StringComparison.OrdinalIgnoreCase)))
                     {
                         onInvalidAttr(element, attr);
                     }
@@ -340,12 +341,39 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation.Narratives
 
                 if (string.Equals("href", attr.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (DangerousHrefSchemes.Any(x => attr.Value.StartsWith(x, StringComparison.OrdinalIgnoreCase)))
+                    string normalizedHref = NormalizeUrlSchemeValue(attr.Value);
+                    if (DangerousHrefSchemes.Any(x => normalizedHref.StartsWith(x, StringComparison.OrdinalIgnoreCase)))
                     {
                         onDangerousHref(element, attr);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Removes leading ASCII whitespace and C0 control characters (U+0000 through U+0020, inclusive)
+        /// from a URL-like attribute value before performing scheme comparisons.
+        /// Browsers strip these characters when resolving a URL's scheme (see the WHATWG URL specification's
+        /// "leading and trailing C0 control or space" trimming step), so values such as " javascript:alert(1)"
+        /// or "\tjavascript:alert(1)" would otherwise bypass a naive <see cref="string.StartsWith(string, StringComparison)"/> check.
+        /// This only affects the value used for scheme detection; the original attribute value is left untouched.
+        /// </summary>
+        /// <param name="value">The raw attribute value.</param>
+        /// <returns>The value with any leading C0 control/space characters removed.</returns>
+        private static string NormalizeUrlSchemeValue(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            int start = 0;
+            while (start < value.Length && value[start] <= '\u0020')
+            {
+                start++;
+            }
+
+            return start == 0 ? value : value.Substring(start);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeHtmlSanitizerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeHtmlSanitizerTests.cs
@@ -165,5 +165,89 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
 
             Assert.Equal(output, results);
         }
+
+        // Leading ASCII whitespace / C0 control characters are normalized away by browsers before a URL's
+        // scheme is resolved. A naive StartsWith() check against the raw attribute value misses this
+        // normalization, allowing values like " javascript:alert(1)" to bypass the dangerous-href denylist
+        // even though a browser would still treat and execute them as javascript: URLs.
+        [Theory]
+        [InlineData("<div><a href=\" javascript:alert('XSS')\">click</a></div>")] // leading space (U+0020)
+        [InlineData("<div><a href=\"\tjavascript:alert('XSS')\">click</a></div>")] // leading tab (U+0009)
+        [InlineData("<div><a href=\"\rjavascript:alert('XSS')\">click</a></div>")] // leading CR (U+000D)
+        [InlineData("<div><a href=\"\njavascript:alert('XSS')\">click</a></div>")] // leading LF (U+000A)
+        [InlineData("<div><a href=\"\u0001javascript:alert('XSS')\">click</a></div>")] // leading C0 control (U+0001)
+        [InlineData("<div><a href=\"\u001Fjavascript:alert('XSS')\">click</a></div>")] // leading C0 control (U+001F)
+        [InlineData("<div><a href=\"  \t\r\njavascript:alert('XSS')\">click</a></div>")] // mixed leading whitespace
+        [InlineData("<div><a href=\" JaVaScRiPt:alert('XSS')\">click</a></div>")] // leading space + mixed case
+        [InlineData("<div><a href=\" vbscript:MsgBox('XSS')\">click</a></div>")]
+        [InlineData("<div><a href=\" data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=\">click</a></div>")]
+        [InlineData("<div><a href=\" livescript:alert('XSS')\">click</a></div>")]
+        [InlineData("<div><a href=\" file:///etc/passwd\">click</a></div>")]
+        public void GivenHtmlWithLeadingWhitespaceOrControlCharsBeforeDangerousHrefScheme_WhenValidatingInRejectMode_ThenValidationErrorIsReturned(string html)
+        {
+            var sanitizer = CreateSanitizer(rejectDangerousHrefs: true);
+
+            var results = sanitizer.Validate(html);
+
+            Assert.NotEmpty(results);
+        }
+
+        [Theory]
+        [InlineData("<div><a href=\" javascript:alert('XSS')\">click</a></div>")]
+        [InlineData("<div><a href=\"\tjavascript:alert('XSS')\">click</a></div>")]
+        [InlineData("<div><a href=\"\rjavascript:alert('XSS')\">click</a></div>")]
+        [InlineData("<div><a href=\"\njavascript:alert('XSS')\">click</a></div>")]
+        [InlineData("<div><a href=\" vbscript:MsgBox('XSS')\">click</a></div>")]
+        public void GivenHtmlWithLeadingWhitespaceOrControlCharsBeforeDangerousHrefScheme_WhenSanitizing_ThenHrefIsRemoved(string html)
+        {
+            var results = _sanitizer.Sanitize(html);
+
+            Assert.DoesNotContain("href", results, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData("<div><img src=\" javascript:alert('XSS')\" /></div>")] // leading space before disallowed scheme
+        [InlineData("<div><img src=\"\tjavascript:alert('XSS')\" /></div>")] // leading tab before disallowed scheme
+        [InlineData("<div><img src=\"\r\njavascript:alert('XSS')\" /></div>")] // leading CRLF before disallowed scheme
+        [InlineData("<div><img src=\"\u0001javascript:alert('XSS')\" /></div>")] // leading C0 control before disallowed scheme
+        public void GivenHtmlWithLeadingWhitespaceOrControlCharsBeforeDisallowedSrcScheme_WhenValidating_ThenValidationErrorIsReturned(string html)
+        {
+            var results = _sanitizer.Validate(html);
+
+            Assert.NotEmpty(results);
+        }
+
+        [Theory]
+        [InlineData("<div><img src=\" javascript:alert('XSS')\" /></div>", "<div><img></div>")]
+        [InlineData("<div><img src=\"\tjavascript:alert('XSS')\" /></div>", "<div><img></div>")]
+        public void GivenHtmlWithLeadingWhitespaceOrControlCharsBeforeDisallowedSrcScheme_WhenSanitizing_ThenSrcIsRemoved(string input, string output)
+        {
+            var results = _sanitizer.Sanitize(input);
+
+            Assert.Equal(output, results);
+        }
+
+        [Theory]
+        [InlineData("<div><a href=\"  https://example.com\">safe</a></div>")] // leading whitespace before safe https scheme
+        [InlineData("<div><a href=\"\thttp://example.com\">safe</a></div>")] // leading tab before safe http scheme
+        [InlineData("<div><a href=\"\r\nmailto:user@example.com\">email</a></div>")] // leading CRLF before safe mailto scheme
+        [InlineData("<div><a href=\" #section1\">anchor</a></div>")] // leading space before safe anchor
+        [InlineData("<div><a href=\" mypage.html\">relative</a></div>")] // leading space before safe relative reference
+        public void GivenHtmlWithLeadingWhitespaceBeforeSafeHrefScheme_WhenValidating_ThenValidationIsSuccessful(string html)
+        {
+            var results = _sanitizer.Validate(html);
+
+            Assert.Empty(results);
+        }
+
+        [Theory]
+        [InlineData("<div><img src=\"  https://example.com/image.png\" /></div>")]
+        [InlineData("<div><img src=\"\thttps://example.com/image.png\" /></div>")]
+        public void GivenHtmlWithLeadingWhitespaceBeforeSafeSrcScheme_WhenValidating_ThenValidationIsSuccessful(string html)
+        {
+            var results = _sanitizer.Validate(html);
+
+            Assert.Empty(results);
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixes a confirmed stored-XSS vulnerability in `NarrativeHtmlSanitizer`.

**Root cause:** `NarrativeHtmlSanitizer.ValidateAttributes` compares `href`/`src` attribute values against a dangerous-scheme denylist (`href`) and an allowed-scheme allowlist (`src`) using a raw `attr.Value.StartsWith(scheme, StringComparison.OrdinalIgnoreCase)` check. Browsers normalize URLs before resolving their scheme — per the WHATWG URL specification, leading (and trailing) **C0 control characters and spaces (U+0000–U+0020)** are trimmed before scheme parsing. Because the sanitizer never performed this normalization, a value such as `" javascript:alert(1)"` or `"\tjavascript:alert(1)"` fails the `StartsWith("javascript:")` denylist check and is treated as safe, yet a browser rendering the narrative HTML still strips the leading whitespace/control character and executes it as a `javascript:` URL. The same gap affects the `src` allowlist check.

**Fix (compatibility-safe, scoped):** Added `NormalizeUrlSchemeValue()`, which strips only **leading** ASCII whitespace/C0 control characters (U+0000–U+0020) from the attribute value, and applied it consistently before both the `href` denylist check and the `src` allowlist check. This intentionally:
- Does **not** replace the `href` denylist with a strict allowlist.
- Does **not** change `style` attribute handling.
- Only affects the value used for scheme *comparison* — the original attribute value emitted by `Sanitize()` is left untouched (aside from removal when the href/src is judged unsafe, same as before).
- Preserves valid `http:`, `https:`, `mailto:`, anchor (`#...`), and relative references, including when preceded by benign leading whitespace.

## Related issues
Addresses [Microsoft Health ADO work item **194209**.](https://microsofthealth.visualstudio.com/Health/_workitems/edit/194209)

## Testing
Added regression tests to `NarrativeHtmlSanitizerTests` (covering both `Validate` and `Sanitize`):


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch (security fix — normalizes leading whitespace/control characters before href/src scheme validation; no public API or behavior change for valid inputs)
