### PR TITLE
Use explicit endpoint in token introspection tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         public ResourceElement Metadata { get; set; }
 
+        /// <summary>
+        /// Gets the token endpoint used when tests acquire client-credential tokens directly.
+        /// </summary>
+        internal Uri ClientCredentialTokenUri => GetClientCredentialTokenEndpoint();
+
         public TestFhirClient GetTestFhirClient(ResourceFormat format, bool reusable = true, HttpMessageHandler authenticationHandler = null)
         {
             return GetTestFhirClient(format, TestApplications.GlobalAdminServicePrincipal, null, reusable, authenticationHandler);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TokenIntrospectionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TokenIntrospectionTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Smart.Tests.E2E
         {
             _fixture = fixture;
             _httpClient = fixture.TestFhirClient.HttpClient;
-            _tokenUri = fixture.TestFhirServer.TokenUri;
+            _tokenUri = fixture.TestFhirServer.ClientCredentialTokenUri;
             _introspectionUri = new Uri(fixture.TestFhirServer.BaseAddress, "/connect/introspect");
         }
 


### PR DESCRIPTION
## Description
Adds the TestTokenEndpoint to the TokenIntrospectionTests.

## Related issues
Addresses [AB#198445](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/198445)

## Testing
Describe how this change was tested.