### PR TITLE
Fix convert-data validation ordering

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ConvertDataControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ConvertDataControllerTests.cs
@@ -151,6 +151,23 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await Assert.ThrowsAsync<ContainerRegistryNotConfiguredException>(() => localController.ConvertData(body));
         }
 
+        [Fact]
+        public async Task GivenAConvertDataRequest_WithNotConfiguredTemplate_WhenContainerRegistryAccessFails_ThenTemplateNotConfiguredThrownBeforeRegistryAccessValidation()
+        {
+            var convertDataConfiguration = new ConvertDataConfiguration() { Enabled = true };
+            convertDataConfiguration.ContainerRegistryServers.Add("test.azurecr.io");
+            var containerRegistryAccessValidator = Substitute.For<IContainerRegistryAccessValidator>();
+            containerRegistryAccessValidator
+                .When(validator => validator.CheckContainerRegistryAccess())
+                .Do(_ => throw new InvalidOperationException());
+
+            var localController = GetController(convertDataConfiguration, new ArtifactStoreConfiguration(), containerRegistryAccessValidator);
+            var body = GetConvertDataParams(Samples.SampleHl7v2Message, "Hl7v2", "abc.azurecr.io/template:123", _testHl7v2RootTemplate);
+
+            await Assert.ThrowsAsync<ContainerRegistryNotConfiguredException>(() => localController.ConvertData(body));
+            containerRegistryAccessValidator.DidNotReceive().CheckContainerRegistryAccess();
+        }
+
         [Theory]
         [InlineData(null, null, null, "test.azurecr.io/template:123")] // configured in ConvertData config
         [InlineData("abc.azurecr.io", null, null, "abc.azurecr.io/template:123")]
@@ -209,7 +226,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         private ConvertDataController GetController(
             ConvertDataConfiguration convertDataConfiguration,
-            ArtifactStoreConfiguration artifactStoreConfiguration)
+            ArtifactStoreConfiguration artifactStoreConfiguration,
+            IContainerRegistryAccessValidator containerRegistryAccessValidator = null)
         {
             var operationConfig = new OperationsConfiguration()
             {
@@ -222,7 +240,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             IOptions<ArtifactStoreConfiguration> optionsArtifactStoreConfiguration = Substitute.For<IOptions<ArtifactStoreConfiguration>>();
             optionsArtifactStoreConfiguration.Value.Returns(artifactStoreConfiguration);
 
-            IContainerRegistryAccessValidator containerRegistryAccessValidator = new BaseContainerRegistryAccessValidator();
+            containerRegistryAccessValidator ??= new BaseContainerRegistryAccessValidator();
 
             return new ConvertDataController(
                 _mediator,

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ConvertDataController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ConvertDataController.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 throw new RequestNotValidException(string.Format(Resources.InvalidTemplateCollectionReference, templateCollectionReference));
             }
 
-            // Validate if template has been configured.
+            // Validate custom template configuration before access so configuration errors retain their specific response.
             bool isDefaultTemplateReference = ImageInfo.IsDefaultTemplateImageReference(templateCollectionReference);
             string registryServer = ExtractRegistryServer(templateCollectionReference);
             if (isDefaultTemplateReference)
@@ -96,8 +96,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
             else
             {
-                _containerRegistryAccessValidator.CheckContainerRegistryAccess();
                 CheckIfCustomTemplateIsConfigured(registryServer, templateCollectionReference);
+                _containerRegistryAccessValidator.CheckContainerRegistryAccess();
             }
 
             var convertDataRequest = new ConvertDataRequest(inputData, inputDataType, registryServer, isDefaultTemplateReference, templateCollectionReference, rootTemplate, treatDatesAsStrings);


### PR DESCRIPTION
## Why

`$convert-data` validates custom template configuration and container-registry access before it sends the conversion request. These checks previously ran in the opposite order: registry access was evaluated before confirming that the requested custom template was configured.

In PaaS deployments using external managed identity, the access validator can throw a `FhirException` when that identity is unavailable. For a request that names an unconfigured custom template, that broader managed-identity failure masked the intended `ContainerRegistryNotConfiguredException` and its specific 400 response.

## Flow after this change

For a non-default template reference, the controller now:

1. Validates that the requested template is configured through the legacy registry-server setting or OCI artifact-store configuration.
2. Returns the existing template-not-configured FHIR 400 when it is not configured, without invoking registry-access validation.
3. Checks container-registry access only after a configured template is confirmed. An unavailable external managed identity can then produce its FHIR 400 `OperationOutcome` for the request that actually requires registry access.

Default-template format and input-data-type validation are unchanged.

## Protected scenario

A tenant sends `$convert-data` for `abc.azurecr.io/template:123`, which is not configured, while external managed identity is disabled or unavailable. The request must receive the existing template-not-configured 400 rather than the managed-identity diagnostic. The regression test injects a throwing access validator and verifies that it is never called for this unconfigured template.

## Test plan

- [x] `dotnet test src\Microsoft.Health.Fhir.Api.UnitTests\Microsoft.Health.Fhir.R4.Api.UnitTests.csproj --filter FullyQualifiedName~ConvertDataControllerTests --no-restore`

[AB#199837](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/199837)