### PR TITLE
Delete search param sequential transaction bundle bug

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -251,7 +251,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                             _logger.LogInformation("Edge Case scenario: sequential transactional bundle has a single record, and it's now changed to execute as parallel.");
                             bundleProcessingLogic = BundleProcessingLogic.Parallel;
                         }
-                        else if (bundleResource.Entry.Any(e => string.Equals(e.Resource?.TypeName, KnownResourceTypes.SearchParameter, StringComparison.Ordinal)))
+                        else if (bundleResource.Entry.Any(e => e.Resource?.TypeName == KnownResourceTypes.SearchParameter
+                                                               //// for deletes type name is not populated, so checking url
+                                                               || e.Request?.Url?.StartsWith(KnownResourceTypes.SearchParameter, StringComparison.OrdinalIgnoreCase) == true))
                         {
                             // SearchParameter persistence relies on the parallel-bundle path (MergeResourcesAndSearchParams)
                             // for atomic resource + status row commit, so any sequential transaction bundle containing a

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -882,30 +882,21 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 resource.BundleResourceContext != null &&
                 resource.BundleResourceContext.IsTransactionalBundle;
 
-            // For non-transaction operations, extract pending statuses now so they are merged with the resource.
-            // Transaction bundles never reach this branch with pending statuses: any transaction bundle that
-            // contains a SearchParameter resource is forced to the parallel path (handled above), where the
-            // statuses ride along with the resource through dbo.MergeResourcesAndSearchParams.
-            if (!isBundleTransaction)
-            {
-                SetAndClearPendingSearchParameterStatus(resource);
-            }
+            // Extract pending statuses now so they are merged with the resource.
+            // This is applicable for any bundle types.
+            SetAndClearPendingSearchParameterStatus(resource);
 
             if (isBundleParallelOperation)
             {
                 // Parallel operations:
                 // - EnlistTransaction: should be always false, and rely on SQL transactions.
-
                 IBundleOrchestratorOperation bundleOperation = _bundleOrchestrator.GetOperation(resource.BundleResourceContext.BundleOperationId);
-                SetAndClearPendingSearchParameterStatus(resource);
-
                 return await bundleOperation.AppendResourceAsync(resource, this, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 // Sequential operations:
                 // - EnlistTransaction: set to true only in sequential transaction bundles (as they rely on C# transactions). Standalone operations should not enlist transactions (as they rely on SQL transactions).
-
                 MergeOptions mergeOptions = new MergeOptions(
                     enlistTransaction: isBundleTransaction,
                     isBundleTransaction: isBundleTransaction);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1179,20 +1179,27 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task GivenSearchParamBundleDelete_ThenConflictWhenReindexAndSuccessOnNext(bool isBatch)
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        public async Task GivenSearchParamBundleDelete_ThenConflictWhenReindexAndSuccessOnNext(bool isBatch, bool isParallel)
         {
             if (!_isSql && !isBatch) // cosmos does not support transaction bundles
             {
                 return;
             }
 
-            var code = isBatch ? "soft-delete-batch-bundle-conflict-test" : "soft-delete-transaction-bundle-conflict-test";
-            var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
-            var create = await _fixture.TestFhirClient.UpdateAsync(searchParam); // use PUT to retain id
-            Assert.True(create.StatusCode == HttpStatusCode.OK || create.StatusCode == HttpStatusCode.Created);
-            Assert.Equal(code, create.Resource.Id);
+            var codePrefix = $"soft-delete-{(isBatch ? "batch" : "transaction")}-{(isParallel ? "parallel" : "sequential")}-bundle-conflict-test";
+            var codes = new[] { $"{codePrefix}-1", $"{codePrefix}-2" };
+
+            foreach (var code in codes)
+            {
+                var searchParam = CreatePersonSearchParam(code, $"http://e2e.org/{code}");
+                var create = await _fixture.TestFhirClient.UpdateAsync(searchParam); // use PUT to retain id
+                Assert.True(create.StatusCode == HttpStatusCode.OK || create.StatusCode == HttpStatusCode.Created);
+                Assert.Equal(code, create.Resource.Id);
+            }
 
             var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
             Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
@@ -1200,25 +1207,32 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             var bundle = new Bundle
             {
                 Type = isBatch ? BundleType.Batch : BundleType.Transaction,
-                Entry = [new() { Request = new Bundle.RequestComponent { Method = Bundle.HTTPVerb.DELETE, Url = $"SearchParameter/{code}" } }],
+                Entry =
+                [
+                    new() { Request = new Bundle.RequestComponent { Method = Bundle.HTTPVerb.DELETE, Url = $"SearchParameter/{codes[0]}" } },
+                    new() { Request = new Bundle.RequestComponent { Method = Bundle.HTTPVerb.DELETE, Url = $"SearchParameter/{codes[1]}" } },
+                ],
             };
+            var bundleOptions = new FhirBundleOptions { BundleProcessingLogic = isParallel ? FhirBundleProcessingLogic.Parallel : FhirBundleProcessingLogic.Sequential };
 
             if (isBatch)
             {
-                // conflict - batch bundle returns entry-level conflict while reindex is running
-                var bundleConflict = await _fixture.TestFhirClient.PostBundleAsync(bundle, new FhirBundleOptions { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel });
+                // conflict - batch bundle returns entry-level conflicts while reindex is running
+                var bundleConflict = await _fixture.TestFhirClient.PostBundleAsync(bundle, bundleOptions);
                 Assert.Equal(HttpStatusCode.OK, bundleConflict.Response.StatusCode);
                 Assert.NotNull(bundleConflict.Resource?.Entry);
-                Assert.Single(bundleConflict.Resource.Entry);
-                var deleteResponse = bundleConflict.Resource.Entry[0].Response;
-                Assert.Equal(((int)HttpStatusCode.Conflict).ToString(), deleteResponse.Status);
-                Assert.Contains("reindex", deleteResponse.Outcome?.ToString() ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+                Assert.Equal(2, bundleConflict.Resource.Entry.Count);
+                foreach (var entry in bundleConflict.Resource.Entry)
+                {
+                    Assert.Equal(((int)HttpStatusCode.Conflict).ToString(), entry.Response.Status);
+                    Assert.Contains("reindex", entry.Response.Outcome?.ToString() ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+                }
             }
             else
             {
                 // conflict - transaction bundle fails the whole request while reindex is running
                 var transactionConflict = await Assert.ThrowsAsync<FhirClientException>(async () =>
-                    await _fixture.TestFhirClient.PostBundleAsync(bundle, new FhirBundleOptions { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel }));
+                    await _fixture.TestFhirClient.PostBundleAsync(bundle, bundleOptions));
                 Assert.Equal(HttpStatusCode.Conflict, transactionConflict.StatusCode);
                 Assert.Contains("reindex", transactionConflict.Message, StringComparison.OrdinalIgnoreCase);
             }
@@ -1227,38 +1241,46 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             Assert.Equal(OperationStatus.Completed, reindexStatus);
 
             // success - bundle delete should succeed after reindex completes
-            var bundleResponse = await _fixture.TestFhirClient.PostBundleAsync(bundle, new FhirBundleOptions { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel });
+            var bundleResponse = await _fixture.TestFhirClient.PostBundleAsync(bundle, bundleOptions);
             Assert.Equal(HttpStatusCode.OK, bundleResponse.Response.StatusCode);
             Assert.NotNull(bundleResponse.Resource?.Entry);
-            Assert.Single(bundleResponse.Resource.Entry);
-            var successResponse = bundleResponse.Resource.Entry[0].Response;
-            Assert.Equal(((int)HttpStatusCode.NoContent).ToString(), successResponse.Status);
+            Assert.Equal(2, bundleResponse.Resource.Entry.Count);
+            foreach (var entry in bundleResponse.Resource.Entry)
+            {
+                Assert.Equal(((int)HttpStatusCode.NoContent).ToString(), entry.Response.Status);
+            }
 
-            // resource is still there (soft-deleted)
-            var resource = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}");
-            Assert.NotNull(resource?.Resource);
+            // resources are still there (soft-deleted)
+            foreach (var code in codes)
+            {
+                var resource = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}");
+                Assert.NotNull(resource?.Resource);
+            }
 
             reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
             Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
             reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
             Assert.Equal(OperationStatus.Completed, reindexStatus);
 
-            // reindex deleted resource - should now be gone
-            var notFoundEx = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}"));
-            Assert.Equal(HttpStatusCode.Gone, notFoundEx.StatusCode);
+            foreach (var code in codes)
+            {
+                // reindex deleted resources - should now be gone
+                var notFoundEx = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}"));
+                Assert.Equal(HttpStatusCode.Gone, notFoundEx.StatusCode);
 
-            // verify history is preserved
-            var history = await _fixture.TestFhirClient.ReadHistoryAsync(ResourceType.SearchParameter, code);
-            Assert.NotNull(history.Resource);
-            Assert.NotEmpty(history.Resource.Entry);
-            Assert.True(history.Resource.Entry.Count >= 2, "History should contain at least 2 versions (create + delete)");
+                // verify history is preserved
+                var history = await _fixture.TestFhirClient.ReadHistoryAsync(ResourceType.SearchParameter, code);
+                Assert.NotNull(history.Resource);
+                Assert.NotEmpty(history.Resource.Entry);
+                Assert.True(history.Resource.Entry.Count >= 2, "History should contain at least 2 versions (create + delete)");
 
-            // verify last version is soft-deleted (check request method is DELETE)
-            var lastEntry = history.Resource.Entry.First();
-            Assert.NotNull(lastEntry.Request);
-            Assert.Equal(Bundle.HTTPVerb.DELETE, lastEntry.Request.Method);
-            Assert.NotNull(lastEntry.Resource);
-            Assert.Equal(code, lastEntry.Resource.Id);
+                // verify last version is soft-deleted (check request method is DELETE)
+                var lastEntry = history.Resource.Entry.First();
+                Assert.NotNull(lastEntry.Request);
+                Assert.Equal(Bundle.HTTPVerb.DELETE, lastEntry.Request.Method);
+                Assert.NotNull(lastEntry.Resource);
+                Assert.Equal(code, lastEntry.Resource.Id);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Sequential transaction bundles are not supported for search params. In case it is still explicitly requested, it is converted to parallel internally. This logic was relying on type name on resources. In case of deletes by URL type name is not populated, and wrong code path was invoked leading to incorrect data saved in the store. 
This PR fixes this logic by checking resource type on URL.  