### PR TITLE
Add search for soft deleted resources

### DIFF
--- a/docs/rest/SoftDeleteSearch.http
+++ b/docs/rest/SoftDeleteSearch.http
@@ -92,33 +92,33 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Search all soft-deleted resource types
 # Returns the deleted Patient and Observation, but not the active Patient.
-GET https://{{hostname}}/_deleted
+GET https://{{hostname}}/$delete-search
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Search soft-deleted patients
 # The resource type is specified in the URL. This returns only the deleted Patient.
-GET https://{{hostname}}/Patient/_deleted
+GET https://{{hostname}}/Patient/$delete-search
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Search soft-deleted observations
-GET https://{{hostname}}/Observation/_deleted
+GET https://{{hostname}}/Observation/$delete-search
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Search resources deleted since a last-updated time
 # _since is inclusive. Use a timestamp before the DELETE requests above.
-GET https://{{hostname}}/_deleted?_since=2000-01-01T00:00:00Z
+GET https://{{hostname}}/$delete-search?_since=2000-01-01T00:00:00Z
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Search a last-updated time range
 # _before is exclusive and cannot be in the future. Replace the example values
 # with timestamps that bracket the DELETE requests before running this request.
-GET https://{{hostname}}/Patient/_deleted?_since=2026-07-30T20:00:00Z&_before=2026-07-30T22:00:00Z
+GET https://{{hostname}}/Patient/$delete-search?_since=2026-07-30T20:00:00Z&_before=2026-07-30T22:00:00Z
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Sort and page through soft-deleted resources
 # Only _lastUpdated is supported for sorting. The default order is descending.
 # @name deletedPage
-GET https://{{hostname}}/_deleted?_count=1&_sort=-_lastUpdated
+GET https://{{hostname}}/$delete-search?_count=1&_sort=-_lastUpdated
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Record the next-page URL
@@ -128,4 +128,3 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 # @name deletedPage
 GET {{deletedNextPage}}
 Authorization: Bearer {{bearer.response.body.access_token}}
-

--- a/docs/rest/SoftDeleteSearch.http
+++ b/docs/rest/SoftDeleteSearch.http
@@ -1,0 +1,131 @@
+# Soft-deleted resources can be searched at the system or resource-type level.
+# The only supported filters are the resource type in the URL and the
+# last-updated bounds (_since and _before).
+
+@hostname = localhost:44348
+
+### Get the bearer token, if authentication is enabled
+# @name bearer
+POST https://{{hostname}}/connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=globalAdminServicePrincipal
+&client_secret=globalAdminServicePrincipal
+&scope=fhir-api
+
+### Create a patient that will be soft deleted
+PUT https://{{hostname}}/Patient/soft-delete-search-patient
+Content-Type: application/fhir+json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "soft-delete-search-patient",
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Deleted",
+      "given": [
+        "Pat"
+      ]
+    }
+  ]
+}
+
+### Create an observation that will be soft deleted
+PUT https://{{hostname}}/Observation/soft-delete-search-observation
+Content-Type: application/fhir+json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Observation",
+  "id": "soft-delete-search-observation",
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "29463-7",
+        "display": "Body weight"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/soft-delete-search-patient"
+  },
+  "valueQuantity": {
+    "value": 72.5,
+    "unit": "kg",
+    "system": "http://unitsofmeasure.org",
+    "code": "kg"
+  }
+}
+
+### Create an active patient to show that normal resources are excluded
+PUT https://{{hostname}}/Patient/soft-delete-search-active-patient
+Content-Type: application/fhir+json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "soft-delete-search-active-patient",
+  "active": true,
+  "name": [
+    {
+      "family": "Active",
+      "given": [
+        "Alex"
+      ]
+    }
+  ]
+}
+
+### Soft delete the sample patient
+DELETE https://{{hostname}}/Patient/soft-delete-search-patient
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Soft delete the sample observation
+DELETE https://{{hostname}}/Observation/soft-delete-search-observation
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Search all soft-deleted resource types
+# Returns the deleted Patient and Observation, but not the active Patient.
+GET https://{{hostname}}/_deleted
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Search soft-deleted patients
+# The resource type is specified in the URL. This returns only the deleted Patient.
+GET https://{{hostname}}/Patient/_deleted
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Search soft-deleted observations
+GET https://{{hostname}}/Observation/_deleted
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Search resources deleted since a last-updated time
+# _since is inclusive. Use a timestamp before the DELETE requests above.
+GET https://{{hostname}}/_deleted?_since=2000-01-01T00:00:00Z
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Search a last-updated time range
+# _before is exclusive and cannot be in the future. Replace the example values
+# with timestamps that bracket the DELETE requests before running this request.
+GET https://{{hostname}}/Patient/_deleted?_since=2026-07-30T20:00:00Z&_before=2026-07-30T22:00:00Z
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Sort and page through soft-deleted resources
+# Only _lastUpdated is supported for sorting. The default order is descending.
+# @name deletedPage
+GET https://{{hostname}}/_deleted?_count=1&_sort=-_lastUpdated
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Record the next-page URL
+@deletedNextPage = {{deletedPage.response.body.link[0].url}}
+
+### Get the next page
+# @name deletedPage
+GET {{deletedNextPage}}
+Authorization: Bearer {{bearer.response.body.access_token}}
+

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -339,6 +339,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                 case OperationsConstants.BulkDelete:
                     routeName = RouteNames.BulkDeleteDefinition;
                     break;
+                case OperationsConstants.DeleteSearch:
+                    routeName = RouteNames.DeleteSearchOperationDefinition;
+                    break;
                 case OperationsConstants.BulkUpdate:
                     routeName = RouteNames.BulkUpdateDefinition;
                     break;

--- a/src/Microsoft.Health.Fhir.Api/Models/DeletedResourceSearchModel.cs
+++ b/src/Microsoft.Health.Fhir.Api/Models/DeletedResourceSearchModel.cs
@@ -1,0 +1,46 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Api.Models;
+
+/// <summary>
+/// Query parameters for searching soft-deleted resources.
+/// </summary>
+public class DeletedResourceSearchModel
+{
+    /// <summary>
+    /// Gets or sets the inclusive lower last-updated bound.
+    /// </summary>
+    [FromQuery(Name = KnownQueryParameterNames.Since)]
+    public PartialDateTime Since { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exclusive upper last-updated bound.
+    /// </summary>
+    [FromQuery(Name = KnownQueryParameterNames.Before)]
+    public PartialDateTime Before { get; set; }
+
+    /// <summary>
+    /// Gets or sets the page size.
+    /// </summary>
+    [FromQuery(Name = KnownQueryParameterNames.Count)]
+    public int? Count { get; set; }
+
+    /// <summary>
+    /// Gets or sets the continuation token.
+    /// </summary>
+    [FromQuery(Name = KnownQueryParameterNames.ContinuationToken)]
+    public string ContinuationToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last-updated sort order.
+    /// </summary>
+    [FromQuery(Name = KnownQueryParameterNames.Sort)]
+    public string Sort { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/delete-search.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/delete-search.json
@@ -1,0 +1,64 @@
+{
+    "resourceType": "OperationDefinition",
+    "id": "delete-search",
+    "url": "[base]/OperationDefinition/delete-search",
+    "version": "1.0.0",
+    "name": "Delete Search",
+    "status": "active",
+    "kind": "operation",
+    "description": "Searches current soft-deleted resources. The operation supports system-level and resource-type-level invocation and filters only by the resource last-updated time.",
+    "code": "delete-search",
+    "system": true,
+    "type": true,
+    "instance": false,
+    "parameter": [
+        {
+            "name": "_since",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "An inclusive lower bound on the soft-deleted resource's last-updated time.",
+            "type": "instant"
+        },
+        {
+            "name": "_before",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "An exclusive upper bound on the soft-deleted resource's last-updated time.",
+            "type": "instant"
+        },
+        {
+            "name": "_count",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The maximum number of soft-deleted resources to return in one page.",
+            "type": "integer"
+        },
+        {
+            "name": "_continuationToken",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The continuation token used to retrieve the next page.",
+            "type": "string"
+        },
+        {
+            "name": "_sort",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The result order. Only _lastUpdated and -_lastUpdated are supported.",
+            "type": "string"
+        },
+        {
+            "name": "return",
+            "use": "out",
+            "min": 1,
+            "max": "1",
+            "documentation": "A history bundle containing current soft-deleted resources.",
+            "type": "Bundle"
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/OperationsConstants.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/OperationsConstants.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string BulkDeleteSoftDeleted = "bulk-delete-soft-deleted";
 
+        public const string DeleteSearch = "delete-search";
+
         public const string Includes = "includes";
 
         public const string BulkUpdate = "bulk-update";

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs
@@ -21,11 +21,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         private const string VidRouteSegment = "{" + KnownActionParameterNames.Vid + "}";
 
         public const string History = "_history";
-        public const string Deleted = "_deleted";
         public const string Search = "_search";
         public const string ResourceType = ResourceTypeRouteSegment;
         public const string ResourceTypeHistory = ResourceType + "/" + History;
-        public const string ResourceTypeDeleted = ResourceType + "/" + Deleted;
         public const string ResourceTypeSearch = ResourceType + "/" + Search;
         public const string ResourceTypeById = ResourceType + "/" + IdRouteSegment;
         public const string ResourceTypeByIdHistory = ResourceTypeById + "/" + History;
@@ -97,6 +95,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         public const string BulkDeleteOperationDefinition = OperationDefinition + "/" + OperationsConstants.BulkDelete;
         public const string ResourceTypeBulkDeleteOperationDefinition = OperationDefinition + "/" + OperationsConstants.ResourceTypeBulkDelete;
         public const string BulkDeleteSoftDeletedOperationDefinition = OperationDefinition + "/" + OperationsConstants.BulkDeleteSoftDeleted;
+
+        public const string DeleteSearch = "$delete-search";
+        public const string DeleteSearchResourceType = ResourceType + "/" + DeleteSearch;
+        public const string DeleteSearchOperationDefinition = OperationDefinition + "/" + OperationsConstants.DeleteSearch;
 
         public const string BulkUpdate = "$bulk-update";
         public const string BulkUpdateResourceType = ResourceType + "/" + BulkUpdate;

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/KnownRoutes.cs
@@ -21,9 +21,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         private const string VidRouteSegment = "{" + KnownActionParameterNames.Vid + "}";
 
         public const string History = "_history";
+        public const string Deleted = "_deleted";
         public const string Search = "_search";
         public const string ResourceType = ResourceTypeRouteSegment;
         public const string ResourceTypeHistory = ResourceType + "/" + History;
+        public const string ResourceTypeDeleted = ResourceType + "/" + Deleted;
         public const string ResourceTypeSearch = ResourceType + "/" + Search;
         public const string ResourceTypeById = ResourceType + "/" + IdRouteSegment;
         public const string ResourceTypeByIdHistory = ResourceTypeById + "/" + History;

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/RouteNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/RouteNames.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
 
         internal const string HistoryTypeId = nameof(HistoryTypeId);
 
-        internal const string Deleted = nameof(Deleted);
+        internal const string DeleteSearch = nameof(DeleteSearch);
 
-        internal const string DeletedType = nameof(DeletedType);
+        internal const string DeleteSearchType = nameof(DeleteSearchType);
 
         internal const string SearchCompartmentByResourceType = nameof(SearchCompartmentByResourceType);
 
@@ -84,6 +84,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         internal const string BulkDeleteDefinition = nameof(BulkDeleteDefinition);
 
         internal const string BulkDeleteSoftDeletedDefinition = nameof(BulkDeleteSoftDeletedDefinition);
+
+        internal const string DeleteSearchOperationDefinition = nameof(DeleteSearchOperationDefinition);
 
         internal const string Includes = nameof(Includes);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/RouteNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/RouteNames.cs
@@ -25,6 +25,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
 
         internal const string HistoryTypeId = nameof(HistoryTypeId);
 
+        internal const string Deleted = nameof(Deleted);
+
+        internal const string DeletedType = nameof(DeletedType);
+
         internal const string SearchCompartmentByResourceType = nameof(SearchCompartmentByResourceType);
 
         internal const string AadSmartOnFhirProxyAuthorize = nameof(AadSmartOnFhirProxyAuthorize);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
@@ -82,6 +82,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bool isAsyncOperation = false);
 
         /// <summary>
+        /// Searches current soft-deleted resources.
+        /// </summary>
+        Task<SearchResult> SearchDeletedAsync(
+            string resourceType,
+            PartialDateTime since,
+            PartialDateTime before,
+            int? count,
+            string continuationToken,
+            string sort,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Searches resources by queryParameters and returns the raw resource,
         /// the current search param values for each resource,
         /// the history of each resource,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -96,6 +96,59 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             CancellationToken cancellationToken,
             bool isAsyncOperation = false)
         {
+            return await SearchByVersionTypeAsync(
+                resourceType,
+                resourceId,
+                at,
+                since,
+                before,
+                count,
+                summary,
+                continuationToken,
+                sort,
+                ResourceVersionType.Latest | ResourceVersionType.History | ResourceVersionType.SoftDeleted,
+                isAsyncOperation,
+                cancellationToken);
+        }
+
+        public async Task<SearchResult> SearchDeletedAsync(
+            string resourceType,
+            PartialDateTime since,
+            PartialDateTime before,
+            int? count,
+            string continuationToken,
+            string sort,
+            CancellationToken cancellationToken)
+        {
+            return await SearchByVersionTypeAsync(
+                resourceType,
+                resourceId: null,
+                at: null,
+                since,
+                before,
+                count,
+                summary: null,
+                continuationToken,
+                sort,
+                ResourceVersionType.SoftDeleted,
+                isAsyncOperation: false,
+                cancellationToken);
+        }
+
+        private async Task<SearchResult> SearchByVersionTypeAsync(
+            string resourceType,
+            string resourceId,
+            PartialDateTime at,
+            PartialDateTime since,
+            PartialDateTime before,
+            int? count,
+            string summary,
+            string continuationToken,
+            string sort,
+            ResourceVersionType resourceVersionTypes,
+            bool isAsyncOperation,
+            CancellationToken cancellationToken)
+        {
             var queryParameters = new List<Tuple<string, string>>();
 
             if (at != null)
@@ -198,9 +251,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 queryParameters.Add(Tuple.Create(KnownQueryParameterNames.Sort, $"-{KnownQueryParameterNames.LastUpdated}"));
             }
 
-            var historyResourceVersionTypes = ResourceVersionType.Latest | ResourceVersionType.History | ResourceVersionType.SoftDeleted;
-
-            SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation, historyResourceVersionTypes);
+            SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation, resourceVersionTypes);
 
             SearchResult searchResult = await SearchAsync(searchOptions, cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchDeletedResourcesRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchDeletedResourcesRequest.cs
@@ -1,0 +1,77 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Medino;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Messages.Search
+{
+    /// <summary>
+    /// A request to search current soft-deleted resources.
+    /// </summary>
+    public class SearchDeletedResourcesRequest : IRequest<SearchResourceHistoryResponse>, IRequireCapability
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchDeletedResourcesRequest"/> class.
+        /// </summary>
+        public SearchDeletedResourcesRequest(
+            string resourceType,
+            PartialDateTime since,
+            PartialDateTime before,
+            int? count,
+            string continuationToken,
+            string sort)
+        {
+            ResourceType = resourceType;
+            Since = since;
+            Before = before;
+            Count = count;
+            ContinuationToken = continuationToken;
+            Sort = sort;
+        }
+
+        /// <summary>
+        /// Gets the optional resource type.
+        /// </summary>
+        public string ResourceType { get; }
+
+        /// <summary>
+        /// Gets the inclusive lower last-updated bound.
+        /// </summary>
+        public PartialDateTime Since { get; }
+
+        /// <summary>
+        /// Gets the exclusive upper last-updated bound.
+        /// </summary>
+        public PartialDateTime Before { get; }
+
+        /// <summary>
+        /// Gets the requested page size.
+        /// </summary>
+        public int? Count { get; }
+
+        /// <summary>
+        /// Gets the continuation token.
+        /// </summary>
+        public string ContinuationToken { get; }
+
+        /// <summary>
+        /// Gets the last-updated sort order.
+        /// </summary>
+        public string Sort { get; }
+
+        /// <inheritdoc />
+        public IEnumerable<CapabilityQuery> RequiredCapabilities()
+        {
+            string capability = string.IsNullOrEmpty(ResourceType)
+                ? "CapabilityStatement.rest.interaction.where(code = 'history-system').exists()"
+                : $"CapabilityStatement.rest.resource.where(type = '{ResourceType}').interaction.where(code = 'history-type').exists()";
+
+            yield return new CapabilityQuery(capability);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchDeletedResourcesRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchDeletedResourcesRequest.cs
@@ -3,9 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using Medino;
-using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Messages.Search
@@ -13,7 +11,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Search
     /// <summary>
     /// A request to search current soft-deleted resources.
     /// </summary>
-    public class SearchDeletedResourcesRequest : IRequest<SearchResourceHistoryResponse>, IRequireCapability
+    public class SearchDeletedResourcesRequest : IRequest<SearchResourceHistoryResponse>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SearchDeletedResourcesRequest"/> class.
@@ -63,15 +61,5 @@ namespace Microsoft.Health.Fhir.Core.Messages.Search
         /// Gets the last-updated sort order.
         /// </summary>
         public string Sort { get; }
-
-        /// <inheritdoc />
-        public IEnumerable<CapabilityQuery> RequiredCapabilities()
-        {
-            string capability = string.IsNullOrEmpty(ResourceType)
-                ? "CapabilityStatement.rest.interaction.where(code = 'history-system').exists()"
-                : $"CapabilityStatement.rest.resource.where(type = '{ResourceType}').interaction.where(code = 'history-type').exists()";
-
-            yield return new CapabilityQuery(capability);
-        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -4,6 +4,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\OperationDefinition\convert-data.json" />
+    <EmbeddedResource Include="Data\OperationDefinition\delete-search.json" />
     <EmbeddedResource Include="Data\OperationDefinition\member-match.json" />
     <EmbeddedResource Include="Data\OperationDefinition\purge-history.json" />
     <EmbeddedResource Include="Data\OperationDefinition\search-parameter-status.json" />

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Search/QueryBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Search/QueryBuilderTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Search
             string query = new QueryBuilder().BuildSqlQuerySpec(searchOptions).QueryText;
 
             Assert.Contains("r.isDeleted =", query);
-            Assert.DoesNotContain("r.isHistory =", query);
+            Assert.Contains("r.isHistory =", query);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Search/QueryBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Search/QueryBuilderTests.cs
@@ -1,0 +1,33 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Search
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class QueryBuilderTests
+    {
+        [Fact]
+        public void GivenSoftDeletedOnlySearch_WhenQueryBuilt_ThenOnlyDeletedResourcesAreSelected()
+        {
+            var searchOptions = new SearchOptions
+            {
+                ResourceVersionTypes = ResourceVersionType.SoftDeleted,
+                Sort = [],
+            };
+
+            string query = new QueryBuilder().BuildSqlQuerySpec(searchOptions).QueryText;
+
+            Assert.Contains("r.isDeleted =", query);
+            Assert.DoesNotContain("r.isHistory =", query);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                         true,
                         (KnownResourceWrapperProperties.IsHistory, true));
                 }
-                else if (searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.Latest) &&
+                else if ((searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.Latest) ||
+                    searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.SoftDeleted)) &&
                     !searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.History))
                 {
                     AppendFilterCondition(

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -79,15 +79,16 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                     searchOptions.Expression.AcceptVisitor(expressionQueryBuilder);
                 }
 
-                if (!searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.Latest))
+                if (searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.History) &&
+                    !searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.Latest))
                 {
                     AppendFilterCondition(
                         "AND",
                         true,
                         (KnownResourceWrapperProperties.IsHistory, true));
                 }
-
-                if (!searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.History))
+                else if (searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.Latest) &&
+                    !searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.History))
                 {
                     AppendFilterCondition(
                         "AND",
@@ -95,7 +96,16 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                         (KnownResourceWrapperProperties.IsHistory, false));
                 }
 
-                if (!searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.SoftDeleted))
+                if (searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.SoftDeleted) &&
+                    !searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.Latest))
+                {
+                    AppendFilterCondition(
+                        "AND",
+                        true,
+                        (KnownResourceWrapperProperties.IsDeleted, true));
+                }
+                else if (searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.Latest) &&
+                    !searchOptions.ResourceVersionTypes.HasFlag(ResourceVersionType.SoftDeleted))
                 {
                     AppendFilterCondition(
                         "AND",

--- a/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Extensions/OperationDefinitionMediatorExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Extensions/OperationDefinitionMediatorExtensionsTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.Fhir.R4.Core.UnitTests.Extensions
         [InlineData("member-match")]
         [InlineData("convert-data")]
         [InlineData("purge-history")]
+        [InlineData("delete-search")]
         public async Task GivenVariousOperationNames_WhenGetOperationDefinitionAsync_ThenCorrectRequestIsSent(string operationName)
         {
             // Arrange

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
@@ -152,8 +152,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "SearchCompartmentByResourceType", _targetFhirControllerClass);
             TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "SystemHistory", _targetFhirControllerClass);
             TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "TypeHistory", _targetFhirControllerClass);
-            TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "DeletedResources", _targetFhirControllerClass);
-            TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "DeletedResourcesByType", _targetFhirControllerClass);
+            TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "DeleteSearch", _targetFhirControllerClass);
+            TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "DeleteSearchByType", _targetFhirControllerClass);
         }
 
         [Fact]
@@ -596,14 +596,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [Fact]
         public async Task GivenSystemDeletedResourceSearch_WhenProcessingRequest_ThenRequestShouldBeCreatedCorrectly()
         {
-            await RunDeletedResourceSearchTest((model, _) => _fhirController.DeletedResources(model));
+            await RunDeletedResourceSearchTest((model, _) => _fhirController.DeleteSearch(model));
         }
 
         [Fact]
         public async Task GivenTypeDeletedResourceSearch_WhenProcessingRequest_ThenRequestShouldBeCreatedCorrectly()
         {
             await RunDeletedResourceSearchTest(
-                (model, type) => _fhirController.DeletedResourcesByType(type, model),
+                (model, type) => _fhirController.DeleteSearchByType(type, model),
                 KnownResourceTypes.Patient);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
@@ -152,6 +152,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "SearchCompartmentByResourceType", _targetFhirControllerClass);
             TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "SystemHistory", _targetFhirControllerClass);
             TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "TypeHistory", _targetFhirControllerClass);
+            TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "DeletedResources", _targetFhirControllerClass);
+            TestIfTargetMethodContainsCustomAttribute(expectedCustomAttribute, "DeletedResourcesByType", _targetFhirControllerClass);
         }
 
         [Fact]
@@ -589,6 +591,20 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 (model, type, id) => _fhirController.History(type, id, model),
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString());
+        }
+
+        [Fact]
+        public async Task GivenSystemDeletedResourceSearch_WhenProcessingRequest_ThenRequestShouldBeCreatedCorrectly()
+        {
+            await RunDeletedResourceSearchTest((model, _) => _fhirController.DeletedResources(model));
+        }
+
+        [Fact]
+        public async Task GivenTypeDeletedResourceSearch_WhenProcessingRequest_ThenRequestShouldBeCreatedCorrectly()
+        {
+            await RunDeletedResourceSearchTest(
+                (model, type) => _fhirController.DeletedResourcesByType(type, model),
+                KnownResourceTypes.Patient);
         }
 
         [Fact]
@@ -1442,6 +1458,47 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await _mediator.Received(1).SendAsync<SearchResourceResponse>(
                 Arg.Any<SearchResourceRequest>(),
                 Arg.Any<CancellationToken>());
+        }
+
+        private async Task RunDeletedResourceSearchTest(
+            Func<DeletedResourceSearchModel, string, Task<IActionResult>> action,
+            string resourceType = null)
+        {
+            var resource = new Bundle
+            {
+                Id = Guid.NewGuid().ToString(),
+                VersionId = Guid.NewGuid().ToString(),
+            };
+            var httpContext = new DefaultHttpContext();
+            _fhirController.ControllerContext.HttpContext = httpContext;
+            _mediator.SendAsync<SearchResourceHistoryResponse>(
+                Arg.Any<SearchDeletedResourcesRequest>(),
+                Arg.Any<CancellationToken>())
+                .Returns(new SearchResourceHistoryResponse(resource.ToResourceElement()));
+            SearchDeletedResourcesRequest request = null;
+            _mediator.When(x => x.SendAsync<SearchResourceHistoryResponse>(
+                    Arg.Any<SearchDeletedResourcesRequest>(),
+                    Arg.Any<CancellationToken>()))
+                .Do(x => request = x.Arg<SearchDeletedResourcesRequest>());
+            var model = new DeletedResourceSearchModel
+            {
+                Since = PartialDateTime.Parse("2025-01-01"),
+                Before = PartialDateTime.Parse("2025-02-01"),
+                Count = 10,
+                ContinuationToken = "token",
+                Sort = $"-{KnownQueryParameterNames.LastUpdated}",
+            };
+
+            IActionResult response = await action(model, resourceType);
+
+            Assert.IsType<FhirResult>(response);
+            Assert.NotNull(request);
+            Assert.Equal(resourceType, request.ResourceType);
+            Assert.Equal(model.Since, request.Since);
+            Assert.Equal(model.Before, request.Before);
+            Assert.Equal(model.Count, request.Count);
+            Assert.Equal(model.ContinuationToken, request.ContinuationToken);
+            Assert.Equal(model.Sort, request.Sort);
         }
 
         private static void TestIfTargetMethodContainsCustomAttribute(Type expectedCustomAttributeType, string methodName, Type targetClassType)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/OperationDefinitionControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/OperationDefinitionControllerTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Messages.Operation;
 using Microsoft.Health.Fhir.Core.Registration;
@@ -267,6 +268,16 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
             await _mediator.DidNotReceive().SendAsync<OperationDefinitionResponse>(
                 Arg.Any<OperationDefinitionRequest>(),
+                Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenConfiguration_WhenDeleteSearchIsEnabled_ThenOperationDefinitionShouldBeReturned()
+        {
+            await _controller.DeleteSearchOperationDefinition();
+
+            await _mediator.Received(1).SendAsync<OperationDefinitionResponse>(
+                Arg.Is<OperationDefinitionRequest>(request => request.OperationName == OperationsConstants.DeleteSearch),
                 Arg.Any<CancellationToken>());
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/OperationsCapabilityProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/OperationsCapabilityProviderTests.cs
@@ -407,6 +407,50 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Operations
             Assert.Equal(OperationDefinitionUrl, restComponent.Operation.First().Definition?.Reference, StringComparer.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public async Task GivenAConformanceBuilder_WhenCallingOperationsCapability_ThenDeleteSearchDetailsAreAdded()
+        {
+            var provider = new OperationsCapabilityProvider(
+                _operationsOptions,
+                _featureOptions,
+                _coreFeatureOptions,
+                _implementationGuidesOptions,
+                _watchdogOptions,
+                _urlResolver,
+                _fhirRuntimeConfiguration);
+            ICapabilityStatementBuilder builder = Substitute.For<ICapabilityStatementBuilder>();
+
+            await provider.BuildAsync(builder, CancellationToken.None);
+
+            builder.Received(1)
+                .Apply(Arg.Is<Action<ListedCapabilityStatement>>(x => x.Method.Name == nameof(OperationsCapabilityProvider.AddDeleteSearchDetails)));
+        }
+
+        [Fact]
+        public void GivenProvider_WhenAddingDetails_ThenDeleteSearchOperationShouldBeAdded()
+        {
+            var provider = new OperationsCapabilityProvider(
+                _operationsOptions,
+                _featureOptions,
+                _coreFeatureOptions,
+                _implementationGuidesOptions,
+                _watchdogOptions,
+                _urlResolver,
+                _fhirRuntimeConfiguration);
+            var restComponent = new ListedRestComponent
+            {
+                Mode = ListedCapabilityStatement.ServerMode,
+            };
+            var capabilityStatement = new ListedCapabilityStatement();
+            capabilityStatement.Rest.Add(restComponent);
+
+            provider.AddDeleteSearchDetails(capabilityStatement);
+
+            Assert.Single(restComponent.Operation);
+            Assert.Equal(OperationsConstants.DeleteSearch, restComponent.Operation.First().Name, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(OperationDefinitionUrl, restComponent.Operation.First().Definition?.Reference, StringComparer.OrdinalIgnoreCase);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
@@ -312,6 +312,17 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
         }
 
         [Fact]
+        public void GivenADeleteSearchOperation_WhenOperationDefinitionUrlIsResolved_ThenCorrectUrlShouldBeReturned()
+        {
+            _urlResolver.ResolveOperationDefinitionUrl(OperationsConstants.DeleteSearch);
+
+            Assert.NotNull(_capturedUrlRouteContext);
+            Assert.Equal(RouteNames.DeleteSearchOperationDefinition, _capturedUrlRouteContext.RouteName);
+            Assert.Equal(Scheme, _capturedUrlRouteContext.Protocol);
+            Assert.Equal(Host, _capturedUrlRouteContext.Host);
+        }
+
+        [Fact]
         public void GivenAnUnknownOperation_WhenOperationResultUrlIsResolved_ThenOperationNotImplementedExceptionShouldBeThrown()
         {
             const string id = "12345";

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -371,6 +371,53 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         }
 
         /// <summary>
+        /// Returns current soft-deleted resources in the system.
+        /// </summary>
+        /// <param name="searchModel">Model for last-updated and paging parameters.</param>
+        [HttpGet]
+        [Route(KnownRoutes.Deleted, Name = RouteNames.Deleted)]
+        [AuditEventType(AuditEventSubType.HistorySystem)]
+        [TypeFilter(typeof(SearchEndpointMetricEmitterAttribute))]
+        public async Task<IActionResult> DeletedResources(DeletedResourceSearchModel searchModel)
+        {
+            ResourceElement response = await _mediator.SearchDeletedResourcesAsync(
+                resourceType: null,
+                searchModel.Since,
+                searchModel.Before,
+                searchModel.Count,
+                searchModel.ContinuationToken,
+                searchModel.Sort,
+                HttpContext.RequestAborted);
+
+            return FhirResult.Create(response);
+        }
+
+        /// <summary>
+        /// Returns current soft-deleted resources of a specific type.
+        /// </summary>
+        /// <param name="typeParameter">The resource type.</param>
+        /// <param name="searchModel">Model for last-updated and paging parameters.</param>
+        [HttpGet]
+        [Route(KnownRoutes.ResourceTypeDeleted, Name = RouteNames.DeletedType)]
+        [AuditEventType(AuditEventSubType.HistoryType)]
+        [TypeFilter(typeof(SearchEndpointMetricEmitterAttribute))]
+        public async Task<IActionResult> DeletedResourcesByType(
+            string typeParameter,
+            DeletedResourceSearchModel searchModel)
+        {
+            ResourceElement response = await _mediator.SearchDeletedResourcesAsync(
+                typeParameter,
+                searchModel.Since,
+                searchModel.Before,
+                searchModel.Count,
+                searchModel.ContinuationToken,
+                searchModel.Sort,
+                HttpContext.RequestAborted);
+
+            return FhirResult.Create(response);
+        }
+
+        /// <summary>
         /// Returns the history of a resource
         /// </summary>
         /// <param name="typeParameter">The resource type.</param>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -375,10 +375,10 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// </summary>
         /// <param name="searchModel">Model for last-updated and paging parameters.</param>
         [HttpGet]
-        [Route(KnownRoutes.Deleted, Name = RouteNames.Deleted)]
+        [Route(KnownRoutes.DeleteSearch, Name = RouteNames.DeleteSearch)]
         [AuditEventType(AuditEventSubType.HistorySystem)]
         [TypeFilter(typeof(SearchEndpointMetricEmitterAttribute))]
-        public async Task<IActionResult> DeletedResources(DeletedResourceSearchModel searchModel)
+        public async Task<IActionResult> DeleteSearch(DeletedResourceSearchModel searchModel)
         {
             ResourceElement response = await _mediator.SearchDeletedResourcesAsync(
                 resourceType: null,
@@ -398,10 +398,10 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <param name="typeParameter">The resource type.</param>
         /// <param name="searchModel">Model for last-updated and paging parameters.</param>
         [HttpGet]
-        [Route(KnownRoutes.ResourceTypeDeleted, Name = RouteNames.DeletedType)]
+        [Route(KnownRoutes.DeleteSearchResourceType, Name = RouteNames.DeleteSearchType)]
         [AuditEventType(AuditEventSubType.HistoryType)]
         [TypeFilter(typeof(SearchEndpointMetricEmitterAttribute))]
-        public async Task<IActionResult> DeletedResourcesByType(
+        public async Task<IActionResult> DeleteSearchByType(
             string typeParameter,
             DeletedResourceSearchModel searchModel)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
@@ -153,6 +153,14 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         }
 
         [HttpGet]
+        [Route(KnownRoutes.DeleteSearchOperationDefinition, Name = RouteNames.DeleteSearchOperationDefinition)]
+        [AllowAnonymous]
+        public async Task<IActionResult> DeleteSearchOperationDefinition()
+        {
+            return await GetOperationDefinitionAsync(OperationsConstants.DeleteSearch);
+        }
+
+        [HttpGet]
         [Route(KnownRoutes.BulkUpdateOperationDefinition, Name = RouteNames.BulkUpdateDefinition)]
         [AllowAnonymous]
         public async Task<IActionResult> BulkUpdateOperationDefinition()
@@ -228,6 +236,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                     break;
                 case OperationsConstants.MemberMatch:
                 case OperationsConstants.PurgeHistory:
+                case OperationsConstants.DeleteSearch:
                     operationEnabled = true;
                     break;
                 case OperationsConstants.SearchParameterStatus:

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
 
             builder.Apply(AddMemberMatchDetails);
             builder.Apply(AddPatientEverythingDetails);
+            builder.Apply(AddDeleteSearchDetails);
 
             if (_operationConfiguration.BulkDelete.Enabled)
             {
@@ -186,6 +187,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
         public void AddBulkDeleteDetails(ListedCapabilityStatement capabilityStatement)
         {
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.BulkDelete);
+        }
+
+        public void AddDeleteSearchDetails(ListedCapabilityStatement capabilityStatement)
+        {
+            GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.DeleteSearch);
         }
 
         public void AddBulkUpdateDetails(ListedCapabilityStatement capabilityStatement)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Extensions/OperationDefinitionMediatorExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Extensions/OperationDefinitionMediatorExtensionsTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         [InlineData("member-match")]
         [InlineData("convert-data")]
         [InlineData("purge-history")]
+        [InlineData("delete-search")]
         public async Task GivenVariousOperationNames_WhenGetOperationDefinitionAsync_ThenCorrectRequestIsSent(string operationName)
         {
             // Arrange

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchDeletedResourcesHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchDeletedResourcesHandlerTests.cs
@@ -1,0 +1,73 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Filters;
+using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Core.Messages.Search;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SearchDeletedResourcesHandlerTests
+    {
+        [Fact]
+        public async Task GivenADeletedResourceSearch_WhenHandled_ThenAHistoryBundleIsReturned()
+        {
+            ISearchService searchService = Substitute.For<ISearchService>();
+            IBundleFactory bundleFactory = Substitute.For<IBundleFactory>();
+            var handler = new SearchDeletedResourcesHandler(
+                searchService,
+                bundleFactory,
+                DisabledFhirAuthorizationService.Instance,
+                new DataResourceFilter(MissingDataFilterCriteria.Default));
+            var request = new SearchDeletedResourcesRequest("Patient", null, null, null, null, null);
+            var searchResult = new SearchResult(Enumerable.Empty<SearchResultEntry>(), null, null, Array.Empty<Tuple<string, string>>());
+            var expectedBundle = new Bundle().ToResourceElement();
+
+            searchService.SearchDeletedAsync("Patient", null, null, null, null, null, CancellationToken.None).Returns(searchResult);
+            bundleFactory.CreateHistoryBundle(searchResult).Returns(expectedBundle);
+
+            SearchResourceHistoryResponse response = await handler.HandleAsync(request, CancellationToken.None);
+
+            Assert.Same(expectedBundle, response.Bundle);
+        }
+
+        [Theory]
+        [InlineData(DataActions.None)]
+        [InlineData(DataActions.Write)]
+        [InlineData(DataActions.ReadById)]
+        public async Task GivenADeletedResourceSearch_WhenUserLacksSearchAccess_ThenAuthorizationFails(DataActions dataActions)
+        {
+            ISearchService searchService = Substitute.For<ISearchService>();
+            IBundleFactory bundleFactory = Substitute.For<IBundleFactory>();
+            IAuthorizationService<DataActions> authorizationService = Substitute.For<IAuthorizationService<DataActions>>();
+            var handler = new SearchDeletedResourcesHandler(
+                searchService,
+                bundleFactory,
+                authorizationService,
+                new DataResourceFilter(MissingDataFilterCriteria.Default));
+            var request = new SearchDeletedResourcesRequest(null, null, null, null, null, null);
+
+            authorizationService.CheckAccess(DataActions.Read | DataActions.Search, CancellationToken.None).Returns(dataActions);
+
+            await Assert.ThrowsAsync<Microsoft.Health.Fhir.Core.Exceptions.UnauthorizedFhirActionException>(
+                () => handler.HandleAsync(request, CancellationToken.None));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
@@ -168,6 +168,44 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Assert.Same(expectedSearchResult, singlePatientSummaryCount);
         }
 
+        [Fact]
+        public async Task GivenADeletedResourceSearch_WhenSearched_ThenOnlySoftDeletedResourcesAreRequested()
+        {
+            const string resourceType = "Observation";
+            var since = PartialDateTime.Parse("2025-01-01");
+            var before = PartialDateTime.Parse("2025-02-01");
+            var expectedSearchOptions = new SearchOptions();
+
+            _searchOptionsFactory.Create(
+                resourceType,
+                Arg.Is<IReadOnlyList<Tuple<string, string>>>(parameters =>
+                    parameters.Contains(Tuple.Create(SearchParameterNames.LastUpdated, $"ge{since}")) &&
+                    parameters.Contains(Tuple.Create(SearchParameterNames.LastUpdated, $"lt{before}")) &&
+                    parameters.Contains(Tuple.Create(KnownQueryParameterNames.Count, "25")) &&
+                    parameters.Contains(Tuple.Create(KnownQueryParameterNames.ContinuationToken, "token")) &&
+                    parameters.Contains(Tuple.Create(KnownQueryParameterNames.Sort, $"-{KnownQueryParameterNames.LastUpdated}"))),
+                resourceVersionTypes: ResourceVersionType.SoftDeleted)
+                .Returns(expectedSearchOptions);
+
+            SearchResult expectedSearchResult = SearchResult.Empty(_unsupportedQueryParameters);
+            _searchService.SearchImplementation = options =>
+            {
+                Assert.Same(expectedSearchOptions, options);
+                return expectedSearchResult;
+            };
+
+            SearchResult actual = await _searchService.SearchDeletedAsync(
+                resourceType,
+                since,
+                before,
+                25,
+                "token",
+                $"-{KnownQueryParameterNames.LastUpdated}",
+                CancellationToken.None);
+
+            Assert.Same(expectedSearchResult, actual);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -129,6 +129,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Expressions\Parsers\SearchValueExpressionBuilderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchExpressionTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchOptionsFactoryTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchDeletedResourcesHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHistoryHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchServiceTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/FhirMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/FhirMediatorExtensions.cs
@@ -141,6 +141,25 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             return result.Bundle;
         }
 
+        public static async Task<ResourceElement> SearchDeletedResourcesAsync(
+            this IMediator mediator,
+            string resourceType,
+            PartialDateTime since = null,
+            PartialDateTime before = null,
+            int? count = null,
+            string continuationToken = null,
+            string sort = null,
+            CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
+
+            var result = await mediator.SendAsync(
+                new SearchDeletedResourcesRequest(resourceType, since, before, count, continuationToken, sort),
+                cancellationToken);
+
+            return result.Bundle;
+        }
+
         public static async Task<ResourceElement> SearchResourceCompartmentAsync(this IMediator mediator, string compartmentType, string compartmentId, string resourceType, IReadOnlyList<Tuple<string, string>> queries, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchDeletedResourcesHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchDeletedResourcesHandler.cs
@@ -1,0 +1,66 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Medino;
+using Microsoft.Health.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Core.Messages.Search;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    /// <summary>
+    /// Handles searches for current soft-deleted resources.
+    /// </summary>
+    public class SearchDeletedResourcesHandler : IRequestHandler<SearchDeletedResourcesRequest, SearchResourceHistoryResponse>
+    {
+        private readonly ISearchService _searchService;
+        private readonly IBundleFactory _bundleFactory;
+        private readonly IAuthorizationService<DataActions> _authorizationService;
+        private readonly IDataResourceFilter _dataResourceFilter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchDeletedResourcesHandler"/> class.
+        /// </summary>
+        public SearchDeletedResourcesHandler(
+            ISearchService searchService,
+            IBundleFactory bundleFactory,
+            IAuthorizationService<DataActions> authorizationService,
+            IDataResourceFilter dataResourceFilter)
+        {
+            _searchService = EnsureArg.IsNotNull(searchService, nameof(searchService));
+            _bundleFactory = EnsureArg.IsNotNull(bundleFactory, nameof(bundleFactory));
+            _authorizationService = EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
+            _dataResourceFilter = EnsureArg.IsNotNull(dataResourceFilter, nameof(dataResourceFilter));
+        }
+
+        /// <inheritdoc />
+        public async Task<SearchResourceHistoryResponse> HandleAsync(SearchDeletedResourcesRequest request, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+
+            await _authorizationService.CheckSearchAccess(cancellationToken);
+
+            SearchResult searchResult = await _searchService.SearchDeletedAsync(
+                request.ResourceType,
+                request.Since,
+                request.Before,
+                request.Count,
+                request.ContinuationToken,
+                request.Sort,
+                cancellationToken);
+
+            searchResult = _dataResourceFilter.Filter(searchResult);
+
+            ResourceElement bundle = _bundleFactory.CreateHistoryBundle(searchResult);
+            return new SearchResourceHistoryResponse(bundle);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
@@ -90,6 +90,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ServerProvideProfileValidation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Features\Search\RawBundleEntryComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchOptionsFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchDeletedResourcesHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHistoryHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ModelAttributeValidator.cs" />

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
@@ -95,6 +95,7 @@ public class SqlQueryGeneratorTests
         var output = _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
 
         Assert.Contains("IsDeleted = 1", _strBuilder.ToString());
+        Assert.Contains("IsHistory = 0", _strBuilder.ToString());
     }
 
     [Fact]

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -1744,12 +1744,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 return;
             }
 
-            if (resourceVersionType.HasFlag(ResourceVersionType.Latest) && !resourceVersionType.HasFlag(ResourceVersionType.History))
+            if ((resourceVersionType.HasFlag(ResourceVersionType.Latest) ||
+                resourceVersionType.HasFlag(ResourceVersionType.SoftDeleted)) &&
+                !resourceVersionType.HasFlag(ResourceVersionType.History))
             {
                 delimited.BeginDelimitedElement();
                 StringBuilder.Append(VLatest.Resource.IsHistory, tableAlias).Append(" = 0 ");
             }
-            else if (resourceVersionType.HasFlag(ResourceVersionType.History) && !resourceVersionType.HasFlag(ResourceVersionType.Latest))
+            else if (resourceVersionType.HasFlag(ResourceVersionType.History) &&
+                !resourceVersionType.HasFlag(ResourceVersionType.Latest))
             {
                 delimited.BeginDelimitedElement();
                 StringBuilder.Append(VLatest.Resource.IsHistory, tableAlias).Append(" = 1 ");


### PR DESCRIPTION
## Description
Adds a $deleted operation that lets users search for soft deleted resources.

## Related issues
Addresses [User Story 108818](https://microsofthealth.visualstudio.com/Health/_workitems/edit/108818)

## Testing
Manual testing and new unit/E2E tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
