### PR TITLE
Fix deleted resources having search parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
@@ -70,7 +70,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         public ResourceWrapper Create(ResourceElement resource, bool deleted, bool keepMeta, bool keepVersion = false)
         {
             RawResource rawResource = _rawResourceFactory.Create(resource, keepMeta, keepVersion);
-            IReadOnlyCollection<SearchIndexEntry> searchIndices = _searchIndexer.Extract(resource);
+            IReadOnlyCollection<SearchIndexEntry> searchIndices = deleted
+                ? Array.Empty<SearchIndexEntry>()
+                : _searchIndexer.Extract(resource);
 
             string searchParamHash = _searchParameterDefinitionManager.GetSearchParameterHashForResourceType(resource.InstanceType);
 
@@ -92,6 +94,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         /// <inheritdoc />
         public void Update(ResourceWrapper resourceWrapper)
         {
+            if (resourceWrapper.IsDeleted)
+            {
+                resourceWrapper.UpdateSearchIndices(Array.Empty<SearchIndexEntry>());
+                return;
+            }
+
             var resourceElement = _resourceDeserializer.Deserialize(resourceWrapper);
             var newIndices = _searchIndexer.Extract(resourceElement);
             ExtractMinAndMaxValues(newIndices);

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EnsureThat;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
@@ -70,9 +71,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         public ResourceWrapper Create(ResourceElement resource, bool deleted, bool keepMeta, bool keepVersion = false)
         {
             RawResource rawResource = _rawResourceFactory.Create(resource, keepMeta, keepVersion);
-            IReadOnlyCollection<SearchIndexEntry> searchIndices = deleted
-                ? Array.Empty<SearchIndexEntry>()
-                : _searchIndexer.Extract(resource);
+            IReadOnlyCollection<SearchIndexEntry> searchIndices = _searchIndexer.Extract(resource);
+
+            if (deleted && searchIndices.Any(x => x.SearchParameter.Code != KnownQueryParameterNames.LastUpdated && x.SearchParameter.Code != KnownQueryParameterNames.Id))
+            {
+                searchIndices = searchIndices.Where(x => x.SearchParameter.Code == KnownQueryParameterNames.LastUpdated || x.SearchParameter.Code == KnownQueryParameterNames.Id).ToList();
+            }
 
             string searchParamHash = _searchParameterDefinitionManager.GetSearchParameterHashForResourceType(resource.InstanceType);
 
@@ -96,7 +100,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         {
             if (resourceWrapper.IsDeleted)
             {
-                resourceWrapper.UpdateSearchIndices(Array.Empty<SearchIndexEntry>());
+                var searchIndices = resourceWrapper.SearchIndices.Where(x => x.SearchParameter.Code == KnownQueryParameterNames.LastUpdated || x.SearchParameter.Code == KnownQueryParameterNames.Id).ToList();
+                resourceWrapper.UpdateSearchIndices(searchIndices);
                 return;
             }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Persistence/ResourceWrapperFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Persistence/ResourceWrapperFactoryTests.cs
@@ -141,5 +141,50 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
                 }
             }
         }
+
+        [Fact]
+        public void GivenDeletedResource_WhenCreate_ThenSearchIndicesAreNotExtracted()
+        {
+            var deceasedSearchParameterInfo = new SearchParameterInfo("deceased", "deceased", ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-deceased"))
+            {
+                IsPartiallySupported = true,
+            };
+            _searchIndexer
+                .Extract(Arg.Any<ResourceElement>())
+                .Returns(new List<SearchIndexEntry>() { new SearchIndexEntry(deceasedSearchParameterInfo, new TokenSearchValue(null, "false", null)) });
+            _compartmentIndexer
+                .Extract(Arg.Any<string>(), Arg.Any<IReadOnlyCollection<SearchIndexEntry>>())
+                .Returns(new CompartmentIndices());
+
+            ResourceWrapper resourceWrapper = _resourceWrapperFactory.Create(Samples.GetDefaultPatient(), deleted: true, keepMeta: false);
+
+            Assert.Empty(resourceWrapper.SearchIndices);
+            _searchIndexer.DidNotReceive().Extract(Arg.Any<ResourceElement>());
+        }
+
+        [Fact]
+        public void GivenDeletedResource_WhenUpdate_ThenSearchIndicesAreCleared()
+        {
+            var deceasedSearchParameterInfo = new SearchParameterInfo("deceased", "deceased", ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-deceased"))
+            {
+                IsPartiallySupported = true,
+            };
+            var existingSearchIndices = new List<SearchIndexEntry>() { new SearchIndexEntry(deceasedSearchParameterInfo, new TokenSearchValue(null, "false", null)) };
+            ResourceElement resource = Samples.GetDefaultPatient();
+            ResourceWrapper resourceWrapper = new ResourceWrapper(
+                resource,
+                _rawResourceFactory.Create(resource, keepMeta: false),
+                new ResourceRequest("DELETE"),
+                deleted: true,
+                existingSearchIndices,
+                new CompartmentIndices(),
+                Array.Empty<KeyValuePair<string, string>>(),
+                searchParameterHash: "hash");
+
+            _resourceWrapperFactory.Update(resourceWrapper);
+
+            Assert.Empty(resourceWrapper.SearchIndices);
+            _searchIndexer.DidNotReceive().Extract(Arg.Any<ResourceElement>());
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Persistence/ResourceWrapperFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Persistence/ResourceWrapperFactoryTests.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Compartment;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -38,6 +40,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
         private readonly SearchParameterInfo _nameSearchParameterInfo;
         private readonly SearchParameterInfo _addressSearchParameterInfo;
         private readonly SearchParameterInfo _ageSearchParameterInfo;
+        private readonly SearchParameterInfo _lastUpdatedSearchParameterInfo;
+        private readonly SearchParameterInfo _idSearchParameterInfo;
+        private readonly SearchParameterInfo _deceasedSearchParameterInfo;
 
         public ResourceWrapperFactoryTests()
         {
@@ -73,6 +78,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
             _nameSearchParameterInfo = new SearchParameterInfo("name", "name", ValueSets.SearchParamType.String, new Uri("https://localhost/searchParameter/name")) { SortStatus = SortParameterStatus.Enabled };
             _addressSearchParameterInfo = new SearchParameterInfo("address-city", "address-city", ValueSets.SearchParamType.String, new Uri("https://localhost/searchParameter/address-city")) { SortStatus = SortParameterStatus.Enabled };
             _ageSearchParameterInfo = new SearchParameterInfo("age", "age", ValueSets.SearchParamType.Number, new Uri("https://localhost/searchParameter/age")) { SortStatus = SortParameterStatus.Supported };
+            _deceasedSearchParameterInfo = new SearchParameterInfo("deceased", "deceased", ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-deceased"))
+            {
+                IsPartiallySupported = true,
+            };
+            _lastUpdatedSearchParameterInfo = new SearchParameterInfo(KnownQueryParameterNames.LastUpdated, KnownQueryParameterNames.LastUpdated, ValueSets.SearchParamType.Date, new Uri("http://hl7.org/fhir/SearchParameter/Resource-lastUpdated"));
+            _idSearchParameterInfo = new SearchParameterInfo(KnownQueryParameterNames.Id, KnownQueryParameterNames.Id, ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Resource-id"));
         }
 
         [Fact]
@@ -143,33 +154,35 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
         }
 
         [Fact]
-        public void GivenDeletedResource_WhenCreate_ThenSearchIndicesAreNotExtracted()
+        public void GivenDeletedResource_WhenCreate_ThenOnlyBasicSearchIndicesAreExtracted()
         {
-            var deceasedSearchParameterInfo = new SearchParameterInfo("deceased", "deceased", ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-deceased"))
-            {
-                IsPartiallySupported = true,
-            };
             _searchIndexer
                 .Extract(Arg.Any<ResourceElement>())
-                .Returns(new List<SearchIndexEntry>() { new SearchIndexEntry(deceasedSearchParameterInfo, new TokenSearchValue(null, "false", null)) });
+                .Returns(new List<SearchIndexEntry>()
+                {
+                    new SearchIndexEntry(_deceasedSearchParameterInfo, new TokenSearchValue(null, "false", null)),
+                    new SearchIndexEntry(_lastUpdatedSearchParameterInfo, new DateTimeSearchValue(DateTimeOffset.UtcNow)),
+                    new SearchIndexEntry(_idSearchParameterInfo, new TokenSearchValue(null, "123", null)),
+                });
             _compartmentIndexer
                 .Extract(Arg.Any<string>(), Arg.Any<IReadOnlyCollection<SearchIndexEntry>>())
                 .Returns(new CompartmentIndices());
 
             ResourceWrapper resourceWrapper = _resourceWrapperFactory.Create(Samples.GetDefaultPatient(), deleted: true, keepMeta: false);
 
-            Assert.Empty(resourceWrapper.SearchIndices);
-            _searchIndexer.DidNotReceive().Extract(Arg.Any<ResourceElement>());
+            Assert.Equal(2, resourceWrapper.SearchIndices.Count);
+            Assert.True(resourceWrapper.SearchIndices.All(x => x.SearchParameter.Code == KnownQueryParameterNames.LastUpdated || x.SearchParameter.Code == KnownQueryParameterNames.Id));
         }
 
         [Fact]
         public void GivenDeletedResource_WhenUpdate_ThenSearchIndicesAreCleared()
         {
-            var deceasedSearchParameterInfo = new SearchParameterInfo("deceased", "deceased", ValueSets.SearchParamType.Token, new Uri("http://hl7.org/fhir/SearchParameter/Patient-deceased"))
+            var existingSearchIndices = new List<SearchIndexEntry>()
             {
-                IsPartiallySupported = true,
+                new SearchIndexEntry(_deceasedSearchParameterInfo, new TokenSearchValue(null, "false", null)),
+                new SearchIndexEntry(_lastUpdatedSearchParameterInfo, new DateTimeSearchValue(DateTimeOffset.UtcNow)),
+                new SearchIndexEntry(_idSearchParameterInfo, new TokenSearchValue(null, "123", null)),
             };
-            var existingSearchIndices = new List<SearchIndexEntry>() { new SearchIndexEntry(deceasedSearchParameterInfo, new TokenSearchValue(null, "false", null)) };
             ResourceElement resource = Samples.GetDefaultPatient();
             ResourceWrapper resourceWrapper = new ResourceWrapper(
                 resource,
@@ -183,8 +196,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
 
             _resourceWrapperFactory.Update(resourceWrapper);
 
-            Assert.Empty(resourceWrapper.SearchIndices);
-            _searchIndexer.DidNotReceive().Extract(Arg.Any<ResourceElement>());
+            Assert.Equal(2, resourceWrapper.SearchIndices.Count);
+            Assert.True(resourceWrapper.SearchIndices.All(x => x.SearchParameter.Code == KnownQueryParameterNames.LastUpdated || x.SearchParameter.Code == KnownQueryParameterNames.Id));
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
@@ -168,6 +169,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.True(cnt == 1, $"total count: expected=1 actual={cnt}");
             cnt = bundle.Resource.Entry.Count(_ => _.Resource.Id == id);
             Assert.True(cnt == 1, $"count with specific id: expected=1 actual={cnt}");
+        }
+
+        [Fact]
+        public async Task GivenAPatient_WhenSoftDeleted_ThenDeceasedFalseCountShouldNotChange()
+        {
+            // A tag filter would hide an invalid Patient-deceased row left on the tombstone.
+            var countBefore = await Client.SearchAsync("Patient?deceased=false&_summary=count");
+
+            var createResponse = await Client.CreateAsync(new Patient());
+            await Client.DeleteAsync(createResponse.Resource);
+
+            var countAfter = await Client.SearchAsync("Patient?deceased=false&_summary=count");
+
+            Assert.Equal(countBefore.Resource.Total, countAfter.Resource.Total);
         }
     }
 }


### PR DESCRIPTION
## Description
Prevents deleted resources from getting search indexes assigned to them.

## Related issues
Addresses [Bug 200259](https://microsofthealth.visualstudio.com/Health/_workitems/edit/200259)

## Testing
New tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
