### PR TITLE
Fix search parameter status defects on long-lived databases

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Messages.Search;
@@ -35,6 +36,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         private static readonly string ResourceSecurity = "http://hl7.org/fhir/SearchParameter/Resource-security";
         private static readonly string ResourceQuery = "http://hl7.org/fhir/SearchParameter/Resource-query";
         private static readonly string ResourceSource = "http://hl7.org/fhir/SearchParameter/Resource-source";
+        private static readonly string MissingUri = "http://hl7.org/fhir/SearchParameter/us-core-patient-gender-identity";
 
         private readonly SearchParameterStatusManager _manager;
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
@@ -253,6 +255,98 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
                 .PublishAsync(
                     Arg.Any<SearchParametersUpdatedNotification>(),
                     Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenASearchParameterMissingFromTheRegistry_WhenUpdatingStatusWithoutIgnoreFlag_ThenSearchParameterNotSupportedExceptionIsThrown()
+        {
+            // Arrange - the url is no longer in the registry, which is what happens once a search parameter
+            // reached the Deleted status and was removed by SearchParameterOperations.GetAndApplySearchParameterUpdates.
+            _searchParameterDefinitionManager
+                .GetSearchParameter(MissingUri)
+                .Returns(x => throw new SearchParameterNotSupportedException(new Uri(MissingUri)));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<SearchParameterNotSupportedException>(
+                () => _manager.UpdateSearchParameterStatusAsync(
+                    new[] { MissingUri },
+                    SearchParameterStatus.PendingHardDelete,
+                    CancellationToken.None));
+
+            await _searchParameterStatusDataStore
+                .DidNotReceive()
+                .UpsertStatuses(Arg.Any<List<ResourceSearchParameterStatus>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
+        }
+
+        [Fact]
+        public async Task GivenASearchParameterMissingFromTheRegistry_WhenUpdatingStatusWithIgnoreFlag_ThenTheUriIsSkipped()
+        {
+            // Arrange - hard deleting a SearchParameter resource whose registry entry is already gone must not fail.
+            _searchParameterDefinitionManager
+                .GetSearchParameter(MissingUri)
+                .Returns(x => throw new SearchParameterNotSupportedException(new Uri(MissingUri)));
+
+            // Act
+            await _manager.UpdateSearchParameterStatusAsync(
+                new[] { MissingUri },
+                SearchParameterStatus.PendingHardDelete,
+                CancellationToken.None,
+                ignoreSearchParameterNotSupportedException: true);
+
+            // Assert - nothing was persisted for a url the registry does not know about.
+            await _searchParameterStatusDataStore
+                .DidNotReceive()
+                .UpsertStatuses(Arg.Any<List<ResourceSearchParameterStatus>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
+        }
+
+        [Fact]
+        public async Task GivenAMixOfKnownAndMissingSearchParameters_WhenUpdatingStatusWithIgnoreFlag_ThenOnlyTheKnownOnesArePersisted()
+        {
+            // Arrange
+            _searchParameterDefinitionManager
+                .GetSearchParameter(MissingUri)
+                .Returns(x => throw new SearchParameterNotSupportedException(new Uri(MissingUri)));
+
+            // Act
+            await _manager.UpdateSearchParameterStatusAsync(
+                new[] { MissingUri, ResourceQuery },
+                SearchParameterStatus.PendingHardDelete,
+                CancellationToken.None,
+                ignoreSearchParameterNotSupportedException: true);
+
+            // Assert
+            await _searchParameterStatusDataStore
+                .Received(1)
+                .UpsertStatuses(
+                    Arg.Is<List<ResourceSearchParameterStatus>>(statuses =>
+                        statuses.Count == 1 &&
+                        statuses[0].Uri.OriginalString == ResourceQuery &&
+                        statuses[0].Status == SearchParameterStatus.PendingHardDelete),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<long?>());
+        }
+
+        [Fact]
+        public async Task GivenASearchParameterMissingFromTheRegistry_WhenDeletingItsStatus_ThenTheRegistryIsNotConsulted()
+        {
+            // Arrange - the Deleted status skips registry validation altogether.
+            _searchParameterDefinitionManager
+                .GetSearchParameter(MissingUri)
+                .Returns(x => throw new SearchParameterNotSupportedException(new Uri(MissingUri)));
+
+            // Act
+            await _manager.DeleteSearchParameterStatusAsync(MissingUri, CancellationToken.None);
+
+            // Assert
+            await _searchParameterStatusDataStore
+                .Received(1)
+                .UpsertStatuses(
+                    Arg.Is<List<ResourceSearchParameterStatus>>(statuses =>
+                        statuses.Count == 1 &&
+                        statuses[0].Uri.OriginalString == MissingUri &&
+                        statuses[0].Status == SearchParameterStatus.Deleted),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<long?>());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -165,7 +165,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             }
 
             // Parse the value.
-            Func<string, ISearchValue> parser = _parserDictionary[Enum.Parse<SearchParamType>(searchParameter.Type.ToString())];
+            // Not every SearchParamType has a parser. SearchParamType.Special (for example Location-near) has no
+            // parser at all and SearchParamType.Composite is handled by the caller. Those parameters are expected to be
+            // marked Unsupported in the search parameter registry, but a stale or repaired registry can still let one
+            // reach this point. Surface it as SearchParameterNotSupportedException, which callers translate into a
+            // NotSupported OperationOutcome, instead of letting a KeyNotFoundException escape as a 500.
+            if (!_parserDictionary.TryGetValue(searchParameter.Type, out Func<string, ISearchValue> parser))
+            {
+                throw searchParameter.Url != null
+                    ? new SearchParameterNotSupportedException(searchParameter.Url)
+                    : new SearchParameterNotSupportedException(
+                        string.Format(CultureInfo.InvariantCulture, Core.Resources.NoConverterForSearchParamType, searchParameter.Type, searchParameter.Expression));
+            }
 
             // Build the expression.
             var helper = new SearchValueExpressionBuilderHelper();

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 await GetAndApplySearchParameterUpdates(cancellationToken);
                 var status = isHardDelete ? SearchParameterStatus.PendingHardDelete : SearchParameterStatus.PendingDelete;
                 _logger.LogInformation("DeleteSearchParameterAsync: Deleting the search parameter '{Url}' with status {Status}", searchParameterUrl, status);
-                await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new[] { searchParameterUrl }, status, cancellationToken, lastUpdated: SearchParamLastUpdated);
+                await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new[] { searchParameterUrl }, status, cancellationToken, ignoreSearchParameterNotSupportedException, lastUpdated: SearchParamLastUpdated);
             }
             catch (FhirException fex)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -136,6 +136,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             await EnsureInitializedAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Persists a new status for a set of search parameters.
+        /// </summary>
+        /// <param name="searchParameterUris">The definition urls of the search parameters to update.</param>
+        /// <param name="status">The status to persist.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="ignoreSearchParameterNotSupportedException">
+        /// When <c>true</c>, urls that are no longer present in the search parameter registry are logged and skipped
+        /// instead of failing the whole operation. Callers that are deleting search parameters use this so that a
+        /// registry entry that was already removed does not turn the delete into a bad request.
+        /// </param>
+        /// <param name="reindexId">The id of the reindex job performing the update, when applicable.</param>
+        /// <param name="lastUpdated">The last updated value used for optimistic concurrency, when applicable.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, long? reindexId = null, DateTimeOffset? lastUpdated = null)
         {
             EnsureArg.IsNotNull(searchParameterUris);
@@ -149,7 +163,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 // This makes sense only for status other than Deleted.
                 if (status != SearchParameterStatus.Deleted)
                 {
-                    _searchParameterDefinitionManager.GetSearchParameter(uri);
+                    try
+                    {
+                        _searchParameterDefinitionManager.GetSearchParameter(uri);
+                    }
+                    catch (SearchParameterNotSupportedException ex) when (ignoreSearchParameterNotSupportedException)
+                    {
+                        // SearchParameterNotSupportedException is thrown by SearchParameterDefinitionManager.GetSearchParameter
+                        // when the given url is not in its cache. That happens legitimately when the parameter already reached
+                        // the Deleted status and was removed from the registry while its SearchParameter resource still exists.
+                        // Callers that pass this flag (for example $bulk-delete and hard delete) want to delete as many search
+                        // parameters as possible, so skip this uri instead of failing the whole request. No status row is written
+                        // for it: the registry no longer knows the url, so persisting for instance PendingHardDelete would leave
+                        // an orphaned row that every reindex job would have to reconcile.
+                        _logger.LogWarning(ex, "The search parameter '{Uri}' is not in the search parameter registry. Skipping its status update to '{NewStatus}'.", uri, status.ToString());
+                        continue;
+                    }
                 }
 
                 // It does not make sense to keep any of existing ResourceSearchParameterStatus components as results do not depend on them.
@@ -159,6 +188,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                     Uri = new Uri(uri),
                     LastUpdated = lastUpdated ?? DateTimeOffset.UtcNow,
                 });
+            }
+
+            if (statuses.Count == 0)
+            {
+                _logger.LogInformation("No search parameter statuses to update.");
+                return;
             }
 
             await _searchParameterStatusDataStore.UpsertStatuses(statuses, cancellationToken, reindexId);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -23,6 +23,7 @@ using Expression=Microsoft.Health.Fhir.Core.Features.Search.Expressions.Expressi
 using SearchComparator = Microsoft.Health.Fhir.ValueSets.SearchComparator;
 using SearchModifierCode = Microsoft.Health.Fhir.ValueSets.SearchModifierCode;
 using SearchParamType = Hl7.Fhir.Model.SearchParamType;
+using SearchParamTypeValueSet = Microsoft.Health.Fhir.ValueSets.SearchParamType;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parsers
 {
@@ -931,6 +932,35 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         {
             Assert.Throws<InvalidSearchOperationException>(
                 () => _parser.Parse(CreateSearchParameter(SearchParamType.Uri), new SearchModifier(modifier, targetTypeModifier?.ToString()), "test"));
+        }
+
+        [Fact]
+        public void GivenASearchParameterTypeWithoutAParser_WhenBuilding_ThenSearchParameterNotSupportedExceptionShouldBeThrown()
+        {
+            // SearchParamType.Special (for example http://hl7.org/fhir/SearchParameter/Location-near) has no value
+            // parser. Such a parameter should never reach the parser because it is marked Unsupported in the registry,
+            // but a stale registry can still let it through. It has to surface as a NotSupported OperationOutcome
+            // rather than as an unhandled KeyNotFoundException, which the API layer would report as a 500.
+            var searchParameter = new SearchParameterInfo(
+                "near",
+                "near",
+                SearchParamTypeValueSet.Special,
+                new Uri("http://hl7.org/fhir/SearchParameter/Location-near"));
+
+            Assert.Throws<SearchParameterNotSupportedException>(
+                () => _parser.Parse(searchParameter, null, "-83.694810|42.256500"));
+        }
+
+        [Fact]
+        public void GivenASearchParameterTypeWithoutAParserAndWithoutAUrl_WhenBuilding_ThenSearchParameterNotSupportedExceptionShouldBeThrown()
+        {
+            var searchParameter = new SearchParameterInfo(
+                DefaultParamName,
+                DefaultParamName,
+                SearchParamTypeValueSet.Special);
+
+            Assert.Throws<SearchParameterNotSupportedException>(
+                () => _parser.Parse(searchParameter, null, "test"));
         }
 
         private SearchParameterInfo CreateSearchParameter(SearchParamType searchParameterType)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterOperationsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterOperationsTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Parameters
 
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
-        private readonly IFhirOperationDataStore _fhirOperationDataStore = Substitute.For<IFhirOperationDataStore>();
         private readonly SearchParameterOperations _searchParameterOperations;
 
         public SearchParameterOperationsTests()
@@ -61,13 +60,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Parameters
                 .GetSearchParameter(MissingUrl)
                 .Returns(x => throw new SearchParameterNotSupportedException(new Uri(MissingUrl)));
 
-            // No active reindex job. default gives (found: false, id: null) without an explicit cast on null.
-            (bool Found, string Id) noActiveReindexJob = default;
-
-            _fhirOperationDataStore
-                .CheckActiveReindexJobsAsync(Arg.Any<CancellationToken>())
-                .Returns(noActiveReindexJob);
-
             var statusManager = new SearchParameterStatusManager(
                 _searchParameterStatusDataStore,
                 _searchParameterDefinitionManager,
@@ -81,10 +73,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Parameters
                 ModelInfoProvider.Instance,
                 Substitute.For<ISearchParameterSupportResolver>(),
                 Substitute.For<IDataStoreSearchParameterValidator>(),
-                () => _fhirOperationDataStore.CreateMockScope(),
                 () => Substitute.For<ISearchService>().CreateMockScope(),
                 Substitute.For<IFhirDataStore>().CreateMockScopeProvider(),
-                Substitute.For<IResourceWrapperFactory>(),
                 NullLogger<SearchParameterOperations>.Instance);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterOperationsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterOperationsTests.cs
@@ -1,0 +1,124 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Medino;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Parameters
+{
+    /// <summary>
+    /// Covers the interaction between <see cref="SearchParameterOperations"/> and
+    /// <see cref="SearchParameterStatusManager"/> when a SearchParameter resource is deleted after its registry entry
+    /// has already been removed. Both types are real here on purpose: the defect this guards against was a named
+    /// argument in the call between them that silently dropped the ignoreSearchParameterNotSupportedException flag.
+    /// </summary>
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.SearchParameterStatus)]
+    public class SearchParameterOperationsTests
+    {
+        private const string MissingUrl = "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender-identity";
+
+        private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
+        private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
+        private readonly IFhirOperationDataStore _fhirOperationDataStore = Substitute.For<IFhirOperationDataStore>();
+        private readonly SearchParameterOperations _searchParameterOperations;
+
+        public SearchParameterOperationsTests()
+        {
+            // The url reached the Deleted status, which is what makes SearchParameterOperations remove it from the
+            // definition manager while the SearchParameter resource itself is still in the data store.
+            _searchParameterStatusDataStore
+                .GetSearchParameterStatuses(Arg.Any<CancellationToken>(), Arg.Any<DateTimeOffset?>())
+                .Returns(new[]
+                {
+                    new ResourceSearchParameterStatus
+                    {
+                        Status = SearchParameterStatus.Deleted,
+                        Uri = new Uri(MissingUrl),
+                        LastUpdated = DateTimeOffset.UtcNow,
+                    },
+                });
+
+            _searchParameterDefinitionManager
+                .GetSearchParameter(MissingUrl)
+                .Returns(x => throw new SearchParameterNotSupportedException(new Uri(MissingUrl)));
+
+            _fhirOperationDataStore
+                .CheckActiveReindexJobsAsync(Arg.Any<CancellationToken>())
+                .Returns((false, (string)null));
+
+            var statusManager = new SearchParameterStatusManager(
+                _searchParameterStatusDataStore,
+                _searchParameterDefinitionManager,
+                Substitute.For<ISearchParameterSupportResolver>(),
+                Substitute.For<IMediator>(),
+                NullLogger<SearchParameterStatusManager>.Instance);
+
+            _searchParameterOperations = new SearchParameterOperations(
+                statusManager,
+                _searchParameterDefinitionManager,
+                ModelInfoProvider.Instance,
+                Substitute.For<ISearchParameterSupportResolver>(),
+                Substitute.For<IDataStoreSearchParameterValidator>(),
+                () => _fhirOperationDataStore.CreateMockScope(),
+                () => Substitute.For<ISearchService>().CreateMockScope(),
+                Substitute.For<IFhirDataStore>().CreateMockScopeProvider(),
+                Substitute.For<IResourceWrapperFactory>(),
+                NullLogger<SearchParameterOperations>.Instance);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GivenASearchParameterMissingFromTheRegistry_WhenDeletingItWithTheIgnoreFlag_ThenNoExceptionIsThrown(bool isHardDelete)
+        {
+            await _searchParameterOperations.DeleteSearchParameterAsync(
+                CreateSearchParameterRawResource(),
+                CancellationToken.None,
+                ignoreSearchParameterNotSupportedException: true,
+                isHardDelete: isHardDelete);
+
+            // The registry does not know the url, so no status row is written for it.
+            await _searchParameterStatusDataStore
+                .DidNotReceive()
+                .UpsertStatuses(Arg.Any<IReadOnlyList<ResourceSearchParameterStatus>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
+        }
+
+        [Fact]
+        public async Task GivenASearchParameterMissingFromTheRegistry_WhenDeletingItWithoutTheIgnoreFlag_ThenSearchParameterNotSupportedExceptionIsThrown()
+        {
+            await Assert.ThrowsAsync<SearchParameterNotSupportedException>(
+                () => _searchParameterOperations.DeleteSearchParameterAsync(
+                    CreateSearchParameterRawResource(),
+                    CancellationToken.None,
+                    ignoreSearchParameterNotSupportedException: false,
+                    isHardDelete: true));
+        }
+
+        private static RawResource CreateSearchParameterRawResource()
+        {
+            return new RawResource(
+                $"{{\"resourceType\":\"SearchParameter\",\"id\":\"us-core-patient-gender-identity\",\"url\":\"{MissingUrl}\"}}",
+                FhirResourceFormat.Json,
+                isMetaSet: false);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterOperationsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterOperationsTests.cs
@@ -61,9 +61,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Parameters
                 .GetSearchParameter(MissingUrl)
                 .Returns(x => throw new SearchParameterNotSupportedException(new Uri(MissingUrl)));
 
+            // No active reindex job. default gives (found: false, id: null) without an explicit cast on null.
+            (bool Found, string Id) noActiveReindexJob = default;
+
             _fhirOperationDataStore
                 .CheckActiveReindexJobsAsync(Arg.Any<CancellationToken>())
-                .Returns((false, (string)null));
+                .Returns(noActiveReindexJob);
 
             var statusManager = new SearchParameterStatusManager(
                 _searchParameterStatusDataStore,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -105,6 +105,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterBehaviorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterDefinitionManagerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterFixtureData.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterOperationsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterSupportResolverTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterToTypeResolverTests.cs" />

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -419,7 +419,23 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 _logger,
                 cancellationToken);
 
-            fileStatuses.RemoveAll((fs) => existingParams.Any((param) => param.Uri == fs.Uri && (param.Status != SearchParameterStatus.Initialized)));
+            // Drop file statuses that are already reflected in the database.
+            //
+            // A row is considered "already reflected" once its stored status has moved past Initialized, because from
+            // that point on the stored status is authoritative (it can have been changed by a customer through
+            // $status, by a reindex job, or by a delete).
+            //
+            // The one exception is a search parameter that unsupported-search-parameters.json marks as Unsupported but
+            // that is stored as Enabled or Supported. The server has no way to evaluate such a parameter, so those rows
+            // can only have come from a defect (see PR #5403, which unconditionally overwrote the file's Unsupported
+            // status between 2026-03-06 and 2026-07-23) and are repaired back to Unsupported below. Rows in any other
+            // stored status - Disabled, Deleted, PendingDelete, PendingHardDelete, PendingDisable - are left alone so
+            // that customer-driven and reindex-driven states are never clobbered. PartialSupport entries come back from
+            // the file as Enabled (not Unsupported) and are therefore untouched by this rule as well.
+            fileStatuses.RemoveAll((fs) => existingParams.Any((param) =>
+                param.Uri == fs.Uri
+                && param.Status != SearchParameterStatus.Initialized
+                && !RequiresUnsupportedRepair(fs, param)));
 
             if (fileStatuses.Count == 0)
             {
@@ -432,6 +448,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             resourceExistCmd.CommandText = "SELECT TOP 1 1 FROM dbo.Resource";
             var hasResources = await resourceExistCmd.ExecuteScalarAsync<int?>(_sqlRetryService, _logger, cancellationToken) == 1;
 
+            // dbo.MergeSearchParams treats the highest LastUpdated in the input as an optimistic concurrency token: it
+            // fails with error 50001 unless that value equals the current max(LastUpdated) in dbo.SearchParam. The
+            // stored procedure then stamps every merged row with a fresh server-side LastUpdated, which is what other
+            // replicas poll on to refresh their caches. So we deliberately do not try to preserve or hand-pick a
+            // LastUpdated per row here - we only need the input's maximum to match what is currently stored.
+            DateTimeOffset? maxExistingLastUpdated = existingParams.Count > 0 ? existingParams.Max(p => p.LastUpdated) : null;
+
             fileStatuses.ForEach(fs =>
             {
                 // Preserve the Unsupported status that comes from unsupported-search-parameters.json.
@@ -442,7 +465,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     fs.Status = hasResources ? SearchParameterStatus.Supported : SearchParameterStatus.Enabled;
                 }
 
-                fs.LastUpdated = existingParams.FirstOrDefault(p => p.Uri == fs.Uri)?.LastUpdated ?? fs.LastUpdated;
+                fs.LastUpdated = maxExistingLastUpdated ?? fs.LastUpdated;
             });
 
             using var cmd = new SqlCommand();
@@ -467,6 +490,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 _logger.LogInformation("Concurrent update detected, retrying");
                 await InitializeSearchParameterStatuses(cancellationToken, retryDepth + 1);
             }
+        }
+
+        /// <summary>
+        /// Determines whether a stored search parameter status has to be repaired back to
+        /// <see cref="SearchParameterStatus.Unsupported"/> because it is stored in a state that claims the server can
+        /// search on a parameter that it has no support for.
+        /// </summary>
+        /// <param name="fileStatus">The status coming from unsupported-search-parameters.json.</param>
+        /// <param name="storedStatus">The status currently stored in dbo.SearchParam.</param>
+        /// <returns><c>true</c> when the stored status has to be rewritten as Unsupported.</returns>
+        private static bool RequiresUnsupportedRepair(ResourceSearchParameterStatus fileStatus, ResourceSearchParameterStatus storedStatus)
+        {
+            return fileStatus.Status == SearchParameterStatus.Unsupported
+                && (storedStatus.Status == SearchParameterStatus.Enabled || storedStatus.Status == SearchParameterStatus.Supported);
         }
 
         private int GetStringId(FhirMemoryCache<int> cache, string stringValue, StoredProcedure sproc)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -432,6 +432,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // stored status - Disabled, Deleted, PendingDelete, PendingHardDelete, PendingDisable - are left alone so
             // that customer-driven and reindex-driven states are never clobbered. PartialSupport entries come back from
             // the file as Enabled (not Unsupported) and are therefore untouched by this rule as well.
+            HashSet<Uri> repairUris = fileStatuses
+                .Where(fs => existingParams.Any(param => param.Uri == fs.Uri && RequiresUnsupportedRepair(fs, param)))
+                .Select(fs => fs.Uri)
+                .ToHashSet();
+
             fileStatuses.RemoveAll((fs) => existingParams.Any((param) =>
                 param.Uri == fs.Uri
                 && param.Status != SearchParameterStatus.Initialized
@@ -442,6 +447,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 _logger.LogInformation("No Search Parameters need to be initialized.");
                 return;
             }
+
+            // dbo.MergeSearchParams refuses any change to search parameters while a reindex job is running and throws
+            // error 50002. When the repair above is the only thing left to merge, that rejection must not fail startup:
+            // the repair is opportunistic, and deferring it to the next startup is strictly better than leaving the
+            // server unable to complete storage initialization for the duration of the reindex. Merges that also carry
+            // new parameters from the file keep the pre-existing behaviour of surfacing the error.
+            bool isRepairOnly = fileStatuses.TrueForAll(fs => repairUris.Contains(fs.Uri));
 
             using var resourceExistCmd = new SqlCommand();
             resourceExistCmd.CommandType = CommandType.Text;
@@ -478,6 +490,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             {
                 await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
                 _logger.LogInformation("Number of Search Parameters initialized: {Number}", fileStatuses.Count);
+            }
+            catch (SqlException ex) when (ex.Number == 50002 && isRepairOnly)
+            {
+                _logger.LogWarning(ex, "A reindex job is in progress, so repairing {Number} search parameter status(es) back to Unsupported was deferred to the next startup.", fileStatuses.Count);
             }
             catch (SqlException ex) when (ex.Number == 50001)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
@@ -8,13 +8,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Medino;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.Test.Utilities;
+using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,6 +31,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence;
 [Trait(Traits.Category, Categories.SearchParameterStatus)]
 public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServerFhirStorageTestsFixture>
 {
+    private const string LocationNearUri = "http://hl7.org/fhir/SearchParameter/Location-near";
+
     private readonly SqlServerFhirStorageTestsFixture _fixture;
     private readonly ITestOutputHelper _testOutputHelper;
 
@@ -101,6 +110,111 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
             Assert.True(dbStatuses.TryGetValue(uri, out var dbStatus), $"Expected search parameter '{uri}' to exist in the SQL SearchParam table.");
             Assert.Equal(SearchParameterStatus.Unsupported, dbStatus.Status);
         }
+    }
+
+    [Fact]
+    public async Task GivenAnAgedDatabaseWhereAnUnsupportedSearchParameterIsStoredAsEnabled_WhenInitializing_ThenItIsRepairedToUnsupported()
+    {
+        // Arrange - reproduce the state that databases seeded between 2026-03-06 (PR #5403) and 2026-07-23
+        // (PR #5684) are left in. PR #5403 overwrote the Unsupported status that comes from
+        // unsupported-search-parameters.json with Enabled/Supported, and because SqlServerFhirModel drops every
+        // file status whose stored status has moved past Initialized, the guard added by PR #5684 never runs for
+        // rows that are already seeded. On such a database Location-near is reported as searchable, reaches the
+        // expression parser and produces a 500 instead of a NotSupported OperationOutcome warning.
+        var fileStatuses = (await _fixture.FilebasedSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
+        var locationNear = fileStatuses.SingleOrDefault(s => s.Uri.OriginalString == LocationNearUri);
+
+        Assert.NotNull(locationNear);
+        Assert.Equal(SearchParameterStatus.Unsupported, locationNear.Status);
+
+        // A second parameter that the file also marks Unsupported is stored as Disabled. Disabled can only be set
+        // deliberately (by $status or a delete), so the repair must leave it alone.
+        var untouchedUri = fileStatuses
+            .First(s => s.Status == SearchParameterStatus.Unsupported && s.Uri.OriginalString != LocationNearUri)
+            .Uri;
+
+        await SeedStoredStatusAsync(locationNear.Uri, SearchParameterStatus.Enabled);
+        await SeedStoredStatusAsync(untouchedUri, SearchParameterStatus.Disabled);
+
+        // Act - simulate a service restart against the existing database.
+        await CreateSqlServerFhirModel().Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+
+        // Assert
+        var dbStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+            .ToDictionary(s => s.Uri);
+
+        Assert.Equal(SearchParameterStatus.Unsupported, dbStatuses[locationNear.Uri].Status);
+        Assert.Equal(SearchParameterStatus.Disabled, dbStatuses[untouchedUri].Status);
+
+        // Restore the parameter that was deliberately disabled so the other tests in this class see a clean state.
+        await SeedStoredStatusAsync(untouchedUri, SearchParameterStatus.Unsupported);
+    }
+
+    [Fact]
+    public async Task GivenADatabaseWhereSearchParameterStatusesAreAlreadyCorrect_WhenInitializing_ThenNothingIsRewritten()
+    {
+        // Arrange - the repair added for the aged-database case must be idempotent: once a row has been written
+        // back to Unsupported, every subsequent startup has to be a no-op, otherwise every replica restart would
+        // merge rows and bump LastUpdated, forcing an unnecessary search parameter cache refresh everywhere.
+        await CreateSqlServerFhirModel().Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+
+        var before = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+            .ToDictionary(s => s.Uri, s => (s.Status, s.LastUpdated));
+
+        // Act
+        await CreateSqlServerFhirModel().Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+
+        // Assert - dbo.MergeSearchParams stamps a fresh LastUpdated on every row it merges, so an unchanged
+        // LastUpdated proves that no merge happened at all.
+        var after = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+            .ToDictionary(s => s.Uri, s => (s.Status, s.LastUpdated));
+
+        Assert.Equal(before.Count, after.Count);
+
+        foreach (var entry in before)
+        {
+            Assert.True(after.TryGetValue(entry.Key, out var actual), $"Expected search parameter '{entry.Key}' to still exist in the SQL SearchParam table.");
+            Assert.Equal(entry.Value.Status, actual.Status);
+            Assert.Equal(entry.Value.LastUpdated, actual.LastUpdated);
+        }
+    }
+
+    /// <summary>
+    /// Writes a status directly to dbo.SearchParam so that a test can start from a database state that only a
+    /// long-lived (rather than a freshly deployed) database would ever be in.
+    /// </summary>
+    private async Task SeedStoredStatusAsync(Uri uri, SearchParameterStatus status)
+    {
+        var dbStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
+        var target = dbStatuses.Single(s => s.Uri == uri);
+
+        target.Status = status;
+
+        // dbo.MergeSearchParams treats the highest LastUpdated in the input as an optimistic concurrency token and
+        // fails with error 50001 unless it matches the current maximum in dbo.SearchParam.
+        target.LastUpdated = dbStatuses.Max(s => s.LastUpdated);
+
+        await _fixture.SqlServerSearchParameterStatusDataStore.UpsertStatuses(new[] { target }, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="SqlServerFhirModel"/> over the fixture's database. The fixture's own instance has
+    /// already initialized to the current schema version and short-circuits on subsequent calls, so a new instance
+    /// is what makes a test behave like a service starting up against an existing database.
+    /// </summary>
+    private SqlServerFhirModel CreateSqlServerFhirModel()
+    {
+        var searchParameterDefinitionManager = (ISearchParameterDefinitionManager)((IServiceProvider)_fixture).GetService(typeof(SearchParameterDefinitionManager));
+
+        return new SqlServerFhirModel(
+            _fixture.SchemaInformation,
+            searchParameterDefinitionManager,
+            () => _fixture.FilebasedSearchParameterStatusDataStore,
+            Options.Create(new SecurityConfiguration { PrincipalClaims = { "oid" } }),
+            _fixture.SqlConnectionWrapperFactory.CreateMockScopeProvider(),
+            Substitute.For<IMediator>(),
+            _fixture.SqlRetryService,
+            NullLogger<SqlServerFhirModel>.Instance);
     }
 
     private async Task CheckSearchParametersForInvalid()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
@@ -14,11 +14,13 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.JobManagement;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.Test.Utilities;
 using NSubstitute;
@@ -136,18 +138,23 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
         await SeedStoredStatusAsync(locationNear.Uri, SearchParameterStatus.Enabled);
         await SeedStoredStatusAsync(untouchedUri, SearchParameterStatus.Disabled);
 
-        // Act - simulate a service restart against the existing database.
-        await CreateSqlServerFhirModel().Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+        try
+        {
+            // Act - simulate a service restart against the existing database.
+            await CreateSqlServerFhirModel().Initialize(SchemaVersionConstants.Max, CancellationToken.None);
 
-        // Assert
-        var dbStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
-            .ToDictionary(s => s.Uri);
+            // Assert
+            var dbStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+                .ToDictionary(s => s.Uri);
 
-        Assert.Equal(SearchParameterStatus.Unsupported, dbStatuses[locationNear.Uri].Status);
-        Assert.Equal(SearchParameterStatus.Disabled, dbStatuses[untouchedUri].Status);
-
-        // Restore the parameter that was deliberately disabled so the other tests in this class see a clean state.
-        await SeedStoredStatusAsync(untouchedUri, SearchParameterStatus.Unsupported);
+            Assert.Equal(SearchParameterStatus.Unsupported, dbStatuses[locationNear.Uri].Status);
+            Assert.Equal(SearchParameterStatus.Disabled, dbStatuses[untouchedUri].Status);
+        }
+        finally
+        {
+            await SeedStoredStatusAsync(untouchedUri, SearchParameterStatus.Unsupported);
+            await RestoreUniformLastUpdatedAsync();
+        }
     }
 
     [Fact]
@@ -176,6 +183,54 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
             Assert.True(after.TryGetValue(entry.Key, out var actual), $"Expected search parameter '{entry.Key}' to still exist in the SQL SearchParam table.");
             Assert.Equal(entry.Value.Status, actual.Status);
             Assert.Equal(entry.Value.LastUpdated, actual.LastUpdated);
+        }
+    }
+
+    [Fact]
+    public async Task GivenADatabaseNeedingRepairAndAReindexJobInProgress_WhenInitializing_ThenTheRepairIsDeferredAndInitializationSucceeds()
+    {
+        // Arrange - dbo.MergeSearchParams throws error 50002 whenever an active QueueType 6 job exists. Before the
+        // repair existed an aged database in steady state had nothing to merge and never reached the sproc, so 50002
+        // was unreachable from startup. Now an affected database calls the sproc on every startup until the repair
+        // lands, and an unhandled 50002 would stop SqlServerFhirModel.Initialize before it sets
+        // _highestInitializedVersion and publishes StorageInitializedNotification - leaving every replica unable to
+        // finish storage initialization for as long as the reindex runs.
+        var fileStatuses = (await _fixture.FilebasedSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
+        Uri locationNear = fileStatuses.Single(s => s.Uri.OriginalString == LocationNearUri).Uri;
+
+        await SeedStoredStatusAsync(locationNear, SearchParameterStatus.Enabled);
+
+        long groupId = await EnqueueReindexJobAsync();
+
+        try
+        {
+            try
+            {
+                // Act
+                await CreateSqlServerFhirModel().Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+
+                // Assert - initialization completed, and the repair was deferred rather than applied.
+                var deferred = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+                    .Single(s => s.Uri == locationNear);
+
+                Assert.Equal(SearchParameterStatus.Enabled, deferred.Status);
+            }
+            finally
+            {
+                await RemoveReindexJobsAsync(groupId);
+            }
+
+            // Assert - the next startup after the reindex finishes performs the deferred repair.
+            await CreateSqlServerFhirModel().Initialize(SchemaVersionConstants.Max, CancellationToken.None);
+
+            var repaired = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None))
+                .Single(s => s.Uri == locationNear);
+
+            Assert.Equal(SearchParameterStatus.Unsupported, repaired.Status);
+        }
+        finally
+        {
+            await RestoreUniformLastUpdatedAsync();
         }
     }
 
@@ -215,6 +270,52 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
             Substitute.For<IMediator>(),
             _fixture.SqlRetryService,
             NullLogger<SqlServerFhirModel>.Instance);
+    }
+
+    /// <summary>
+    /// Re-stamps every row in dbo.SearchParam with a single LastUpdated value. dbo.MergeSearchParams only touches the
+    /// rows it merges, so seeding and repairing individual rows leaves the table with a mix of LastUpdated values.
+    /// Other tests in this class upsert a subset of statuses, which the stored procedure only accepts when that subset
+    /// carries the current maximum, so tests that mutate individual rows restore the uniform state they inherited.
+    /// </summary>
+    private async Task RestoreUniformLastUpdatedAsync()
+    {
+        var dbStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
+        var maxLastUpdated = dbStatuses.Max(s => s.LastUpdated);
+
+        dbStatuses.ForEach(s => s.LastUpdated = maxLastUpdated);
+
+        await _fixture.SqlServerSearchParameterStatusDataStore.UpsertStatuses(dbStatuses, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Enqueues a reindex job so that dbo.GetActiveJobs reports a reindex in progress, which is what makes
+    /// dbo.MergeSearchParams reject search parameter changes with error 50002.
+    /// </summary>
+    private async Task<long> EnqueueReindexJobAsync()
+    {
+        var queueClient = (IQueueClient)((IServiceProvider)_fixture).GetService(typeof(IQueueClient));
+
+        IReadOnlyList<JobInfo> jobs = await queueClient.EnqueueAsync(
+            (byte)QueueType.Reindex,
+            new[] { "{\"typeId\":1}" },
+            groupId: null,
+            forceOneActiveJobGroup: false,
+            CancellationToken.None);
+
+        return jobs[0].GroupId;
+    }
+
+    private async Task RemoveReindexJobsAsync(long groupId)
+    {
+        using SqlConnectionWrapper sqlConnectionWrapper = await _fixture.SqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(CancellationToken.None, true);
+        using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
+
+        sqlCommandWrapper.CommandText = "DELETE FROM dbo.JobQueue WHERE QueueType = @QueueType AND GroupId = @GroupId";
+        sqlCommandWrapper.Parameters.AddWithValue("@QueueType", (byte)QueueType.Reindex);
+        sqlCommandWrapper.Parameters.AddWithValue("@GroupId", groupId);
+
+        await sqlCommandWrapper.ExecuteNonQueryAsync(CancellationToken.None);
     }
 
     private async Task CheckSearchParametersForInvalid()


### PR DESCRIPTION
## Related issues
Addresses [AB#200388](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/200388)

> Supersedes #5714, which GitHub auto-closed when its head branch was renamed to follow the `users/jaerwin/` convention. Same three commits, unchanged.

Fixes three defects that are only reachable on a **long-lived** SQL database. fhir-server's own E2E CI deploys a brand-new environment with a fresh database on every run (`samples/templates/default-azuredeploy-docker.json`), so none of these are reachable there. The Azure FHIR PaaS (Gen2) prod E2E pipeline runs the same test binaries against databases that are never recreated, which is where all three show up.

Each defect is a separate commit so they can be reviewed and reverted independently.

---

## Defect 1a — `KeyNotFoundException` for search parameter types with no value parser

**Symptom:** `KeyNotFoundException: The given key 'Special' was not present in the dictionary.` escaping as HTTP 500 (60 occurrences over 14 days on the eastus2euap R4 test account, first 2026-07-26T20:27:10Z, persisting across three service versions).

```
at SearchParameterExpressionParser.Parse(...) SearchParameterExpressionParser.cs:line 52
at ExpressionParser.ParseImpl(...) ExpressionParser.cs:line 295
at SearchOptionsFactory.Create(...) SearchOptionsFactory.cs:line 413
```

**Root cause:** `SearchParameterExpressionParser` builds `_parserDictionary` with exactly 7 entries — Date, Number, Quantity, Reference, String, Token, Uri (`SearchParameterExpressionParser.cs:34-44`). There is no entry for `SearchParamType.Special` (Composite is handled upstream). `Build(...)` looked the parser up with a raw indexer, so anything else threw `KeyNotFoundException`, which the API layer reports as a 500.

**Fix:** `TryGetValue`, and throw `SearchParameterNotSupportedException` when there is no parser. `SearchOptionsFactory` already catches that exception (`SearchOptionsFactory.cs:430`) and records the parameter in `unsupportedSearchParameters`, which becomes a `NotSupported` warning under `handling=lenient` and a 400 under `handling=strict`.

This is defence in depth — on its own it does **not** make the E2E test pass, because that test asserts the exact diagnostics string produced by the status path in 1b.

**Why CI never caught it:** on a fresh database `Location-near` is correctly stored as `Unsupported`, `IsSearchable` is false, and the parameter never reaches the parser.

---

## Defect 1b — `Unsupported` status is never repaired on existing databases (the real cause of the `Location?near=` 500)

**Symptom:** `Location?near=...` returns HTTP 500 instead of a bundle with a `NotSupported` warning. Acceptance test: `BasicSearchTests.GivenASearchRequestOnASearchParameterMarkedUnsupportedAtStartup_WhenHandled_ReturnsBundleWithNotSupportedWarning`.

**Root cause chain:**

1. `http://hl7.org/fhir/SearchParameter/Location-near` is listed in `src/Microsoft.Health.Fhir.Core/Data/{R4,R4B,Stu3,R5}/unsupported-search-parameters.json`, and `FilebasedSearchParameterStatusDataStore` returns it with `Status = Unsupported`.
2. **PR #5403** (2026-03-06) added `fs.Status = hasResources ? Supported : Enabled;` unconditionally in `SqlServerFhirModel.InitializeSearchParameterStatuses`, clobbering the file's `Unsupported` status and persisting `Location-near` as Enabled/Supported into customer databases.
3. **PR #5684** (2026-07-23) guarded that with `if (fs.Status != SearchParameterStatus.Unsupported)`. **The guard is unreachable for already-seeded rows**, because earlier in the same method
   ```csharp
   fileStatuses.RemoveAll((fs) => existingParams.Any((param) => param.Uri == fs.Uri && (param.Status != SearchParameterStatus.Initialized)));
   ```
   drops every file status whose DB row already exists with any status other than `Initialized`. So #5684 only helps green-field databases.
4. `SearchParameterStatusManager.EnsureInitializedAsync` trusts the DB status — it only re-evaluates support when the stored status *is* `Unsupported`. There is no path that demotes a stored `Enabled` back to `Unsupported`. `IsSearchable` stays true, the parameter reaches the expression parser, and every request 500s.

> ⚠️ **Databases seeded between 2026-03-06 (PR #5403) and 2026-07-23 (PR #5684) are affected and are repaired automatically on the next startup by this change.** No manual remediation or migration script is required.

**Fix:** keep file statuses in the merge list when the file says `Unsupported` but the stored status is `Enabled` or `Supported`, so `dbo.MergeSearchParams` writes them back to `Unsupported`.

*Why the repair is limited to `Enabled`/`Supported`:* `SearchParameterStateUpdateHandler.ParseRequestForUpdate` refuses `$status` updates on parameters whose stored status is `Unsupported` or `Deleted`, and only allows `Supported`/`Disabled` as a target. So `Enabled`/`Supported` on a file-`Unsupported` parameter can only have come from the #5403 defect. `Disabled`, `Deleted` and the `Pending*` states are left untouched so customer-driven and reindex-driven states are never clobbered. `PartialSupport` entries come back from the file as `Enabled` with `IsPartiallySupported = true` (not `Unsupported`), so they are never matched by the repair rule and keep their existing behaviour.

*On `LastUpdated`:* the old code did `fs.LastUpdated = existingParams.FirstOrDefault(...)?.LastUpdated ?? fs.LastUpdated;`. Reading `MergeSearchParams.sql`, the highest `LastUpdated` in the input TVP is used purely as an **optimistic concurrency token** — the sproc computes `@ExpectedLastUpdated = (SELECT max(LastUpdated) FROM @SearchParams)` and raises error 50001 unless it equals `(SELECT max(LastUpdated) FROM dbo.SearchParam)`. It then stamps **every merged row** with a fresh server-side `@LastUpdated = sysUTCdatetime()`, and that is what other replicas poll on to refresh their caches. So we do not need to (and must not) hand-pick a per-row value: carrying an *old* repaired row's `LastUpdated` into the input would fail the concurrency check, retry 3× and then throw at startup. The value is now normalized to the current max in `dbo.SearchParam` for every row in the merge, and cache refresh on other replicas happens automatically via the sproc's fresh stamp. (The previous code only worked because `InitializeBase.sql` inserts brand-new rows with `SYSDATETIMEOFFSET()`, so those rows were always the DB max.)

*Idempotency:* after a repaired startup the file status and stored status agree again, so the row is dropped by `RemoveAll` as before, `fileStatuses` is empty and no merge is issued at all. Covered by a dedicated test that asserts `LastUpdated` is unchanged across two startups.

**Why CI never caught it:** on a fresh database every `SearchParam` row starts at `Initialized`, so `RemoveAll` keeps it and the #5684 guard applies. The corruption requires a database that was seeded by a build in the affected window.


### Follow-up in the same area: `MergeSearchParams` error 50002 while a reindex is running

Making the repair reachable also makes a previously unreachable failure mode live, so it is handled in the same PR (separate commit).

`MergeSearchParams.sql` runs **two** guards before merging: it calls `dbo.GetActiveJobs @QueueType = 6` and `THROW 50002, 'Changes to search parameters are not allowed while a reindex job is in progress...'` if a reindex job is active, and only then does the `50001` optimistic-concurrency check. `InitializeSearchParameterStatuses` only caught `50001`.

**Why this was not reachable before:** on an affected database in steady state, `RemoveAll` emptied `fileStatuses`, the method hit its early return, and the stored procedure was never invoked. After this change an affected database invokes `MergeSearchParams` on **every** startup until the repair lands.

**Consequence if left unhandled:** `SqlServerFhirModel.EnsureInitialized()` → `Initialize()` → `InitializeSearchParameterStatuses()`. An exception there means `_highestInitializedVersion = version` never executes and `StorageInitializedNotification` is never published, so `ThrowIfNotInitialized()` keeps firing. Nothing memoizes the failure, so it self-heals once the reindex finishes — but during a rolling upgrade of a customer who needs the repair *and* has a reindex in flight, every replica would fail to complete storage initialization for the duration of that reindex (potentially hours). Our own `eastus2euap` test accounts run reindex E2E tests, so this could have tripped during the very rollout meant to green the pipeline.

**Fix:** `catch (SqlException ex) when (ex.Number == 50002 && isRepairOnly)` logs a warning and returns. `isRepairOnly` is computed from a `HashSet<Uri>` of the URIs captured *before* `RemoveAll`, so the new catch only applies when the merge carries nothing but repair rows. The repair is opportunistic and deferring it to the next startup is strictly better than failing initialization. Merges that also carry **new** parameters from the file — the long-standing path, where 50002 is deliberate — are unchanged and still surface the error.


---

## Defect 2 — `ignoreSearchParameterNotSupportedException` was a dead parameter → HTTP 400 on hard-delete

**Symptom:** `DELETE /SearchParameter/{id}?hardDelete=true` returns 400 instead of 204. On the STU3 eastus2euap test account `DELETE /SearchParameter/us-core-patient-gender-identity?hardDelete=true` returned 400 on 70/70 attempts since 2026-07-27T01:49:25Z, while its two siblings from the same fixture (`us-core-ethnicity`, `us-core-race`) returned 204 every time. Its first two hard-deletes succeeded on 2026-07-26T21:42; the permanent 400 began ~4 minutes after `ReindexOrchestratorJob ... completed cache refresh at the End: SearchParamLastUpdated 07/27/2026 01:45:19`. Logged exception is `SearchParameterNotSupportedException` from logger `SearchParameterOperations` with body `Error deleting search parameter.` — **not** the SQL 50001 / `SearchParameterConcurrencyConflict` error.

Acceptance test: `BulkDeleteTests.GivenBulkDeleteRequest_WhenSearchParametersDeleted_ThenSearchParameterStatusShouldBeUpdated`, which fails in its first step, the `CleanupAsync()` local function.

**Root cause:**

| Step | Location | Behaviour |
|---|---|---|
| 1 | `DeletionService.DeleteSearchParameterWithLockAsync` (~712) | passes `ignoreSearchParameterNotSupportedException: true` |
| 2 | `SearchParameterOperations.DeleteSearchParameterAsync` (~195) | declared the flag, **never read it**; line ~208 passed `lastUpdated:` as a named argument, so the flag fell back to its default of `false` |
| 3 | `SearchParameterStatusManager.UpdateSearchParameterStatusAsync` (~139) | declared the flag, **never read it**; called `GetSearchParameter(uri)` for any status other than `Deleted` |
| 4 | `SearchParameterDefinitionManager.GetSearchParameter(string)` (~187) | throws `SearchParameterNotSupportedException` when the url is absent from `UrlLookup` |
| 5 | `SearchParameterOperations.DeleteSearchParameterAsync` catch block | logs `Error deleting search parameter.`, appends `CustomSearchDeleteError` and rethrows → HTTP 400 |

The url is missing from `UrlLookup` because `GetAndApplySearchParameterUpdates` (~270-273) calls `DeleteSearchParameter(uri)` for statuses that reached `Deleted`, removing the entry from the definition manager — while the `SearchParameter` **resource row still exists** in the store. A hard delete of that resource then tries to set `PendingHardDelete` on a url the registry no longer knows.

**History:** the flag *was* honoured when **PR #5026** (2025-07-08, commit `1a9c4a0da`) added it — it wrapped the `GetSearchParameter` validation in a `try/catch (SearchParameterNotSupportedException)` inside `UpdateSearchParameterStatusAsync`. That handling was removed by the **#5433 "Atomic Search Param operations" refactor** (2026-04-28, commit `fc4753958`), leaving the parameter dead in both methods ever since.

**Fix:** thread the flag end to end and restore #5026's intent.
- `SearchParameterOperations.DeleteSearchParameterAsync` now passes the flag explicitly (avoiding the named-argument trap).
- `SearchParameterStatusManager.UpdateSearchParameterStatusAsync` catches `SearchParameterNotSupportedException` around the validation with an exception filter (`when (ignoreSearchParameterNotSupportedException)`) and logs + skips the uri.
- **A skipped uri gets no status row**, matching #5026. Writing an orphaned `PendingHardDelete` row would poison every reindex cycle: `ReindexOrchestratorJob.CreateReindexProcessingJobsAsync` includes `PendingHardDelete` in its `validStatus` set (~279) and then logs `status=null uri=...` as an Error for urls it cannot resolve in the registry (~304-310), with a `TODO` to throw in future.
- Added an early return when every uri was skipped, so we don't call `UpsertStatuses` with an empty list.

**Net effect:** hard-deleting a `SearchParameter` resource whose registry entry is already gone returns 204, not 400.

**Why CI never caught it:** it requires a `SearchParameter` that previously reached `Deleted` status (removing it from the in-memory registry) while its resource row survives — i.e. accumulated state from earlier runs against the same database.

---

## Tests

No E2E test was modified — the two named in the brief are the acceptance criteria.

**New unit tests**
- `SearchValueExpressionBuilderTests` — 2 tests: a `Special`-typed parameter with a url, and one without a url, both must throw `SearchParameterNotSupportedException` rather than `KeyNotFoundException`.
- `SearchParameterStatusManagerTests` — 4 tests: without the flag it still throws; with the flag the uri is skipped and `UpsertStatuses` is not called; a mix of known and missing uris persists only the known ones; `Deleted` still bypasses registry validation entirely.
- `SearchParameterOperationsTests` (new file) — exercises the **real** `SearchParameterOperations` wired to a **real** `SearchParameterStatusManager`, so the named-argument trap in step 2 cannot be silently reintroduced. Covers hard and soft delete with the flag (no exception, no upsert) and without the flag (throws).

**New integration tests** (`SqlServerSearchParameterInitializationTests`)
- `GivenAnAgedDatabaseWhereAnUnsupportedSearchParameterIsStoredAsEnabled_WhenInitializing_ThenItIsRepairedToUnsupported` — seeds `Location-near` as `Enabled` (simulating a database seeded in the affected window), plus a second file-`Unsupported` parameter as `Disabled`, then restarts. Asserts the first is repaired to `Unsupported` and the second is left alone.
- `GivenADatabaseWhereSearchParameterStatusesAreAlreadyCorrect_WhenInitializing_ThenNothingIsRewritten` — asserts every status *and* `LastUpdated` is byte-for-byte unchanged across a second startup, which proves no merge was issued.
- `GivenADatabaseNeedingRepairAndAReindexJobInProgress_WhenInitializing_ThenTheRepairIsDeferredAndInitializationSucceeds` — enqueues a real `QueueType.Reindex` job so `dbo.GetActiveJobs` reports a reindex in progress, then asserts `Initialize` **completes** and leaves the parameter as `Enabled`; after the job is removed, the next startup applies the deferred repair. Verified to fail (the 50002 `SqlException` escapes `SqlServerFhirModel.Initialize`) with the new catch removed.

Both use a **fresh `SqlServerFhirModel` instance** rather than the fixture's. `SqlServerFhirModel.Initialize` short-circuits on `_highestInitializedVersion == version`, and the fixture already initializes to `SchemaVersionConstants.Max`, so calling `Initialize` again on the fixture's instance is a no-op and cannot exercise the startup path. A new instance is what makes the test behave like a service starting up against an existing database.

The repair test was verified to **fail** (`Expected: Unsupported / Actual: Enabled`) with the `SqlServerFhirModel` fix reverted, and pass with it applied.

**Results** (SDK 10.0.302, local SQL Server):

| Suite | Result |
|---|---|
| `{R4,R4B,Stu3,R5}.Core.UnitTests` — `SearchValueExpressionBuilderTests`, `SearchParameterOperationsTests`, `SearchParameterBehaviorTests`, `SearchParameterRetryTests`, `DeletionServiceTests` | 216 / 216 / 215 / 216 passed |
| `Core.UnitTests` — `SearchParameterStatusManagerTests` | 9 passed |
| `R4.Core.UnitTests` — full targeted sweep incl. `SearchParameterDefinitionManagerTests`, `SearchOptionsFactoryTests` | 315 passed |
| `R4.Tests.Integration` — `SqlServerSearchParameterInitializationTests` | 6 passed (stable over 3 consecutive runs) |
| `R4.Tests.Integration` — all `~SearchParameter` tests | 43 passed; the 11 failures are all `(CosmosDb)` variants that cannot connect to a local emulator |

All touched projects build with 0 warnings, 0 errors.



