### PR TITLE
Reject mixed SMART scope contexts

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -198,8 +198,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                 {
                     fhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
 
-                    bool includeFhirUserClaim = true;
-
                     // examine the scopes claim for any SMART on FHIR clinical scopes
                     DataActions permittedDataActions = 0;
                     var scopeClaimsBuilder = new StringBuilder();
@@ -259,16 +257,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                             scopeClaims));
                     }
 
-                    bool smartV1AccessLevelUsed = false;
-                    bool smartV2AccessLevelUsed = false;
+                    string clinicalScopeContext = null;
                     foreach (Match match in matches)
                     {
-                        var accessLevel = match.Groups["accessLevel"]?.Value;
-                        if (string.IsNullOrEmpty(accessLevel))
-                        {
-                            continue;
-                        }
-
                         // The regex finds clinical-scope substrings rather than matching whole tokens, so a
                         // malformed scope whose token is only partially valid (e.g. "patient/Observation.read-only",
                         // "patient/Observation.rs?active", "patient/Observation.rsXYZ") still produces a match for
@@ -281,6 +272,27 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                             throw new BadHttpRequestException(string.Format(
                                 Api.Resources.SmartScopeInvalidSearchParameters,
                                 scopeClaims));
+                        }
+
+                        string currentClinicalScopeContext = match.Groups["id"].Value;
+                        if (clinicalScopeContext != null
+                            && !clinicalScopeContext.Equals(currentClinicalScopeContext, StringComparison.OrdinalIgnoreCase))
+                        {
+                            throw new BadHttpRequestException(Api.Resources.MixedSMARTScopeContextsAreNotAllowed);
+                        }
+
+                        clinicalScopeContext = currentClinicalScopeContext;
+                    }
+
+                    bool includeFhirUserClaim = !string.Equals("system", clinicalScopeContext, StringComparison.OrdinalIgnoreCase);
+                    bool smartV1AccessLevelUsed = false;
+                    bool smartV2AccessLevelUsed = false;
+                    foreach (Match match in matches)
+                    {
+                        var accessLevel = match.Groups["accessLevel"]?.Value;
+                        if (string.IsNullOrEmpty(accessLevel))
+                        {
+                            continue;
                         }
 
                         // Detect v1 vs v2 based on the accessLevel value.
@@ -418,11 +430,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                             fhirRequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(resource, permittedDataActions, id, smartScopeSearchParameters.Parameters.Any() ? smartScopeSearchParameters : null));
 
                             scopeRestrictions.Append($" ( {resource}-{permittedDataActions} ) ");
-
-                            if (string.Equals("system", id, StringComparison.OrdinalIgnoreCase))
-                            {
-                                includeFhirUserClaim = false; // we skip fhirUser claim for system scopes
-                            }
                         }
                     }
 

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -653,6 +653,15 @@ namespace Microsoft.Health.Fhir.Api {
                 return ResourceManager.GetString("MixedSMARTV1AndV2ScopesAreNotAllowed", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to SMART clinical scopes must use a single context. Patient, user, and system scopes cannot be mixed..
+        /// </summary>
+        public static string MixedSMARTScopeContextsAreNotAllowed {
+            get {
+                return ResourceManager.GetString("MixedSMARTScopeContextsAreNotAllowed", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Search parameter modifiers are not supported in SMART on FHIR clinical scopes. The scope &apos;{0}&apos; contains an unsupported modifier in parameter &apos;{1}&apos;..

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -412,6 +412,9 @@
   <data name="MixedSMARTV1AndV2ScopesAreNotAllowed" xml:space="preserve">
     <value>Mixed SMART v1 and v2 scopes are not allowed. Please use either SMART v1 or SMART v2 scopes. </value>
   </data>
+  <data name="MixedSMARTScopeContextsAreNotAllowed" xml:space="preserve">
+    <value>SMART clinical scopes must use a single context. Patient, user, and system scopes cannot be mixed.</value>
+  </data>
   <data name="SmartScopeSearchParameterModifiersNotSupported" xml:space="preserve">
     <value>Search parameter modifiers are not supported in SMART on FHIR clinical scopes. The scope '{0}' contains an unsupported modifier in parameter '{1}'.</value>
     <comment>{0} is the scope string; {1} is the offending search parameter key=value</comment>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -163,8 +163,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         }
 
         [Theory]
-        [MemberData(nameof(GetMixedTestScopes))]
-        public async Task GivenMixedSmartScope_WhenInvoked_ThenBadRequestIsThrown(string scopes)
+        [MemberData(nameof(GetMixedSmartScopeVersions))]
+        public async Task GivenMixedSmartScopeVersions_WhenInvoked_ThenBadRequestIsThrown(string scopes)
         {
             HttpContext httpContext = new DefaultHttpContext();
 
@@ -196,6 +196,46 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 await Assert.ThrowsAsync<BadHttpRequestException>(() =>
                     _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMixedSmartScopeContexts))]
+        public async Task GivenMixedSmartScopeContexts_WhenInvoked_ThenBadRequestIsThrown(string scopes)
+        {
+            HttpContext httpContext = new DefaultHttpContext();
+
+            var fhirConfiguration = new FhirServerConfiguration();
+            fhirConfiguration.Security.Enabled = true;
+            var authorizationConfiguration = fhirConfiguration.Security.Authorization;
+            authorizationConfiguration.Enabled = true;
+            await LoadRoles(authorizationConfiguration);
+
+            var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
+            var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
+
+            foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
+            {
+                var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
+                var fhirRequestContext = new DefaultFhirRequestContext();
+
+                fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
+
+                var scopesClaim = new Claim(singleClaim, scopes);
+                var claimsIdentity = new ClaimsIdentity(new List<Claim>() { scopesClaim, rolesClaim, fhirUserClaim });
+                var expectedPrincipal = new ClaimsPrincipal(claimsIdentity);
+
+                httpContext.User = expectedPrincipal;
+                fhirRequestContext.Principal = expectedPrincipal;
+
+                _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
+
+                var exception = await Assert.ThrowsAsync<BadHttpRequestException>(() =>
+                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
+
+                Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+                Assert.Equal(Api.Resources.MixedSMARTScopeContextsAreNotAllowed, exception.Message);
             }
         }
 
@@ -469,6 +509,41 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         }
 
         [Fact]
+        public async Task GivenOnlySystemScopes_WhenFhirUserNotProvided_ThenScopeRestrictionsAreApplied()
+        {
+            var fhirConfiguration = new FhirServerConfiguration();
+            fhirConfiguration.Security.Enabled = true;
+            var authorizationConfiguration = fhirConfiguration.Security.Authorization;
+            authorizationConfiguration.Enabled = true;
+            await LoadRoles(authorizationConfiguration);
+
+            var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
+
+            foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
+            {
+                var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+                var fhirRequestContext = new DefaultFhirRequestContext();
+                fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
+
+                HttpContext httpContext = new DefaultHttpContext();
+                var scopesClaim = new Claim(singleClaim, "system/Patient.read");
+                var claimsIdentity = new ClaimsIdentity(new List<Claim>() { scopesClaim, rolesClaim });
+                var expectedPrincipal = new ClaimsPrincipal(claimsIdentity);
+
+                httpContext.User = expectedPrincipal;
+                fhirRequestContext.Principal = expectedPrincipal;
+
+                _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
+
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+
+                Assert.Equal(
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export | DataActions.Search, "system"),
+                    Assert.Single(fhirRequestContext.AccessControlContext.AllowedResourceActions));
+            }
+        }
+
+        [Fact]
         public async Task GivenAllDataActionExceptSmart_WhenScopesProvided_ThenScopeRestrictionsNotApplied()
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -593,11 +668,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             };
             yield return new object[]
             {
-                "patient.Patient.read",
+                "user.Patient.read",
                 "user.Observation.write",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export | DataActions.Search, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export | DataActions.Search, "user"),
                     new ScopeRestriction("Observation", DataActions.Write | DataActions.Create | DataActions.Delete | DataActions.Update, "user"),
                 },
             };
@@ -635,10 +710,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             };
             yield return new object[]
             {
-                "patient.Patient.read user.Observation.write",
+                "user.Patient.read user.Observation.write",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export | DataActions.Search, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export | DataActions.Search, "user"),
                     new ScopeRestriction("Observation", DataActions.Write | DataActions.Create | DataActions.Update | DataActions.Delete, "user"),
                 },
             };
@@ -688,12 +763,12 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             };
             yield return new object[]
             {
-                "patient/Patient.read launch/patient user/Observation.read offline_access openid user/Encounter.* fhirUser",
+                "patient/Patient.read launch/patient patient/Observation.read offline_access openid patient/Encounter.* fhirUser",
                 new List<ScopeRestriction>()
                 {
                     new ScopeRestriction("Patient", DataActions.Read | DataActions.Export | DataActions.Search, "patient"),
-                    new ScopeRestriction("Observation", DataActions.Read | DataActions.Export | DataActions.Search, "user"),
-                    new ScopeRestriction("Encounter", DataActions.Read | DataActions.Search | DataActions.Write | DataActions.Export | DataActions.Create | DataActions.Update | DataActions.Delete, "user"),
+                    new ScopeRestriction("Observation", DataActions.Read | DataActions.Export | DataActions.Search, "patient"),
+                    new ScopeRestriction("Encounter", DataActions.Read | DataActions.Search | DataActions.Write | DataActions.Export | DataActions.Create | DataActions.Update | DataActions.Delete, "patient"),
                 },
             };
 
@@ -710,11 +785,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             yield return new object[] { "user/*.rs", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.ReadById | DataActions.Search | DataActions.Export, "user") } };
             yield return new object[]
             {
-                "patient/Patient.rs user/Observation.cud",
+                "patient/Patient.rs patient/Observation.cud",
                 new List<ScopeRestriction>()
                 {
                     new ScopeRestriction("Patient", DataActions.ReadById | DataActions.Search | DataActions.Export, "patient"),
-                    new ScopeRestriction("Observation", DataActions.Create | DataActions.Update | DataActions.Delete, "user"),
+                    new ScopeRestriction("Observation", DataActions.Create | DataActions.Update | DataActions.Delete, "patient"),
                 },
             };
 
@@ -734,11 +809,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             yield return new object[] { "patient/Patient.write", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Write | DataActions.Create | DataActions.Update | DataActions.Delete, "patient") } };
             yield return new object[]
             {
-                "patient/Patient.c user/Observation.cu",
+                "patient/Patient.c patient/Observation.cu",
                 new List<ScopeRestriction>()
                 {
                     new ScopeRestriction("Patient", DataActions.Create, "patient"),
-                    new ScopeRestriction("Observation", DataActions.Create | DataActions.Update, "user"),
+                    new ScopeRestriction("Observation", DataActions.Create | DataActions.Update, "patient"),
                 },
             };
 
@@ -878,14 +953,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 },
             };
 
-            // Mixed: some scopes with %2f, some with regular / separator
+            // Some scopes with %2f, some with regular / separator
             yield return new object[]
             {
-                "patient%2fPatient.read user/Observation.write",
+                "patient%2fPatient.read patient/Observation.write",
                 new List<ScopeRestriction>()
                 {
                     new ScopeRestriction("Patient", DataActions.Read | DataActions.Export | DataActions.Search, "patient"),
-                    new ScopeRestriction("Observation", DataActions.Write | DataActions.Create | DataActions.Update | DataActions.Delete, "user"),
+                    new ScopeRestriction("Observation", DataActions.Write | DataActions.Create | DataActions.Update | DataActions.Delete, "patient"),
                 },
             };
 
@@ -903,11 +978,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             // V2 granular with %2f
             yield return new object[]
             {
-                "user%2fPatient.cud patient%2fObservation.rs",
+                "user%2fPatient.cud user%2fObservation.rs",
                 new List<ScopeRestriction>()
                 {
                     new ScopeRestriction("Patient", DataActions.Create | DataActions.Update | DataActions.Delete, "user"),
-                    new ScopeRestriction("Observation", DataActions.ReadById | DataActions.Search | DataActions.Export, "patient"),
+                    new ScopeRestriction("Observation", DataActions.ReadById | DataActions.Search | DataActions.Export, "user"),
                 },
             };
 
@@ -923,24 +998,36 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             };
         }
 
-        public static IEnumerable<object[]> GetMixedTestScopes()
+        public static IEnumerable<object[]> GetMixedSmartScopeVersions()
         {
             yield return new object[] { "patient/Patient.read patient/Observation.r" };
-            yield return new object[] { "patient.Patient.read user.Observation.cr" };
+            yield return new object[] { "patient.Patient.read patient.Observation.cr" };
             yield return new object[] { "patient$Patient.rd patient/Observation.write" };
             yield return new object[] { "patient$Patient.read patient/Observation.cr" };
-            yield return new object[] { "patient/Patient.read launch/patient user/Observation.read offline_access openid user/Encounter.r fhirUser" };
-            yield return new object[] { "patient/Patient.rs user/Observation.cud user/Encounter.write" };
-            yield return new object[] { "patient/Patient.read user/Observation.c" };
-            yield return new object[] { "patient/Patient.all user/Observation.r" };
-            yield return new object[] { "patient/Patient.write user/Observation.u" };
-            yield return new object[] { "patient/Patient.read user/Observation.d" };
+            yield return new object[] { "patient/Patient.read launch/patient patient/Observation.read offline_access openid patient/Encounter.r fhirUser" };
+            yield return new object[] { "patient/Patient.rs patient/Observation.cud patient/Encounter.write" };
+            yield return new object[] { "patient/Patient.read patient/Observation.c" };
+            yield return new object[] { "patient/Patient.all patient/Observation.r" };
+            yield return new object[] { "patient/Patient.write patient/Observation.u" };
+            yield return new object[] { "patient/Patient.read patient/Observation.d" };
             yield return new object[] { "patient/Patient.read patient/Patient.cruds" };
-            yield return new object[] { "system/Patient.write user/Patient.r" };
-            yield return new object[] { "patient/Patient.* user/Observation.d" };
+            yield return new object[] { "system/Patient.write system/Patient.r" };
+            yield return new object[] { "patient/Patient.* patient/Observation.d" };
             yield return new object[] { "patient/Patient.all patient/Patient.cruds" };
-            yield return new object[] { "system/Patient.all user/Patient.r" };
-            yield return new object[] { "system/Patient.* user/Patient.r" };
+            yield return new object[] { "system/Patient.all system/Patient.r" };
+            yield return new object[] { "system/Patient.* system/Patient.r" };
+        }
+
+        public static IEnumerable<object[]> GetMixedSmartScopeContexts()
+        {
+            yield return new object[] { "patient/Patient.read user/Observation.read" };
+            yield return new object[] { "user/Patient.read patient/Observation.read" };
+            yield return new object[] { "patient/Patient.read system/Observation.read" };
+            yield return new object[] { "system/Patient.read patient/Observation.read" };
+            yield return new object[] { "user/Patient.read system/Observation.read" };
+            yield return new object[] { "system/Patient.read user/Observation.read" };
+            yield return new object[] { "patient/Patient.read user/Observation.read system/Encounter.read" };
+            yield return new object[] { "patient%2fPatient.read system/Observation.read" };
         }
 
         public static IEnumerable<object[]> GetScopesWithModifiers()


### PR DESCRIPTION
## Description

- Reject SMART clinical scopes that mix `patient`, `user`, and `system` contexts with HTTP 400.
- Validate the aggregate clinical scope context before applying authorization restrictions.
- Preserve system-only scope behavior without requiring a `fhirUser` claim.
- Retain the existing secure default of `ErrorOnMissingFhirUserClaim = true`.

## Related issues
Addresses [issue #194208](https://microsofthealth.visualstudio.com/Health/_workitems/edit/194208).

## Testing
- SMART middleware tests passed for R4, R4B, R5, and STU3 (181 tests per version).

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)