### PR TITLE
Allow machine specific nuget config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,9 +4,16 @@
     <add key="repositoryPath" value="packages" />
   </config>
   <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="azure-default">
+      <package pattern="*" />
+    </packageSource>
     <packageSource key="Microsoft Health OSS">
       <package pattern="Microsoft.Health.*" />
     </packageSource>

--- a/nuget.config
+++ b/nuget.config
@@ -1,22 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
   <packageSources>
-    <clear />
-    <add key="MicrosoftProxy" value="https://packagefeedproxy.microsoft.io/nuget/v3/index.json" />
     <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="MicrosoftProxy">
-      <package pattern="*" />
-    </packageSource>
     <packageSource key="Microsoft Health OSS">
       <package pattern="Microsoft.Health.*" />
     </packageSource>
   </packageSourceMapping>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -5,11 +5,11 @@
   </config>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="MicrosoftProxy" value="https://packagefeedproxy.microsoft.io/nuget/v3/index.json" />
     <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="nuget.org">
+    <packageSource key="MicrosoftProxy">
       <package pattern="*" />
     </packageSource>
     <packageSource key="Microsoft Health OSS">


### PR DESCRIPTION
## Description
Allow machine specific nuget config for corp policy about where public packages go.

## Related issues
[AB#204462](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/204462)

## Testing
dotnet restore locally
github execution of proxy

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch
