### PR TITLE
Experiment: atomic target-first chained search with sort support

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
@@ -211,54 +211,6 @@ public partial class SqlQueryGeneratorTests
         Assert.Contains(sortOrder == SortOrder.Ascending ? "SortValue ASC" : "SortValue DESC", generatedSql);
     }
 
-    [Theory]
-    [InlineData(SortOrder.Ascending, "ORDER BY t.SortValue ASC")]
-    [InlineData(SortOrder.Descending, "ORDER BY t.SortValue DESC")]
-    public void GivenAdjacentUnsupportedNumberSortOnTargetFirstChainedSearch_WhenSqlGenerated_ThenEntireOptimizationIsRejected(
-        SortOrder sortOrder,
-        string orderBy)
-    {
-        (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
-        var sortParam = new SearchParameterInfo(
-            "value",
-            "value",
-            SearchParamType.Number,
-            new Uri("http://hl7.org/fhir/SearchParameter/Observation-value"));
-        _fhirModel.GetSearchParamId(sortParam.Url).Returns((short)1283);
-        tableExpressions.Add(
-            new SearchParamTableExpression(
-                NumberQueryGenerator.Instance,
-                new SortExpression(sortParam),
-                SearchParamTableExpressionKind.Sort));
-        SqlRootExpression sqlExpression = new(tableExpressions, []);
-        SearchOptions searchOptions = new()
-        {
-            Sort = [(sortParam, sortOrder)],
-            ResourceVersionTypes = ResourceVersionType.Latest,
-        };
-
-        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
-
-        string generatedSql = _strBuilder.ToString();
-        Assert.DoesNotContain("chainTarget", generatedSql);
-        Assert.Contains("FROM dbo.ReferenceSearchParam refSource", generatedSql);
-        Assert.Contains("FROM dbo.ReferenceSearchParam", generatedSql);
-        Assert.Contains("FROM dbo.DateTimeSearchParam", generatedSql);
-        Assert.Contains("SingleValue AS SortValue", generatedSql);
-        Assert.Contains("FROM dbo.NumberSearchParam", generatedSql);
-        Assert.Contains("cte3.SortValue", generatedSql);
-        Assert.Contains(orderBy, generatedSql);
-        Assert.True(
-            generatedSql.IndexOf("FROM dbo.ReferenceSearchParam refSource", StringComparison.Ordinal) <
-            generatedSql.LastIndexOf("FROM dbo.ReferenceSearchParam", StringComparison.Ordinal));
-        Assert.True(
-            generatedSql.LastIndexOf("FROM dbo.ReferenceSearchParam", StringComparison.Ordinal) <
-            generatedSql.IndexOf("FROM dbo.DateTimeSearchParam", StringComparison.Ordinal));
-        Assert.True(
-            generatedSql.IndexOf("FROM dbo.DateTimeSearchParam", StringComparison.Ordinal) <
-            generatedSql.IndexOf("FROM dbo.NumberSearchParam", StringComparison.Ordinal));
-    }
-
     [Fact]
     public void GivenTargetFirstChainedSearchWithTop_WhenSqlGenerated_ThenOptimizedShapeIsPreserved()
     {

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
@@ -11,6 +11,7 @@ using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.SqlServer.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
 using Microsoft.Health.Fhir.ValueSets;
 using NSubstitute;
@@ -56,16 +57,7 @@ public partial class SqlQueryGeneratorTests
     public void GivenChainedReferenceSearchWithPrecedingSourceFilter_WhenSqlGenerated_ThenExistingQueryShapeIsUsed()
     {
         (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
-        var sourceFilterParam = new SearchParameterInfo(
-            "status",
-            "status",
-            SearchParamType.Token,
-            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
-        Expression sourceFilter = Expression.SearchParameter(
-            sourceFilterParam,
-            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
-        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
-        tableExpressions.Insert(0, new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal));
+        tableExpressions.Insert(0, CreateSourceStatusFilterExpression());
         SqlRootExpression sqlExpression = new(tableExpressions, []);
         SearchOptions searchOptions = new()
         {
@@ -112,6 +104,64 @@ public partial class SqlQueryGeneratorTests
     }
 
     [Theory]
+    [InlineData(SortOrder.Ascending, "IsMin = 1", "SortValue  ASC")]
+    [InlineData(SortOrder.Descending, "IsMax = 1", "SortValue  DESC")]
+    public void GivenPlainSortedChainedReferenceSearch_WhenSqlGenerated_ThenMultiValuedRowsAreCollapsedAndOrdered(
+        SortOrder sortOrder,
+        string minOrMaxPredicate,
+        string orderBy)
+    {
+        (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
+        SearchParameterInfo sortParam = CreateSortDateParameter();
+        AddSortExpression(tableExpressions, sortParam, SearchParamTableExpressionKind.Sort);
+        tableExpressions.Add(new SearchParamTableExpression(null, null, SearchParamTableExpressionKind.Top));
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            Sort = [(sortParam, sortOrder)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
+        Assert.Contains("cte3 AS", generatedSql);
+        Assert.Contains("StartDateTime AS SortValue", generatedSql);
+        Assert.Contains(minOrMaxPredicate, generatedSql);
+        Assert.Contains("SELECT DISTINCT TOP (", generatedSql);
+        Assert.Contains(orderBy, generatedSql);
+        Assert.Contains(", Sid1 ASC", generatedSql);
+    }
+
+    [Theory]
+    [InlineData(SortOrder.Ascending, " OR StartDateTime > ")]
+    [InlineData(SortOrder.Descending, " OR StartDateTime < ")]
+    public void GivenPlainSortedChainedReferenceSearchWithContinuationToken_WhenSqlGenerated_ThenSortAndSurrogateBoundariesArePreserved(
+        SortOrder sortOrder,
+        string sortComparison)
+    {
+        (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
+        SearchParameterInfo sortParam = CreateSortDateParameter();
+        AddSortExpression(tableExpressions, sortParam, SearchParamTableExpressionKind.Sort);
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            ContinuationToken = new ContinuationToken(["2026-09-05T17:00:00.0000000Z", (short)125, 42L]).ToString(),
+            Sort = [(sortParam, sortOrder)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
+        Assert.Contains("StartDateTime =", generatedSql);
+        Assert.Contains("ResourceSurrogateId >", generatedSql);
+        Assert.Contains(sortComparison, generatedSql);
+    }
+
+    [Theory]
     [InlineData(SortOrder.Ascending, " OR StartDateTime > ")]
     [InlineData(SortOrder.Descending, " OR StartDateTime < ")]
     public void GivenSortedChainedReferenceSearchWithContinuationToken_WhenSqlGenerated_ThenTargetFirstShapePreservesPagingSemantics(
@@ -143,16 +193,7 @@ public partial class SqlQueryGeneratorTests
     public void GivenSortedChainedReferenceSearchWithPrecedingSourceFilter_WhenSqlGenerated_ThenGenericShapeIsUsed(SortOrder sortOrder)
     {
         (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
-        var sourceFilterParam = new SearchParameterInfo(
-            "status",
-            "status",
-            SearchParamType.Token,
-            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
-        Expression sourceFilter = Expression.SearchParameter(
-            sourceFilterParam,
-            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
-        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
-        tableExpressions.Insert(0, new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal));
+        tableExpressions.Insert(0, CreateSourceStatusFilterExpression());
         AddSortExpression(tableExpressions, dateParam);
         SqlRootExpression sqlExpression = new(tableExpressions, []);
         SearchOptions searchOptions = new()
@@ -320,16 +361,7 @@ public partial class SqlQueryGeneratorTests
     public void GivenTargetFirstChainedSearchWithFollowingSourcePredicate_WhenSqlGenerated_ThenOptimizedShapeFeedsFollowingPredicate()
     {
         (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
-        var sourceFilterParam = new SearchParameterInfo(
-            "status",
-            "status",
-            SearchParamType.Token,
-            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
-        Expression sourceFilter = Expression.SearchParameter(
-            sourceFilterParam,
-            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
-        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
-        tableExpressions.Add(new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal));
+        tableExpressions.Add(CreateSourceStatusFilterExpression());
         SqlRootExpression sqlExpression = new(tableExpressions, []);
         SearchOptions searchOptions = new()
         {
@@ -350,19 +382,10 @@ public partial class SqlQueryGeneratorTests
     [Theory]
     [InlineData(SortOrder.Ascending)]
     [InlineData(SortOrder.Descending)]
-    public void GivenSortedTargetFirstChainedSearchWithFollowingSourcePredicate_WhenSqlGenerated_ThenSortValueIsProjectedAfterFollowingPredicate(SortOrder sortOrder)
+    public void GivenSortedTargetFirstChainedSearchWithFollowingSourcePredicate_WhenSqlGenerated_ThenGenericSortIsAppliedAfterFollowingPredicate(SortOrder sortOrder)
     {
         (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
-        var sourceFilterParam = new SearchParameterInfo(
-            "status",
-            "status",
-            SearchParamType.Token,
-            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
-        Expression sourceFilter = Expression.SearchParameter(
-            sourceFilterParam,
-            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
-        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
-        tableExpressions.Add(new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal));
+        tableExpressions.Add(CreateSourceStatusFilterExpression());
         AddSortExpression(tableExpressions, dateParam);
         SqlRootExpression sqlExpression = new(tableExpressions, []);
         SearchOptions searchOptions = new()
@@ -381,20 +404,53 @@ public partial class SqlQueryGeneratorTests
         Assert.Contains(sortOrder == SortOrder.Ascending ? "SortValue ASC" : "SortValue DESC", generatedSql);
     }
 
+    [Theory]
+    [InlineData(SortOrder.Ascending, false, true)]
+    [InlineData(SortOrder.Ascending, true, false)]
+    [InlineData(SortOrder.Descending, false, false)]
+    [InlineData(SortOrder.Descending, true, true)]
+    public void GivenPlainSortedTargetFirstChainedSearch_WhenSortRewritten_ThenMissingAndValuedPhasesArePreserved(
+        SortOrder sortOrder,
+        bool secondPhase,
+        bool expectMissingPhase)
+    {
+        (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
+        SearchParameterInfo sortParam = CreateSortDateParameter();
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        var searchOptions = new SqlSearchOptions(
+            new SearchOptions
+            {
+                SearchParameters = [],
+                Sort = [(sortParam, sortOrder)],
+                UnsupportedSearchParams = [],
+                ResourceVersionTypes = ResourceVersionType.Latest,
+            })
+        {
+            SortQuerySecondPhase = secondPhase,
+        };
+        var rewriter = new SortRewriter(_queryGeneratorFactory);
+
+        SqlRootExpression rewrittenExpression = (SqlRootExpression)rewriter.VisitSqlRoot(sqlExpression, searchOptions);
+
+        Assert.Equal(4, rewrittenExpression.SearchParamTableExpressions.Count);
+        SearchParamTableExpression phaseExpression = rewrittenExpression.SearchParamTableExpressions[^1];
+        if (expectMissingPhase)
+        {
+            Assert.Equal(SearchParamTableExpressionKind.NotExists, phaseExpression.Kind);
+            Assert.True(Assert.IsType<MissingSearchParameterExpression>(phaseExpression.Predicate).IsMissing);
+        }
+        else
+        {
+            Assert.Equal(SearchParamTableExpressionKind.Sort, phaseExpression.Kind);
+            Assert.IsType<SortExpression>(phaseExpression.Predicate);
+        }
+    }
+
     [Fact]
     public void GivenInterveningSourcePredicateInChainedSearch_WhenSqlGenerated_ThenExistingQueryShapeIsUsed()
     {
         (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
-        var sourceFilterParam = new SearchParameterInfo(
-            "status",
-            "status",
-            SearchParamType.Token,
-            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
-        Expression sourceFilter = Expression.SearchParameter(
-            sourceFilterParam,
-            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
-        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
-        tableExpressions.Insert(2, new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal));
+        tableExpressions.Insert(2, CreateSourceStatusFilterExpression());
         SqlRootExpression sqlExpression = new(tableExpressions, []);
         SearchOptions searchOptions = new()
         {
@@ -534,12 +590,42 @@ public partial class SqlQueryGeneratorTests
             dateParam);
     }
 
-    private static void AddSortExpression(List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam)
+    private SearchParamTableExpression CreateSourceStatusFilterExpression()
+    {
+        var sourceFilterParam = new SearchParameterInfo(
+            "status",
+            "status",
+            SearchParamType.Token,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        Expression sourceFilter = Expression.SearchParameter(
+            sourceFilterParam,
+            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
+        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
+
+        return new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal);
+    }
+
+    private SearchParameterInfo CreateSortDateParameter()
+    {
+        var sortParam = new SearchParameterInfo(
+            "issued",
+            "issued",
+            SearchParamType.Date,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-issued"));
+        _fhirModel.GetSearchParamId(sortParam.Url).Returns((short)1282);
+
+        return sortParam;
+    }
+
+    private static void AddSortExpression(
+        List<SearchParamTableExpression> tableExpressions,
+        SearchParameterInfo dateParam,
+        SearchParamTableExpressionKind kind = SearchParamTableExpressionKind.SortWithFilter)
     {
         tableExpressions.Add(
             new SearchParamTableExpression(
                 DateTimeQueryGenerator.Instance,
                 new SortExpression(dateParam),
-                SearchParamTableExpressionKind.SortWithFilter));
+                kind));
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
 using Microsoft.Health.Fhir.ValueSets;
@@ -80,19 +81,83 @@ public partial class SqlQueryGeneratorTests
         Assert.Contains("JOIN dbo.Resource refTarget", generatedSql);
     }
 
-    [Fact]
-    public void GivenSortedChainedReferenceSearch_WhenSqlGenerated_ThenExistingQueryShapeIsUsed()
+    [Theory]
+    [InlineData(SortOrder.Ascending, "IsMin = 1", "SortValue ASC")]
+    [InlineData(SortOrder.Descending, "IsMax = 1", "SortValue DESC")]
+    public void GivenSortedChainedReferenceSearch_WhenSqlGenerated_ThenTargetFirstShapePreservesSortValue(
+        SortOrder sortOrder,
+        string minOrMaxPredicate,
+        string orderBy)
     {
         (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
-        tableExpressions.Add(
-            new SearchParamTableExpression(
-                DateTimeQueryGenerator.Instance,
-                new SortExpression(dateParam),
-                SearchParamTableExpressionKind.Sort));
+        AddSortExpression(tableExpressions, dateParam);
         SqlRootExpression sqlExpression = new(tableExpressions, []);
         SearchOptions searchOptions = new()
         {
-            Sort = [(dateParam, SortOrder.Ascending)],
+            Sort = [(dateParam, sortOrder)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
+        Assert.Contains("INNER HASH JOIN cte1 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1", generatedSql);
+        Assert.Contains("cte3 AS", generatedSql);
+        Assert.Contains("StartDateTime AS SortValue", generatedSql);
+        Assert.Contains("JOIN cte2 ON ResourceTypeId = cte2.T1 AND ResourceSurrogateId = cte2.Sid1", generatedSql);
+        Assert.Contains(minOrMaxPredicate, generatedSql);
+        Assert.Contains("cte3.SortValue", generatedSql);
+        Assert.Contains(orderBy, generatedSql);
+    }
+
+    [Theory]
+    [InlineData(SortOrder.Ascending, " OR StartDateTime > ")]
+    [InlineData(SortOrder.Descending, " OR StartDateTime < ")]
+    public void GivenSortedChainedReferenceSearchWithContinuationToken_WhenSqlGenerated_ThenTargetFirstShapePreservesPagingSemantics(
+        SortOrder sortOrder,
+        string sortComparison)
+    {
+        (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
+        AddSortExpression(tableExpressions, dateParam);
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            ContinuationToken = new ContinuationToken(["2026-09-05T17:00:00.0000000Z", (short)125, 42L]).ToString(),
+            Sort = [(dateParam, sortOrder)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
+        Assert.Contains("StartDateTime =", generatedSql);
+        Assert.Contains("ResourceSurrogateId >", generatedSql);
+        Assert.Contains(sortComparison, generatedSql);
+    }
+
+    [Theory]
+    [InlineData(SortOrder.Ascending)]
+    [InlineData(SortOrder.Descending)]
+    public void GivenSortedChainedReferenceSearchWithPrecedingSourceFilter_WhenSqlGenerated_ThenGenericShapeIsUsed(SortOrder sortOrder)
+    {
+        (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
+        var sourceFilterParam = new SearchParameterInfo(
+            "status",
+            "status",
+            SearchParamType.Token,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        Expression sourceFilter = Expression.SearchParameter(
+            sourceFilterParam,
+            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
+        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
+        tableExpressions.Insert(0, new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal));
+        AddSortExpression(tableExpressions, dateParam);
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            Sort = [(dateParam, sortOrder)],
             ResourceVersionTypes = ResourceVersionType.Latest,
         };
 
@@ -101,7 +166,8 @@ public partial class SqlQueryGeneratorTests
         string generatedSql = _strBuilder.ToString();
         Assert.DoesNotContain("chainTarget", generatedSql);
         Assert.Contains("FROM dbo.ReferenceSearchParam refSource", generatedSql);
-        Assert.Contains(" AS SortValue", generatedSql);
+        Assert.Contains("StartDateTime AS SortValue", generatedSql);
+        Assert.Contains(sortOrder == SortOrder.Ascending ? "SortValue ASC" : "SortValue DESC", generatedSql);
     }
 
     [Fact]
@@ -122,6 +188,31 @@ public partial class SqlQueryGeneratorTests
         Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
         Assert.Contains("INNER HASH JOIN cte1 ON ResourceTypeId = T1 AND ResourceSurrogateId = Sid1", generatedSql);
         Assert.Contains("SELECT DISTINCT TOP (", generatedSql);
+    }
+
+    [Theory]
+    [InlineData(SortOrder.Ascending)]
+    [InlineData(SortOrder.Descending)]
+    public void GivenSortedTargetFirstChainedSearchWithTop_WhenSqlGenerated_ThenTopUsesProjectedSortValue(SortOrder sortOrder)
+    {
+        (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
+        AddSortExpression(tableExpressions, dateParam);
+        tableExpressions.Add(new SearchParamTableExpression(null, null, SearchParamTableExpressionKind.Top));
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            Sort = [(dateParam, sortOrder)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
+        Assert.Contains("SELECT DISTINCT TOP (", generatedSql);
+        Assert.Contains("cte3.SortValue", generatedSql);
+        Assert.Contains("FROM cte3", generatedSql);
+        Assert.Contains(sortOrder == SortOrder.Ascending ? "ORDER BY SortValue  ASC" : "ORDER BY SortValue  DESC", generatedSql);
     }
 
     [Fact]
@@ -184,6 +275,47 @@ public partial class SqlQueryGeneratorTests
         Assert.Contains(";WITH cte3 AS (SELECT * FROM @FilteredData)", generatedSql);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GivenSortedTargetFirstChainedSearchWithIncludeOrRevInclude_WhenSqlGenerated_ThenSortValueIsPersisted(bool reversed)
+    {
+        (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
+        var includeParam = new SearchParameterInfo(
+            "subject",
+            "subject",
+            SearchParamType.Reference,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-subject"));
+        var includeExpression = new IncludeExpression(
+            ["Observation"],
+            includeParam,
+            "Observation",
+            "Patient",
+            null,
+            wildCard: false,
+            reversed,
+            iterate: false);
+        _fhirModel.GetResourceTypeId("Patient").Returns((short)71);
+        _fhirModel.GetSearchParamId(includeParam.Url).Returns((short)1279);
+        AddSortExpression(tableExpressions, dateParam);
+        tableExpressions.Add(new SearchParamTableExpression(null, null, SearchParamTableExpressionKind.Top));
+        tableExpressions.Add(new SearchParamTableExpression(IncludeQueryGenerator.Instance, includeExpression, SearchParamTableExpressionKind.Include));
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            IncludeCount = 100,
+            Sort = [(dateParam, SortOrder.Ascending)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
+        Assert.Contains("INSERT INTO @FilteredData SELECT T1, Sid1, IsMatch, IsPartial, Row, SortValue FROM cte4", generatedSql);
+        Assert.Contains(";WITH cte4 AS (SELECT * FROM @FilteredData)", generatedSql);
+    }
+
     [Fact]
     public void GivenTargetFirstChainedSearchWithFollowingSourcePredicate_WhenSqlGenerated_ThenOptimizedShapeFeedsFollowingPredicate()
     {
@@ -213,6 +345,40 @@ public partial class SqlQueryGeneratorTests
         Assert.Contains("FROM dbo.TokenSearchParam", generatedSql);
         Assert.Contains("EXISTS (SELECT * FROM cte2", generatedSql);
         Assert.Equal<short>([(short)1242, (short)1273, (short)1277, (short)1278], _queryGenerator.SearchParamIds.Order());
+    }
+
+    [Theory]
+    [InlineData(SortOrder.Ascending)]
+    [InlineData(SortOrder.Descending)]
+    public void GivenSortedTargetFirstChainedSearchWithFollowingSourcePredicate_WhenSqlGenerated_ThenSortValueIsProjectedAfterFollowingPredicate(SortOrder sortOrder)
+    {
+        (List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam) = CreateTargetFirstChainedSearchExpressions();
+        var sourceFilterParam = new SearchParameterInfo(
+            "status",
+            "status",
+            SearchParamType.Token,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-status"));
+        Expression sourceFilter = Expression.SearchParameter(
+            sourceFilterParam,
+            Expression.StringEquals(FieldName.TokenCode, null, "final", false));
+        _fhirModel.GetSearchParamId(sourceFilterParam.Url).Returns((short)1278);
+        tableExpressions.Add(new SearchParamTableExpression(TokenQueryGenerator.Instance, sourceFilter, SearchParamTableExpressionKind.Normal));
+        AddSortExpression(tableExpressions, dateParam);
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            Sort = [(dateParam, sortOrder)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.Contains("FROM dbo.ReferenceSearchParam chainTarget", generatedSql);
+        Assert.Contains("FROM dbo.TokenSearchParam", generatedSql);
+        Assert.Contains("EXISTS (SELECT * FROM cte3", generatedSql);
+        Assert.Contains("cte4.SortValue", generatedSql);
+        Assert.Contains(sortOrder == SortOrder.Ascending ? "SortValue ASC" : "SortValue DESC", generatedSql);
     }
 
     [Fact]
@@ -366,5 +532,14 @@ public partial class SqlQueryGeneratorTests
                 new SearchParamTableExpression(DateTimeQueryGenerator.Instance, datePredicate, SearchParamTableExpressionKind.Normal),
             ],
             dateParam);
+    }
+
+    private static void AddSortExpression(List<SearchParamTableExpression> tableExpressions, SearchParameterInfo dateParam)
+    {
+        tableExpressions.Add(
+            new SearchParamTableExpression(
+                DateTimeQueryGenerator.Instance,
+                new SortExpression(dateParam),
+                SearchParamTableExpressionKind.SortWithFilter));
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.TargetFirstChainedSearch.cs
@@ -211,6 +211,54 @@ public partial class SqlQueryGeneratorTests
         Assert.Contains(sortOrder == SortOrder.Ascending ? "SortValue ASC" : "SortValue DESC", generatedSql);
     }
 
+    [Theory]
+    [InlineData(SortOrder.Ascending, "ORDER BY t.SortValue ASC")]
+    [InlineData(SortOrder.Descending, "ORDER BY t.SortValue DESC")]
+    public void GivenAdjacentUnsupportedNumberSortOnTargetFirstChainedSearch_WhenSqlGenerated_ThenEntireOptimizationIsRejected(
+        SortOrder sortOrder,
+        string orderBy)
+    {
+        (List<SearchParamTableExpression> tableExpressions, _) = CreateTargetFirstChainedSearchExpressions();
+        var sortParam = new SearchParameterInfo(
+            "value",
+            "value",
+            SearchParamType.Number,
+            new Uri("http://hl7.org/fhir/SearchParameter/Observation-value"));
+        _fhirModel.GetSearchParamId(sortParam.Url).Returns((short)1283);
+        tableExpressions.Add(
+            new SearchParamTableExpression(
+                NumberQueryGenerator.Instance,
+                new SortExpression(sortParam),
+                SearchParamTableExpressionKind.Sort));
+        SqlRootExpression sqlExpression = new(tableExpressions, []);
+        SearchOptions searchOptions = new()
+        {
+            Sort = [(sortParam, sortOrder)],
+            ResourceVersionTypes = ResourceVersionType.Latest,
+        };
+
+        _queryGenerator.VisitSqlRoot(sqlExpression, searchOptions);
+
+        string generatedSql = _strBuilder.ToString();
+        Assert.DoesNotContain("chainTarget", generatedSql);
+        Assert.Contains("FROM dbo.ReferenceSearchParam refSource", generatedSql);
+        Assert.Contains("FROM dbo.ReferenceSearchParam", generatedSql);
+        Assert.Contains("FROM dbo.DateTimeSearchParam", generatedSql);
+        Assert.Contains("SingleValue AS SortValue", generatedSql);
+        Assert.Contains("FROM dbo.NumberSearchParam", generatedSql);
+        Assert.Contains("cte3.SortValue", generatedSql);
+        Assert.Contains(orderBy, generatedSql);
+        Assert.True(
+            generatedSql.IndexOf("FROM dbo.ReferenceSearchParam refSource", StringComparison.Ordinal) <
+            generatedSql.LastIndexOf("FROM dbo.ReferenceSearchParam", StringComparison.Ordinal));
+        Assert.True(
+            generatedSql.LastIndexOf("FROM dbo.ReferenceSearchParam", StringComparison.Ordinal) <
+            generatedSql.IndexOf("FROM dbo.DateTimeSearchParam", StringComparison.Ordinal));
+        Assert.True(
+            generatedSql.IndexOf("FROM dbo.DateTimeSearchParam", StringComparison.Ordinal) <
+            generatedSql.IndexOf("FROM dbo.NumberSearchParam", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void GivenTargetFirstChainedSearchWithTop_WhenSqlGenerated_ThenOptimizedShapeIsPreserved()
     {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 SortContext sortContext = GetSortRelatedDetails(context);
                 if (sortCandidate.ChainLevel != 0 ||
                     sortCandidate.QueryGenerator == null ||
-                    string.IsNullOrEmpty(sortContext.SortColumnName))
+                    ReferenceEquals(sortContext.SortColumnName, null))
                 {
                     return null;
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 SortContext sortContext = GetSortRelatedDetails(context);
                 if (sortCandidate.ChainLevel != 0 ||
                     sortCandidate.QueryGenerator == null ||
-                    ReferenceEquals(sortContext.SortColumnName, null))
+                    string.IsNullOrEmpty(sortContext.SortColumnName))
                 {
                     return null;
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
@@ -21,46 +21,33 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             IReadOnlyList<SearchParamTableExpression> tableExpressions,
             SearchOptions context)
         {
-            if (!TryMatchTargetFirstChainedSearch(
-                    tableExpressions,
-                    context,
-                    out SqlChainLinkExpression chainExpression,
-                    out SearchParamTableExpression targetExpression,
-                    out SearchParamTableExpression sourceDateExpression,
-                    out SearchParamTableExpression sortExpression))
+            TargetFirstChainedSearchMatch match = MatchTargetFirstChainedSearch(tableExpressions, context);
+            if (match == null)
             {
                 return 0;
             }
 
-            AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchTarget(targetExpression, chainExpression, context));
-            int targetCteId = _tableExpressionCounter;
-            AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchSource(chainExpression, targetCteId));
-            int sourceCteId = _tableExpressionCounter;
-            AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchSourceDateFilter(sourceDateExpression, context, sourceCteId));
+            int targetCteId = AppendTargetFirstChainedSearchCte(
+                () => AppendTargetFirstChainedSearchTarget(match.TargetExpression, match.ChainExpression, context));
+            int sourceCteId = AppendTargetFirstChainedSearchCte(
+                () => AppendTargetFirstChainedSearchSource(match.ChainExpression, targetCteId));
+            int filteredSourceCteId = AppendTargetFirstChainedSearchCte(
+                () => AppendTargetFirstChainedSearchSourceDateFilter(match.SourceDateExpression, context, sourceCteId));
 
-            if (sortExpression != null)
+            if (match.SortExpression != null)
             {
-                int filteredSourceCteId = _tableExpressionCounter;
-                AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchSort(sortExpression, context, filteredSourceCteId));
+                AppendTargetFirstChainedSearchCte(
+                    () => AppendTargetFirstChainedSearchSort(match.SortExpression, context, filteredSourceCteId));
                 _sortVisited = true;
             }
 
-            return sortExpression == null ? 3 : 4;
+            return match.ConsumedTableExpressionCount;
         }
 
-        private bool TryMatchTargetFirstChainedSearch(
+        private TargetFirstChainedSearchMatch MatchTargetFirstChainedSearch(
             IReadOnlyList<SearchParamTableExpression> tableExpressions,
-            SearchOptions context,
-            out SqlChainLinkExpression chainExpression,
-            out SearchParamTableExpression targetExpression,
-            out SearchParamTableExpression sourceDateExpression,
-            out SearchParamTableExpression sortExpression)
+            SearchOptions context)
         {
-            chainExpression = null;
-            targetExpression = null;
-            sourceDateExpression = null;
-            sortExpression = null;
-
             const int chainExpressionIndex = 0;
             const int targetExpressionIndex = 1;
             const int sourceDateExpressionIndex = 2;
@@ -69,7 +56,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 tableExpressions.Count <= sourceDateExpressionIndex ||
                 tableExpressions.Any(x => x.HasUnionAllExpression()))
             {
-                return false;
+                return null;
             }
 
             SearchParamTableExpression chainCandidate = tableExpressions[chainExpressionIndex];
@@ -79,7 +66,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 chainCandidateExpression.Reversed ||
                 chainCandidateExpression.ExpressionOnTarget != null)
             {
-                return false;
+                return null;
             }
 
             SearchParamTableExpression targetCandidate = tableExpressions[targetExpressionIndex];
@@ -91,9 +78,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 sourceDateCandidate.ChainLevel != 0 ||
                 !ReferenceEquals(sourceDateCandidate.QueryGenerator, DateTimeQueryGenerator.Instance))
             {
-                return false;
+                return null;
             }
 
+            SearchParamTableExpression sortExpression = null;
+            int consumedTableExpressionCount = 3;
+
+            // Only consume a sort that immediately follows the optimized predicates. A later sort must
+            // remain in the generic pipeline so any intervening source predicates are applied first.
             if (tableExpressions.Count > sortExpressionIndex &&
                 tableExpressions[sortExpressionIndex].Kind is SearchParamTableExpressionKind.Sort or SearchParamTableExpressionKind.SortWithFilter)
             {
@@ -103,32 +95,37 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     sortCandidate.QueryGenerator == null ||
                     string.IsNullOrEmpty(sortContext.SortColumnName))
                 {
-                    return false;
+                    return null;
                 }
 
                 sortExpression = sortCandidate;
+                consumedTableExpressionCount++;
             }
 
-            chainExpression = chainCandidateExpression;
-            targetExpression = targetCandidate;
-            sourceDateExpression = sourceDateCandidate;
-            return true;
+            return new TargetFirstChainedSearchMatch(
+                chainCandidateExpression,
+                targetCandidate,
+                sourceDateCandidate,
+                sortExpression,
+                consumedTableExpressionCount);
         }
 
-        private void AppendTargetFirstChainedSearchCte(Action appendBody)
+        private int AppendTargetFirstChainedSearchCte(Action appendBody)
         {
             if (_tableExpressionCounter >= 0)
             {
                 StringBuilder.AppendLine().Append(",");
             }
 
-            StringBuilder.Append(TableExpressionName(++_tableExpressionCounter)).AppendLine(" AS").AppendLine("(");
+            int cteId = ++_tableExpressionCounter;
+            StringBuilder.Append(TableExpressionName(cteId)).AppendLine(" AS").AppendLine("(");
             using (StringBuilder.Indent())
             {
                 appendBody();
             }
 
             StringBuilder.Append(")");
+            return cteId;
         }
 
         private void AppendTargetFirstChainedSearchTarget(
@@ -243,6 +240,33 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
 
             AppendSortContinuationPredicate(delimited, sortContext);
+        }
+
+        private sealed class TargetFirstChainedSearchMatch
+        {
+            public TargetFirstChainedSearchMatch(
+                SqlChainLinkExpression chainExpression,
+                SearchParamTableExpression targetExpression,
+                SearchParamTableExpression sourceDateExpression,
+                SearchParamTableExpression sortExpression,
+                int consumedTableExpressionCount)
+            {
+                ChainExpression = chainExpression;
+                TargetExpression = targetExpression;
+                SourceDateExpression = sourceDateExpression;
+                SortExpression = sortExpression;
+                ConsumedTableExpressionCount = consumedTableExpressionCount;
+            }
+
+            public SqlChainLinkExpression ChainExpression { get; }
+
+            public SearchParamTableExpression TargetExpression { get; }
+
+            public SearchParamTableExpression SourceDateExpression { get; }
+
+            public SearchParamTableExpression SortExpression { get; }
+
+            public int ConsumedTableExpressionCount { get; }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.TargetFirstChainedSearch.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
@@ -15,82 +17,75 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
     /// </summary>
     internal partial class SqlQueryGenerator
     {
-        private TargetFirstChainedSearchState _targetFirstChainedSearchState;
-
-        private bool TryHandleTargetFirstChainedSearchChainExpression(
-            SearchParamTableExpression tableExpression,
-            SqlChainLinkExpression chainExpression,
+        private int TryAppendTargetFirstChainedSearchCtes(
+            IReadOnlyList<SearchParamTableExpression> tableExpressions,
             SearchOptions context)
         {
-            if (!TryMatchTargetFirstChainedSearch(tableExpression, chainExpression, out SearchParamTableExpression targetExpression, out SearchParamTableExpression sourceDateExpression))
+            if (!TryMatchTargetFirstChainedSearch(
+                    tableExpressions,
+                    context,
+                    out SqlChainLinkExpression chainExpression,
+                    out SearchParamTableExpression targetExpression,
+                    out SearchParamTableExpression sourceDateExpression,
+                    out SearchParamTableExpression sortExpression))
             {
-                return false;
+                return 0;
             }
 
-            _targetFirstChainedSearchState = new TargetFirstChainedSearchState(chainExpression, targetExpression, sourceDateExpression);
-            AppendTargetFirstChainedSearchTarget(targetExpression, chainExpression, context);
-            return true;
-        }
+            AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchTarget(targetExpression, chainExpression, context));
+            int targetCteId = _tableExpressionCounter;
+            AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchSource(chainExpression, targetCteId));
+            int sourceCteId = _tableExpressionCounter;
+            AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchSourceDateFilter(sourceDateExpression, context, sourceCteId));
 
-        private bool TryHandleTargetFirstChainedSearchNormalExpression(SearchParamTableExpression tableExpression, SearchOptions context)
-        {
-            TargetFirstChainedSearchState state = _targetFirstChainedSearchState;
-            if (state == null)
+            if (sortExpression != null)
             {
-                return false;
+                int filteredSourceCteId = _tableExpressionCounter;
+                AppendTargetFirstChainedSearchCte(() => AppendTargetFirstChainedSearchSort(sortExpression, context, filteredSourceCteId));
+                _sortVisited = true;
             }
 
-            if (ReferenceEquals(tableExpression, state.TargetExpression))
-            {
-                AppendTargetFirstChainedSearchSource(state.ChainExpression);
-                state.SourceCteId = _tableExpressionCounter;
-                return true;
-            }
-
-            if (ReferenceEquals(tableExpression, state.SourceDateExpression) &&
-                state.SourceCteId == _tableExpressionCounter - 1)
-            {
-                AppendTargetFirstChainedSearchSourceDateFilter(tableExpression, context, state.SourceCteId);
-                _targetFirstChainedSearchState = null;
-                return true;
-            }
-
-            _targetFirstChainedSearchState = null;
-            return false;
+            return sortExpression == null ? 3 : 4;
         }
 
         private bool TryMatchTargetFirstChainedSearch(
-            SearchParamTableExpression tableExpression,
-            SqlChainLinkExpression chainExpression,
+            IReadOnlyList<SearchParamTableExpression> tableExpressions,
+            SearchOptions context,
+            out SqlChainLinkExpression chainExpression,
             out SearchParamTableExpression targetExpression,
-            out SearchParamTableExpression sourceDateExpression)
+            out SearchParamTableExpression sourceDateExpression,
+            out SearchParamTableExpression sortExpression)
         {
+            chainExpression = null;
             targetExpression = null;
             sourceDateExpression = null;
+            sortExpression = null;
 
-            if (_tableExpressionCounter != 0 ||
-                tableExpression.ChainLevel != 1 ||
-                chainExpression.Reversed ||
-                chainExpression.ExpressionOnTarget != null ||
-                _rootExpression.SearchParamTableExpressions.Any(x =>
-                    x.HasUnionAllExpression() ||
-                    x.Kind == SearchParamTableExpressionKind.Sort ||
-                    x.Kind == SearchParamTableExpressionKind.SortWithFilter))
-            {
-                return false;
-            }
-
+            const int chainExpressionIndex = 0;
             const int targetExpressionIndex = 1;
             const int sourceDateExpressionIndex = 2;
-            if (_rootExpression.SearchParamTableExpressions.Count <= sourceDateExpressionIndex)
+            const int sortExpressionIndex = 3;
+            if (_tableExpressionCounter != -1 ||
+                tableExpressions.Count <= sourceDateExpressionIndex ||
+                tableExpressions.Any(x => x.HasUnionAllExpression()))
             {
                 return false;
             }
 
-            SearchParamTableExpression targetCandidate = _rootExpression.SearchParamTableExpressions[targetExpressionIndex];
-            SearchParamTableExpression sourceDateCandidate = _rootExpression.SearchParamTableExpressions[sourceDateExpressionIndex];
+            SearchParamTableExpression chainCandidate = tableExpressions[chainExpressionIndex];
+            if (chainCandidate.Kind != SearchParamTableExpressionKind.Chain ||
+                chainCandidate.ChainLevel != 1 ||
+                chainCandidate.Predicate is not SqlChainLinkExpression chainCandidateExpression ||
+                chainCandidateExpression.Reversed ||
+                chainCandidateExpression.ExpressionOnTarget != null)
+            {
+                return false;
+            }
+
+            SearchParamTableExpression targetCandidate = tableExpressions[targetExpressionIndex];
+            SearchParamTableExpression sourceDateCandidate = tableExpressions[sourceDateExpressionIndex];
             if (targetCandidate.Kind != SearchParamTableExpressionKind.Normal ||
-                targetCandidate.ChainLevel != tableExpression.ChainLevel ||
+                targetCandidate.ChainLevel != chainCandidate.ChainLevel ||
                 !ReferenceEquals(targetCandidate.QueryGenerator, ReferenceQueryGenerator.Instance) ||
                 sourceDateCandidate.Kind != SearchParamTableExpressionKind.Normal ||
                 sourceDateCandidate.ChainLevel != 0 ||
@@ -99,9 +94,41 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 return false;
             }
 
+            if (tableExpressions.Count > sortExpressionIndex &&
+                tableExpressions[sortExpressionIndex].Kind is SearchParamTableExpressionKind.Sort or SearchParamTableExpressionKind.SortWithFilter)
+            {
+                SearchParamTableExpression sortCandidate = tableExpressions[sortExpressionIndex];
+                SortContext sortContext = GetSortRelatedDetails(context);
+                if (sortCandidate.ChainLevel != 0 ||
+                    sortCandidate.QueryGenerator == null ||
+                    string.IsNullOrEmpty(sortContext.SortColumnName))
+                {
+                    return false;
+                }
+
+                sortExpression = sortCandidate;
+            }
+
+            chainExpression = chainCandidateExpression;
             targetExpression = targetCandidate;
             sourceDateExpression = sourceDateCandidate;
             return true;
+        }
+
+        private void AppendTargetFirstChainedSearchCte(Action appendBody)
+        {
+            if (_tableExpressionCounter >= 0)
+            {
+                StringBuilder.AppendLine().Append(",");
+            }
+
+            StringBuilder.Append(TableExpressionName(++_tableExpressionCounter)).AppendLine(" AS").AppendLine("(");
+            using (StringBuilder.Indent())
+            {
+                appendBody();
+            }
+
+            StringBuilder.Append(")");
         }
 
         private void AppendTargetFirstChainedSearchTarget(
@@ -135,14 +162,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             targetExpression.Predicate.AcceptVisitor(targetExpression.QueryGenerator, GetContext(chainTargetTableAlias));
         }
 
-        private void AppendTargetFirstChainedSearchSource(SqlChainLinkExpression chainExpression)
+        private void AppendTargetFirstChainedSearchSource(SqlChainLinkExpression chainExpression, int targetCteId)
         {
             const string referenceSourceTableAlias = "refSource";
 
             StringBuilder.Append("SELECT ")
                 .Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceSourceTableAlias).Append(" AS T1, ")
                 .Append(VLatest.ReferenceSearchParam.ResourceSurrogateId, referenceSourceTableAlias).AppendLine(" AS Sid1, T2, Sid2")
-                .Append("FROM ").AppendLine(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex()))
+                .Append("FROM ").AppendLine(TableExpressionName(targetCteId))
                 .Append(_joinShift).Append("INNER LOOP JOIN ").Append(VLatest.ReferenceSearchParam).Append(' ').Append(referenceSourceTableAlias)
                 .Append(" ON ").Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias).Append(" = T2")
                 .Append(" AND ").Append(VLatest.ReferenceSearchParam.ReferenceResourceId, referenceSourceTableAlias).AppendLine(" = Id2");
@@ -189,25 +216,33 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             dateExpression.Predicate.AcceptVisitor(dateExpression.QueryGenerator, GetContext());
         }
 
-        private sealed class TargetFirstChainedSearchState
+        private void AppendTargetFirstChainedSearchSort(
+            SearchParamTableExpression sortExpression,
+            SearchOptions context,
+            int filteredSourceCteId)
         {
-            public TargetFirstChainedSearchState(
-                SqlChainLinkExpression chainExpression,
-                SearchParamTableExpression targetExpression,
-                SearchParamTableExpression sourceDateExpression)
+            SortContext sortContext = GetSortRelatedDetails(context);
+            string filteredSourceCte = TableExpressionName(filteredSourceCteId);
+            StringBuilder.Append("SELECT ")
+                .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T1, ")
+                .Append(VLatest.Resource.ResourceSurrogateId, null).Append(" AS Sid1, ")
+                .Append(sortContext.SortColumnName, null).AppendLine(" AS SortValue")
+                .Append("FROM ").AppendLine(sortExpression.QueryGenerator.Table)
+                .Append(_joinShift).Append("JOIN ").Append(filteredSourceCte)
+                .Append(" ON ").Append(VLatest.Resource.ResourceTypeId, null).Append(" = ").Append(filteredSourceCte).Append(".T1")
+                .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" = ").Append(filteredSourceCte).AppendLine(".Sid1");
+
+            using var delimited = StringBuilder.BeginDelimitedWhereClause();
+            AppendHistoryClause(delimited, context.ResourceVersionTypes, sortExpression);
+            AppendMinOrMax(delimited, context);
+
+            if (sortExpression.Predicate != null)
             {
-                ChainExpression = chainExpression;
-                TargetExpression = targetExpression;
-                SourceDateExpression = sourceDateExpression;
+                delimited.BeginDelimitedElement();
+                sortExpression.Predicate.AcceptVisitor(sortExpression.QueryGenerator, GetContext());
             }
 
-            public SqlChainLinkExpression ChainExpression { get; }
-
-            public SearchParamTableExpression TargetExpression { get; }
-
-            public SearchParamTableExpression SourceDateExpression { get; }
-
-            public int SourceCteId { get; set; } = -1;
+            AppendSortContinuationPredicate(delimited, sortContext);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -130,11 +130,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 var isSortValueNeeded = IsSortValueNeeded(context);
                 if (isSortValueNeeded)
                 {
-                    var sortContext = GetSortRelatedDetails(context);
+                    var sortContext = GetGenericSortRelatedDetails(context);
                     var dbType = sortContext.SortColumnName.Metadata.SqlDbType;
                     var typeStr = dbType.ToString().ToLowerInvariant();
                     StringBuilder.Append($", SortValue {typeStr}");
-                    if (dbType != System.Data.SqlDbType.DateTime2 && dbType != System.Data.SqlDbType.DateTime) // we support only date time and short string
+                    if (dbType == System.Data.SqlDbType.Decimal)
+                    {
+                        StringBuilder.Append("(36, 18)");
+                    }
+                    else if (dbType != System.Data.SqlDbType.DateTime2 && dbType != System.Data.SqlDbType.DateTime)
                     {
                         StringBuilder.Append($"({sortContext.SortColumnName.Metadata.MaxLength})");
                     }
@@ -1332,7 +1336,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 throw new InvalidOperationException("Multiple chain level is not possible.");
             }
 
-            SortContext sortContext = GetSortRelatedDetails(context);
+            SortContext sortContext = GetGenericSortRelatedDetails(context);
 
             if (!string.IsNullOrEmpty(sortContext.SortColumnName) && searchParamTableExpression.QueryGenerator != null)
             {
@@ -1372,7 +1376,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void HandleTableKindSortWithFilter(SearchParamTableExpression searchParamTableExpression, SearchOptions context)
         {
-            SortContext sortContext = GetSortRelatedDetails(context);
+            SortContext sortContext = GetGenericSortRelatedDetails(context);
 
             if (!string.IsNullOrEmpty(sortContext.SortColumnName) && searchParamTableExpression.QueryGenerator != null)
             {
@@ -1767,7 +1771,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void AppendMinOrMax(in IndentedStringBuilder.DelimitedScope delimited, SearchOptions context)
         {
-            if (_schemaInfo.Current < SchemaVersionConstants.AddMinMaxForDateAndStringSearchParamVersion)
+            if (_schemaInfo.Current < SchemaVersionConstants.AddMinMaxForDateAndStringSearchParamVersion ||
+                context.Sort[0].searchParameterInfo.Type is not (ValueSets.SearchParamType.Date or ValueSets.SearchParamType.String))
             {
                 return;
             }
@@ -1899,6 +1904,25 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     }
 
                     break;
+            }
+
+            return sortContext;
+        }
+
+        private static SortContext GetGenericSortRelatedDetails(SearchOptions context)
+        {
+            SortContext sortContext = GetSortRelatedDetails(context);
+            if (!ReferenceEquals(sortContext.SortColumnName, null) ||
+                context.Sort?[0].searchParameterInfo.Type != ValueSets.SearchParamType.Number)
+            {
+                return sortContext;
+            }
+
+            sortContext.SortColumnName = VLatest.NumberSearchParam.SingleValue;
+            if (sortContext.ContinuationToken != null &&
+                decimal.TryParse(sortContext.ContinuationToken.SortValue, out decimal numberSortValue))
+            {
+                sortContext.SortValue = numberSortValue;
             }
 
             return sortContext;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -130,15 +130,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 var isSortValueNeeded = IsSortValueNeeded(context);
                 if (isSortValueNeeded)
                 {
-                    var sortContext = GetGenericSortRelatedDetails(context);
+                    var sortContext = GetSortRelatedDetails(context);
                     var dbType = sortContext.SortColumnName.Metadata.SqlDbType;
                     var typeStr = dbType.ToString().ToLowerInvariant();
                     StringBuilder.Append($", SortValue {typeStr}");
-                    if (dbType == System.Data.SqlDbType.Decimal)
-                    {
-                        StringBuilder.Append("(36, 18)");
-                    }
-                    else if (dbType != System.Data.SqlDbType.DateTime2 && dbType != System.Data.SqlDbType.DateTime)
+                    if (dbType != System.Data.SqlDbType.DateTime2 && dbType != System.Data.SqlDbType.DateTime) // we support only date time and short string
                     {
                         StringBuilder.Append($"({sortContext.SortColumnName.Metadata.MaxLength})");
                     }
@@ -1336,7 +1332,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 throw new InvalidOperationException("Multiple chain level is not possible.");
             }
 
-            SortContext sortContext = GetGenericSortRelatedDetails(context);
+            SortContext sortContext = GetSortRelatedDetails(context);
 
             if (!string.IsNullOrEmpty(sortContext.SortColumnName) && searchParamTableExpression.QueryGenerator != null)
             {
@@ -1376,7 +1372,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void HandleTableKindSortWithFilter(SearchParamTableExpression searchParamTableExpression, SearchOptions context)
         {
-            SortContext sortContext = GetGenericSortRelatedDetails(context);
+            SortContext sortContext = GetSortRelatedDetails(context);
 
             if (!string.IsNullOrEmpty(sortContext.SortColumnName) && searchParamTableExpression.QueryGenerator != null)
             {
@@ -1771,8 +1767,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void AppendMinOrMax(in IndentedStringBuilder.DelimitedScope delimited, SearchOptions context)
         {
-            if (_schemaInfo.Current < SchemaVersionConstants.AddMinMaxForDateAndStringSearchParamVersion ||
-                context.Sort[0].searchParameterInfo.Type is not (ValueSets.SearchParamType.Date or ValueSets.SearchParamType.String))
+            if (_schemaInfo.Current < SchemaVersionConstants.AddMinMaxForDateAndStringSearchParamVersion)
             {
                 return;
             }
@@ -1904,25 +1899,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     }
 
                     break;
-            }
-
-            return sortContext;
-        }
-
-        private static SortContext GetGenericSortRelatedDetails(SearchOptions context)
-        {
-            SortContext sortContext = GetSortRelatedDetails(context);
-            if (!ReferenceEquals(sortContext.SortColumnName, null) ||
-                context.Sort?[0].searchParameterInfo.Type != ValueSets.SearchParamType.Number)
-            {
-                return sortContext;
-            }
-
-            sortContext.SortColumnName = VLatest.NumberSearchParam.SingleValue;
-            if (sortContext.ContinuationToken != null &&
-                decimal.TryParse(sortContext.ContinuationToken.SortValue, out decimal numberSortValue))
-            {
-                sortContext.SortValue = numberSortValue;
             }
 
             return sortContext;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -150,7 +150,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 UnionExpression smartV2UnionExpression = null;
                 SearchParamTableExpressionQueryGenerator smartV2QueryGenerator = null;
                 StringBuilder.AppendLine(";WITH");
-                StringBuilder.AppendDelimited($"{Environment.NewLine},", expression.SearchParamTableExpressions.SortExpressionsByQueryLogic(), (sb, tableExpression) =>
+                IReadOnlyList<SearchParamTableExpression> orderedTableExpressions = expression.SearchParamTableExpressions.SortExpressionsByQueryLogic();
+                int consumedTableExpressionCount = TryAppendTargetFirstChainedSearchCtes(orderedTableExpressions, context);
+                List<SearchParamTableExpression> remainingTableExpressions = orderedTableExpressions.Skip(consumedTableExpressionCount).ToList();
+                if (consumedTableExpressionCount > 0 && remainingTableExpressions.Count > 0)
+                {
+                    StringBuilder.AppendLine().Append(",");
+                }
+
+                StringBuilder.AppendDelimited($"{Environment.NewLine},", remainingTableExpressions, (sb, tableExpression) =>
                 {
                     if (tableExpression.SplitExpressions(out UnionExpression unionExpression, out SearchParamTableExpression allOtherRemainingExpressions))
                     {
@@ -639,11 +647,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void HandleTableKindNormal(SearchParamTableExpression searchParamTableExpression, SearchOptions context)
         {
-            if (TryHandleTargetFirstChainedSearchNormalExpression(searchParamTableExpression, context))
-            {
-                return;
-            }
-
             var specialCaseTableName = searchParamTableExpression.QueryGenerator.Table;
 
             if (searchParamTableExpression.ChainLevel == 0)
@@ -879,11 +882,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             string referenceTargetResourceTableAlias)
         {
             var chainedExpression = (SqlChainLinkExpression)searchParamTableExpression.Predicate;
-            if (TryHandleTargetFirstChainedSearchChainExpression(searchParamTableExpression, chainedExpression, context))
-            {
-                return;
-            }
-
             StringBuilder.Append("SELECT ");
             if (searchParamTableExpression.ChainLevel == 1)
             {
@@ -1360,16 +1358,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         searchParamTableExpression.Predicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
                     }
 
-                    // if continuation token exists, add it to the query
-                    if (sortContext.ContinuationToken != null)
-                    {
-                        var sortOperand = sortContext.SortOrder == SortOrder.Ascending ? ">" : "<";
-
-                        delimited.BeginDelimitedElement();
-                        StringBuilder.Append("((").Append(sortContext.SortColumnName, null).Append(" = ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false));
-                        StringBuilder.Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" > ").Append(Parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, sortContext.ContinuationToken.ResourceSurrogateId, includeInHash: false)).Append(")");
-                        StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
-                    }
+                    AppendSortContinuationPredicate(delimited, sortContext);
 
                     if (!UseAppendWithJoin())
                     {
@@ -1409,16 +1398,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         searchParamTableExpression.Predicate.AcceptVisitor(searchParamTableExpression.QueryGenerator, GetContext());
                     }
 
-                    // if continuation token exists, add it to the query
-                    if (sortContext.ContinuationToken != null)
-                    {
-                        var sortOperand = sortContext.SortOrder == SortOrder.Ascending ? ">" : "<";
-
-                        delimited.BeginDelimitedElement();
-                        StringBuilder.Append("((").Append(sortContext.SortColumnName, null).Append(" = ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false));
-                        StringBuilder.Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" > ").Append(Parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, sortContext.ContinuationToken.ResourceSurrogateId, includeInHash: false)).Append(")");
-                        StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
-                    }
+                    AppendSortContinuationPredicate(delimited, sortContext);
 
                     if (!UseAppendWithJoin())
                     {
@@ -1428,6 +1408,22 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
 
             _sortVisited = true;
+        }
+
+        private void AppendSortContinuationPredicate(
+            in IndentedStringBuilder.DelimitedScope delimited,
+            SortContext sortContext)
+        {
+            if (sortContext.ContinuationToken == null)
+            {
+                return;
+            }
+
+            string sortOperand = sortContext.SortOrder == SortOrder.Ascending ? ">" : "<";
+            delimited.BeginDelimitedElement();
+            StringBuilder.Append("((").Append(sortContext.SortColumnName, null).Append(" = ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false))
+                .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" > ").Append(Parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, sortContext.ContinuationToken.ResourceSurrogateId, includeInHash: false)).Append(")")
+                .Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
         }
 
         private SearchParameterQueryGeneratorContext GetContext(string tableAlias = null)


### PR DESCRIPTION
## Comparison goal

This draft compares a cleaner atomic target-first chained-search rewrite against PR #5725's narrowly gated implementation.

## Changes

- recognizes and emits the complete target-first CTE group at the root query-generator level
- owns selective target reference, source backlink, source date predicate, and an immediately following sort projection as one atomic rewrite
- preserves ascending/descending plain `Sort` and `SortWithFilter` behavior, Min/Max selection for multi-valued rows, deduplication, and continuation-token tie breaks
- preserves missing-value two-phase sort selection, Top, count-only, include/revinclude, and trailing-filter propagation
- uses an explicit match result with consumed-expression count and returned CTE IDs instead of out parameters, magic return counts, and counter-derived IDs
- extracts repeated status-filter test setup

## Intentional limitation

A sort separated from the target-first predicates by another source filter is deliberately not consumed atomically. The optimized three-CTE filter feeds the existing generic filter/sort pipeline so the intervening predicate is applied before sort projection; this avoids partial semantic changes while retaining the target-first optimization.

## Validation

- baseline SQL Server unit test project build passed before changes
- updated SQL Server unit test project build passed with 0 warnings and 0 errors
- focused `SqlQueryGeneratorTests` passed: 35/35
- isolated `CompartmentQueryGeneratorTests` passed: 26/26 after an unrelated transient full-suite failure
- full `Microsoft.Health.Fhir.SqlServer.UnitTests` suite passed: 1,072/1,072
- rubber-duck review found no correctness or simplicity issues
