### PR TITLE
Fixing an incorrect 500 error response.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -6,11 +6,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EnsureThat;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
 using Microsoft.AspNetCore.Http;
@@ -19,7 +21,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Configs;
-using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
@@ -240,9 +242,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                     }
                     catch (Exception ex) when (ex is UriFormatException || ex is FormatException || ex is ArgumentException)
                     {
-                        throw new BadHttpRequestException(string.Format(
-                            Api.Resources.SmartScopeInvalidSearchParameters,
-                            scopeClaims));
+                        var error = string.Format(Api.Resources.SmartScopeInvalidSearchParameters, scopeClaims);
+                        _logger.LogWarning(ex, error);
+                        await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                        return;
                     }
 
                     MatchCollection matches;
@@ -250,11 +253,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                     {
                         matches = ClinicalScopeRegEx.Matches(scopeClaims);
                     }
-                    catch (RegexMatchTimeoutException)
+                    catch (RegexMatchTimeoutException ex)
                     {
-                        throw new BadHttpRequestException(string.Format(
-                            Api.Resources.SmartScopeInvalidSearchParameters,
-                            scopeClaims));
+                        var error = string.Format(Api.Resources.SmartScopeInvalidSearchParameters, scopeClaims);
+                        _logger.LogWarning(ex, error);
+                        await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                        return;
                     }
 
                     string clinicalScopeContext = null;
@@ -269,16 +273,19 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                         int matchEnd = match.Index + match.Length;
                         if (matchEnd < scopeClaims.Length && !char.IsWhiteSpace(scopeClaims[matchEnd]))
                         {
-                            throw new BadHttpRequestException(string.Format(
-                                Api.Resources.SmartScopeInvalidSearchParameters,
-                                scopeClaims));
+                            var error = string.Format(Api.Resources.SmartScopeInvalidSearchParameters, scopeClaims);
+                            _logger.LogWarning(error);
+                            await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                            return;
                         }
 
                         string currentClinicalScopeContext = match.Groups["id"].Value;
                         if (clinicalScopeContext != null
                             && !clinicalScopeContext.Equals(currentClinicalScopeContext, StringComparison.OrdinalIgnoreCase))
                         {
-                            throw new BadHttpRequestException(Api.Resources.MixedSMARTScopeContextsAreNotAllowed);
+                            _logger.LogWarning(Api.Resources.MixedSMARTScopeContextsAreNotAllowed);
+                            await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, Api.Resources.MixedSMARTScopeContextsAreNotAllowed);
+                            return;
                         }
 
                         clinicalScopeContext = currentClinicalScopeContext;
@@ -315,16 +322,19 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                             // malformed access level is not silently accepted.
                             if (accessLevel.Distinct().Count() != accessLevel.Length)
                             {
-                                throw new BadHttpRequestException(string.Format(
-                                    Api.Resources.SmartScopeInvalidSearchParameters,
-                                    match.Value.Trim()));
+                                var error = string.Format(Api.Resources.SmartScopeInvalidSearchParameters, match.Value?.Trim());
+                                _logger.LogWarning(error);
+                                await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                                return;
                             }
                         }
 
-                        // If both types are detected, throw an error.
+                        // If both types are detected, write an error and return.
                         if (smartV1AccessLevelUsed && smartV2AccessLevelUsed)
                         {
-                            throw new BadHttpRequestException(string.Format(Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed));
+                            _logger.LogWarning(Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed);
+                            await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, Api.Resources.MixedSMARTV1AndV2ScopesAreNotAllowed);
+                            return;
                         }
 
                         fhirRequestContext.AccessControlContext.ClinicalScopes.Add(match.Value);
@@ -350,10 +360,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                             if (!resource.Equals(KnownResourceTypes.All, StringComparison.Ordinal)
                                 && !ModelInfoProvider.IsKnownResource(resource, ignoreCase: false))
                             {
-                                throw new BadHttpRequestException(string.Format(
-                                    Api.Resources.SmartScopeUnknownResourceType,
-                                    match.Value.Trim(),
-                                    resource));
+                                var error = string.Format(Api.Resources.SmartScopeUnknownResourceType, match.Value.Trim(), resource);
+                                _logger.LogWarning(error);
+                                await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                                return;
                             }
 
                             // If Finer-grained resource constraints using search parameters present
@@ -382,20 +392,20 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                                     // (e.g., "_has:Observation:patient:code").
                                     if (IsChainedSearchParameter(paramKey))
                                     {
-                                        throw new BadHttpRequestException(string.Format(
-                                            Api.Resources.SmartScopeSearchParameterChainedSearchNotSupported,
-                                            match.Value.Trim(),
-                                            $"{paramKey}={paramValue}"));
+                                        var error = string.Format(Api.Resources.SmartScopeSearchParameterChainedSearchNotSupported, match.Value?.Trim(), $"{paramKey}={paramValue}");
+                                        _logger.LogWarning(error);
+                                        await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                                        return;
                                     }
 
                                     // Detect FHIR search modifiers anywhere in the parameter key (e.g.
                                     // "name:exact", "category:not", "value-quantity:ofType").
                                     if (ContainsSearchModifier(paramKey))
                                     {
-                                        throw new BadHttpRequestException(string.Format(
-                                            Api.Resources.SmartScopeSearchParameterModifiersNotSupported,
-                                            match.Value.Trim(),
-                                            $"{paramKey}={paramValue}"));
+                                        var error = string.Format(Api.Resources.SmartScopeSearchParameterModifiersNotSupported, match.Value?.Trim(), $"{paramKey}={paramValue}");
+                                        _logger.LogWarning(error);
+                                        await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                                        return;
                                     }
 
                                     // Result parameters that pull in additional resources (_include/_revinclude)
@@ -403,19 +413,20 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                                     // resource types the scope does not grant, so reject them.
                                     if (IsIncludeParameter(paramKey))
                                     {
-                                        throw new BadHttpRequestException(string.Format(
-                                            Api.Resources.SmartScopeSearchParameterIncludesNotSupported,
-                                            match.Value.Trim(),
-                                            $"{paramKey}={paramValue}"));
+                                        var error = string.Format(Api.Resources.SmartScopeSearchParameterIncludesNotSupported, match.Value?.Trim(), $"{paramKey}={paramValue}");
+                                        _logger.LogWarning(error);
+                                        await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                                        return;
                                     }
 
                                     // Reject malformed key-value pairs (a missing '=' or a value that still
                                     // contains '=') instead of silently dropping the constraint (fail-open).
                                     if (parts.Length != 2 || paramValue.Contains('=', StringComparison.Ordinal))
                                     {
-                                        throw new BadHttpRequestException(string.Format(
-                                            Api.Resources.SmartScopeInvalidSearchParameters,
-                                            match.Value.Trim()));
+                                        var error = string.Format(Api.Resources.SmartScopeInvalidSearchParameters, match.Value?.Trim());
+                                        _logger.LogWarning(error);
+                                        await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                                        return;
                                     }
 
                                     smartScopeSearchParameters.Add(paramKey, paramValue);
@@ -456,14 +467,19 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                         {
                             if (authorizationConfiguration.ErrorOnMissingFhirUserClaim)
                             {
-                                throw new BadHttpRequestException(string.Format(Api.Resources.FhirUserClaimMustBeURL, fhirUser));
+                                var error = string.Format(Api.Resources.FhirUserClaimMustBeURL, fhirUser);
+                                _logger.LogError(error);
+                                await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, error);
+                                return;
                             }
                         }
                         catch (ArgumentNullException)
                         {
                             if (authorizationConfiguration.ErrorOnMissingFhirUserClaim)
                             {
-                                throw new BadHttpRequestException(Api.Resources.FhirUserClaimCannotBeNull);
+                                _logger.LogWarning(Api.Resources.FhirUserClaimCannotBeNull);
+                                await WriteErrorResponseAsync(fhirRequestContext, context, HttpStatusCode.BadRequest, Api.Resources.FhirUserClaimCannotBeNull);
+                                return;
                             }
                         }
                     }
@@ -472,6 +488,49 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
             // Call the next delegate/middleware in the pipeline
             await _next(context);
+        }
+
+        private Task WriteErrorResponseAsync(
+            IFhirRequestContext requestContext,
+            HttpContext httpContext,
+            HttpStatusCode statusCode,
+            string errorMessage,
+            OperationOutcome.IssueType issueType = OperationOutcome.IssueType.Invalid)
+        {
+            EnsureArg.IsNotNull(requestContext, nameof(requestContext));
+            EnsureArg.IsNotNull(httpContext, nameof(httpContext));
+            EnsureArg.IsNotNull(httpContext.Response, nameof(httpContext.Response));
+
+            try
+            {
+                var body = new
+                {
+                    resourceType = nameof(OperationOutcome),
+                    id = requestContext.CorrelationId,
+                    meta = new
+                    {
+                        lastUpdated = Clock.UtcNow.ToString("o"),
+                    },
+                    issue = new[]
+                    {
+                        new
+                        {
+                           severity = OperationOutcome.IssueSeverity.Error.GetLiteral(),
+                           code = issueType.GetLiteral(),
+                           diagnostics = errorMessage,
+                        },
+                    },
+                };
+
+                httpContext.Response.Clear();
+                httpContext.Response.StatusCode = (int)statusCode;
+                return httpContext.Response.WriteAsJsonAsync(body);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to write error response.");
+                throw;
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -490,7 +490,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
             await _next(context);
         }
 
-        private Task WriteErrorResponseAsync(
+        private async Task WriteErrorResponseAsync(
             IFhirRequestContext requestContext,
             HttpContext httpContext,
             HttpStatusCode statusCode,
@@ -524,7 +524,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
                 httpContext.Response.Clear();
                 httpContext.Response.StatusCode = (int)statusCode;
-                return httpContext.Response.WriteAsJsonAsync(body);
+                await httpContext.Response.WriteAsJsonAsync(body);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -6,10 +6,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -20,7 +24,6 @@ using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Smart;
 using Microsoft.Health.Fhir.Core.Configs;
-using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
@@ -177,11 +180,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
+            using var stream = new MemoryStream();
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                stream.SetLength(0);
+                httpContext.Response.Body = stream;
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-                var fhirRequestContext = new DefaultFhirRequestContext();
+                var fhirRequestContext = new DefaultFhirRequestContext()
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                };
 
                 fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -194,8 +204,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                ValidateErrorResponse(httpContext);
             }
         }
 
@@ -214,11 +224,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
+            using var stream = new MemoryStream();
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                stream.SetLength(0);
+                httpContext.Response.Body = stream;
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-                var fhirRequestContext = new DefaultFhirRequestContext();
+                var fhirRequestContext = new DefaultFhirRequestContext()
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                };
 
                 fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -231,11 +248,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                var exception = await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
-
-                Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
-                Assert.Equal(Api.Resources.MixedSMARTScopeContextsAreNotAllowed, exception.Message);
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                ValidateErrorResponse(
+                    httpContext,
+                    new[] { Api.Resources.MixedSMARTScopeContextsAreNotAllowed });
             }
         }
 
@@ -254,11 +270,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
+            using var stream = new MemoryStream();
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                stream.SetLength(0);
+                httpContext.Response.Body = stream;
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-                var fhirRequestContext = new DefaultFhirRequestContext();
+                var fhirRequestContext = new DefaultFhirRequestContext()
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                };
 
                 fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -271,11 +294,15 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                var exception = await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
-
-                Assert.Contains("modifiers are not supported", exception.Message);
-                Assert.Contains("unsupported modifier", exception.Message);
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                ValidateErrorResponse(
+                    httpContext,
+                    new[]
+                    {
+                        "modifiers are not supported",
+                        "unsupported modifier",
+                    },
+                    true);
             }
         }
 
@@ -294,11 +321,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
+            using var stream = new MemoryStream();
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                stream.SetLength(0);
+                httpContext.Response.Body = stream;
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-                var fhirRequestContext = new DefaultFhirRequestContext();
+                var fhirRequestContext = new DefaultFhirRequestContext()
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                };
 
                 fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -311,11 +345,15 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                var exception = await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
-
-                Assert.Contains("Chained search parameters are not supported", exception.Message);
-                Assert.Contains("chained search parameter", exception.Message);
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                ValidateErrorResponse(
+                    httpContext,
+                    new[]
+                    {
+                        "Chained search parameters are not supported",
+                        "chained search parameter",
+                    },
+                    true);
             }
         }
 
@@ -334,11 +372,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
+            using var stream = new MemoryStream();
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                stream.SetLength(0);
+                httpContext.Response.Body = stream;
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-                var fhirRequestContext = new DefaultFhirRequestContext();
+                var fhirRequestContext = new DefaultFhirRequestContext()
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                };
 
                 fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -351,10 +396,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                var exception = await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
-
-                Assert.Contains("_include and _revinclude are not supported", exception.Message);
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                ValidateErrorResponse(
+                    httpContext,
+                    new[]
+                    {
+                        "_include and _revinclude are not supported",
+                    },
+                    true);
             }
         }
 
@@ -373,11 +422,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
+            using var stream = new MemoryStream();
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                stream.SetLength(0);
+                httpContext.Response.Body = stream;
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-                var fhirRequestContext = new DefaultFhirRequestContext();
+                var fhirRequestContext = new DefaultFhirRequestContext()
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                };
 
                 fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -390,8 +446,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                ValidateErrorResponse(httpContext);
             }
         }
 
@@ -418,11 +474,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
+            using var stream = new MemoryStream();
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
+                stream.SetLength(0);
+                httpContext.Response.Body = stream;
+
                 var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-                var fhirRequestContext = new DefaultFhirRequestContext();
+                var fhirRequestContext = new DefaultFhirRequestContext()
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                };
 
                 fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -435,8 +498,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
                 _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-                await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                    _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+                ValidateErrorResponse(httpContext);
             }
         }
 
@@ -481,7 +544,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
-            var fhirRequestContext = new DefaultFhirRequestContext();
+            var fhirRequestContext = new DefaultFhirRequestContext()
+            {
+                CorrelationId = Guid.NewGuid().ToString(),
+            };
 
             fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
@@ -504,8 +570,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
             _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
 
-            await Assert.ThrowsAsync<BadHttpRequestException>(() =>
-                _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService));
+            using var stream = new MemoryStream();
+            httpContext.Response.Body = stream;
+
+            await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+            ValidateErrorResponse(httpContext);
         }
 
         [Fact]
@@ -847,7 +916,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 },
             };
 
-                        // Multiple scopes with search parameters
+            // Multiple scopes with search parameters
             yield return new object[]
             {
                 "patient/Patient.rs?name=john patient/Observation.s?code=44501&status=final",
@@ -858,7 +927,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 },
             };
 
-                        // Complex example with all SMART v2 granular permissions and search parameters
+            // Complex example with all SMART v2 granular permissions and search parameters
             yield return new object[]
             {
                 "user/Patient.cruds?name=Smith&birthdate=ge2000 user/Observation.rs?category=vital-signs",
@@ -1143,6 +1212,49 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var roleLoader = new RoleLoader(authConfig, hostEnvironment);
             await roleLoader.StartAsync(CancellationToken.None);
             return authConfig;
+        }
+
+        private static void ValidateErrorResponse(HttpContext context, string[] errorMessages = null, bool contain = false)
+        {
+            Assert.NotNull(context.Response);
+            Assert.Equal(HttpStatusCode.BadRequest, (HttpStatusCode)context.Response.StatusCode);
+
+            Assert.NotNull(context.Response.Body);
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            using var reader = new StreamReader(context.Response.Body, leaveOpen: true);
+            var body = reader.ReadToEnd();
+            var options = new JsonSerializerOptions().ForFhir(typeof(OperationOutcome).Assembly);
+            var resource = JsonSerializer.Deserialize<OperationOutcome>(body, options);
+
+            Assert.NotNull(resource);
+            Assert.Single(
+                resource.Issue,
+                x =>
+                {
+                    Assert.Equal(OperationOutcome.IssueSeverity.Error, x.Severity);
+                    Assert.Equal(OperationOutcome.IssueType.Invalid, x.Code);
+                    if (errorMessages == null || errorMessages.Length == 0)
+                    {
+                        Assert.NotNull(x.Diagnostics);
+                    }
+                    else
+                    {
+                        if (contain)
+                        {
+                            foreach (var errorMessage in errorMessages)
+                            {
+                                Assert.Contains(errorMessage, x.Diagnostics);
+                            }
+                        }
+                        else
+                        {
+                            Assert.Equal(errorMessages[0], x.Diagnostics);
+                        }
+                    }
+
+                    Assert.NotEmpty(x.Diagnostics);
+                    return true;
+                });
         }
     }
 }


### PR DESCRIPTION
## Description
The change will fix two issues.
- An incorrect 500 error response when a request contains a mix of smart v1 and v2 scopes.
- An unnecessary routing of a request to the custom error endpoint.

## Related issues
Addresses [issue #196788].
[Bug 196788](https://microsofthealth.visualstudio.com/Health/_workitems/edit/196788): FHIR incident 826328930: mixed SMART v1/v2 scopes return 500 instead of a handled auth error

## Testing
Tested by manual testing and running the smart UTs.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
