### PR TITLE
[CosmosDb] Add FHIR runtime state configuration

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/ConfigurationExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/ConfigurationExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Registration;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Operations)]
+    public sealed class ConfigurationExtensionsTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\t\r\n")]
+        public void GivenAnEmptyRuntimeStateConfiguration_WhenGettingRuntimeState_ThenActiveIsReturned(string configuredRuntimeState)
+        {
+            FhirRuntimeState actual = ConfigurationExtensions.GetRuntimeStateConfiguration(configuredRuntimeState);
+
+            Assert.Equal(FhirRuntimeState.Active, actual);
+        }
+
+        [Theory]
+        [InlineData("Active", FhirRuntimeState.Active)]
+        [InlineData(" active ", FhirRuntimeState.Active)]
+        [InlineData("DEPRECATED", FhirRuntimeState.Deprecated)]
+        [InlineData(" deprecated ", FhirRuntimeState.Deprecated)]
+        public void GivenAValidRuntimeStateConfiguration_WhenGettingRuntimeState_ThenConfiguredStateIsReturned(
+            string configuredRuntimeState,
+            FhirRuntimeState expected)
+        {
+            FhirRuntimeState actual = ConfigurationExtensions.GetRuntimeStateConfiguration(configuredRuntimeState);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("Unknown")]
+        [InlineData("1")]
+        [InlineData("2")]
+        public void GivenAnInvalidRuntimeStateConfiguration_WhenGettingRuntimeState_ThenActiveIsReturned(string configuredRuntimeState)
+        {
+            FhirRuntimeState actual = ConfigurationExtensions.GetRuntimeStateConfiguration(configuredRuntimeState);
+
+            Assert.Equal(FhirRuntimeState.Active, actual);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Registration/FhirRuntimeConfigurationTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Registration/FhirRuntimeConfigurationTests.cs
@@ -19,10 +19,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Registration
         public void GivenARuntimeConfiguration_WhenForAzureApiForFHIR_FollowsTheExpectedValues()
         {
             // Azure API For FHIR.
-            IFhirRuntimeConfiguration runtimeConfiguration = new AzureApiForFhirRuntimeConfiguration();
+            IFhirRuntimeConfiguration runtimeConfiguration = new AzureApiForFhirRuntimeConfiguration(FhirRuntimeState.Deprecated);
 
             // Support to Cosmos Db.
             Assert.Equal(KnownDataStores.CosmosDb, runtimeConfiguration.DataStore);
+
+            Assert.Equal(FhirRuntimeState.Deprecated, runtimeConfiguration.RuntimeState);
 
             // No support to Selective Search Parameter.
             Assert.False(runtimeConfiguration.IsSelectiveSearchParameterSupported);
@@ -42,6 +44,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Registration
 
             // Support to SQL Server.
             Assert.Equal(KnownDataStores.SqlServer, runtimeConfiguration.DataStore);
+
+            Assert.Equal(FhirRuntimeState.Active, runtimeConfiguration.RuntimeState);
 
             // Support to Selective Search Parameter.
             Assert.True(runtimeConfiguration.IsSelectiveSearchParameterSupported);

--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -180,5 +180,10 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Gets or sets a value indicating whether SMART system scope authorization is enforced for Bulk Export.
         /// </summary>
         public bool EnableSmartExportScopeAuthorization { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating the runtime state of the FHIR server.
+        /// </summary>
+        public string RuntimeState { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Registration;
+
+namespace Microsoft.Health.Fhir.Core.Extensions
+{
+    public static class ConfigurationExtensions
+    {
+        public static FhirRuntimeState GetRuntimeStateConfiguration(string configuredRuntimeState)
+        {
+            if (string.IsNullOrWhiteSpace(configuredRuntimeState))
+            {
+                return FhirRuntimeState.Active;
+            }
+
+            string normalizedRuntimeState = configuredRuntimeState.Trim();
+            if (Enum.TryParse(normalizedRuntimeState, ignoreCase: true, out FhirRuntimeState runtimeState) &&
+                Enum.IsDefined(runtimeState) &&
+                string.Equals(normalizedRuntimeState, runtimeState.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return runtimeState;
+            }
+
+            return FhirRuntimeState.Active;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Registration/AzureApiForFhirRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/AzureApiForFhirRuntimeConfiguration.cs
@@ -9,7 +9,14 @@ namespace Microsoft.Health.Fhir.Core.Registration
 {
     public class AzureApiForFhirRuntimeConfiguration : IFhirRuntimeConfiguration
     {
+        public AzureApiForFhirRuntimeConfiguration(FhirRuntimeState runtimeState = FhirRuntimeState.Active)
+        {
+            RuntimeState = runtimeState;
+        }
+
         public string DataStore => KnownDataStores.CosmosDb;
+
+        public FhirRuntimeState RuntimeState { get; }
 
         public bool IsSelectiveSearchParameterSupported => false;
 

--- a/src/Microsoft.Health.Fhir.Core/Registration/AzureHealthDataServicesRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/AzureHealthDataServicesRuntimeConfiguration.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Registration
     {
         public string DataStore => KnownDataStores.SqlServer;
 
+        public FhirRuntimeState RuntimeState => FhirRuntimeState.Active;
+
         public bool IsSelectiveSearchParameterSupported => true;
 
         public bool IsCustomerKeyValidationBackgroundWorkerSupported => true;

--- a/src/Microsoft.Health.Fhir.Core/Registration/FhirRuntimeState.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/FhirRuntimeState.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Registration
+{
+    /// <summary>
+    /// The effective runtime state of the FHIR service.
+    /// </summary>
+    public enum FhirRuntimeState
+    {
+        /// <summary>
+        /// The FHIR service is active.
+        /// </summary>
+        Active,
+
+        /// <summary>
+        /// The FHIR service is deprecated.
+        /// </summary>
+        Deprecated,
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Registration/IFhirRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/IFhirRuntimeConfiguration.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Health.Fhir.Core.Registration
         string DataStore { get; }
 
         /// <summary>
+        /// Gets the effective runtime state of the FHIR service.
+        /// </summary>
+        FhirRuntimeState RuntimeState { get; }
+
+        /// <summary>
         /// Selective Search Parameter.
         /// </summary>
         bool IsSelectiveSearchParameterSupported { get; }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         public async Task GivenASystemLevelExport_WhenRequestSentToMediator_CorrectIsParallelValueInRequest(bool isApiForFhir, bool expectedIsParallel, bool? inputIsParallelValue)
         {
             // Get export controller with specific runtime configuration (if needed).
-            IFhirRuntimeConfiguration fhirConfig = isApiForFhir ? Substitute.For<AzureApiForFhirRuntimeConfiguration>() : Substitute.For<IFhirRuntimeConfiguration>();
+            IFhirRuntimeConfiguration fhirConfig = isApiForFhir ? new AzureApiForFhirRuntimeConfiguration(runtimeState: FhirRuntimeState.Active) : new AzureHealthDataServicesRuntimeConfiguration();
             var exportController = GetController(_exportEnabledJobConfiguration, _featureConfiguration, _artifactStoreConfig, fhirConfig);
 
             // Setup additional dependencies needed for test execution.

--- a/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/StartupTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/StartupTests.cs
@@ -52,6 +52,10 @@ namespace Microsoft.Health.Fhir.Shared.Web.UnitTests
             string configuredRuntimeState,
             FhirRuntimeState expectedRuntimeState)
         {
+            // This test ensures that the default values are properly handled for Gen1 runtime state.
+            // Empty/null values should be treated as "Active" for Gen1 runtime state.
+            // Active/Deprecates values should be treated as-is for Gen1 runtime state.
+
             var settings = new Dictionary<string, string>
             {
                 { "DataStore", KnownDataStores.CosmosDb },
@@ -72,6 +76,8 @@ namespace Microsoft.Health.Fhir.Shared.Web.UnitTests
         [Fact]
         public void GivenDeprecatedGen2RuntimeState_WhenAddingRuntimeConfiguration_ThenEffectiveStateIsActive()
         {
+            // This test ensures that the 'Active' is always handled for Gen2 runtime state, no matter what the configured value is.
+
             var settings = new Dictionary<string, string>
             {
                 { "DataStore", KnownDataStores.SqlServer },
@@ -92,21 +98,25 @@ namespace Microsoft.Health.Fhir.Shared.Web.UnitTests
         [Theory]
         [InlineData("Invalid")]
         [InlineData("1")]
-        public void GivenInvalidGen1RuntimeState_WhenAddingRuntimeConfiguration_ThenInitializationFails(string configuredRuntimeState)
+        public void GivenInvalidGen1RuntimeState_WhenAddingRuntimeConfiguration_ThenInitializationContinuesAsActive(string configuredRuntimeState)
         {
+            // This test ensures that invalid values are properly handled for Gen1 runtime state as 'Active'.
+
             var settings = new Dictionary<string, string>
             {
                 { "DataStore", KnownDataStores.CosmosDb },
                 { RuntimeStateConfigurationKey, configuredRuntimeState },
             };
             IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+            var services = new ServiceCollection();
             var fhirServerBuilder = Substitute.For<IFhirServerBuilder>();
-            fhirServerBuilder.Services.Returns(new ServiceCollection());
+            fhirServerBuilder.Services.Returns(services);
 
-            TargetInvocationException exception = Assert.Throws<TargetInvocationException>(
-                () => InvokeAddRuntimeConfiguration(configuration, fhirServerBuilder));
+            InvokeAddRuntimeConfiguration(configuration, fhirServerBuilder);
 
-            Assert.IsType<InvalidOperationException>(exception.InnerException);
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IFhirRuntimeConfiguration runtimeConfiguration = serviceProvider.GetRequiredService<IFhirRuntimeConfiguration>();
+            Assert.Equal(FhirRuntimeState.Active, runtimeConfiguration.RuntimeState);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/StartupTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/StartupTests.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.ApplicationInsights;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Web;
 using Microsoft.Health.Test.Utilities;
@@ -38,6 +40,74 @@ namespace Microsoft.Health.Fhir.Shared.Web.UnitTests
         private const string TelemetryProviderOpenTelemetryConfigurationValue = "OpenTelemetry";
         private const string TelemetryProviderNoneConfigurationValue = "None";
         private const string AddTelemetryProviderMethodName = "AddTelemetryProvider";
+        private const string AddRuntimeConfigurationMethodName = "AddRuntimeConfiguration";
+        private const string RuntimeStateConfigurationKey = "FhirServer:CoreFeatures:RuntimeState";
+
+        [Theory]
+        [InlineData(null, FhirRuntimeState.Active)]
+        [InlineData("", FhirRuntimeState.Active)]
+        [InlineData("Active", FhirRuntimeState.Active)]
+        [InlineData("Deprecated", FhirRuntimeState.Deprecated)]
+        public void GivenGen1RuntimeState_WhenAddingRuntimeConfiguration_ThenEffectiveStateIsRegistered(
+            string configuredRuntimeState,
+            FhirRuntimeState expectedRuntimeState)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "DataStore", KnownDataStores.CosmosDb },
+                { RuntimeStateConfigurationKey, configuredRuntimeState },
+            };
+            IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+            var services = new ServiceCollection();
+            var fhirServerBuilder = Substitute.For<IFhirServerBuilder>();
+            fhirServerBuilder.Services.Returns(services);
+
+            InvokeAddRuntimeConfiguration(configuration, fhirServerBuilder);
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IFhirRuntimeConfiguration runtimeConfiguration = serviceProvider.GetRequiredService<IFhirRuntimeConfiguration>();
+            Assert.Equal(expectedRuntimeState, runtimeConfiguration.RuntimeState);
+        }
+
+        [Fact]
+        public void GivenDeprecatedGen2RuntimeState_WhenAddingRuntimeConfiguration_ThenEffectiveStateIsActive()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "DataStore", KnownDataStores.SqlServer },
+                { RuntimeStateConfigurationKey, FhirRuntimeState.Deprecated.ToString() },
+            };
+            IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+            var services = new ServiceCollection();
+            var fhirServerBuilder = Substitute.For<IFhirServerBuilder>();
+            fhirServerBuilder.Services.Returns(services);
+
+            InvokeAddRuntimeConfiguration(configuration, fhirServerBuilder);
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IFhirRuntimeConfiguration runtimeConfiguration = serviceProvider.GetRequiredService<IFhirRuntimeConfiguration>();
+            Assert.Equal(FhirRuntimeState.Active, runtimeConfiguration.RuntimeState);
+        }
+
+        [Theory]
+        [InlineData("Invalid")]
+        [InlineData("1")]
+        public void GivenInvalidGen1RuntimeState_WhenAddingRuntimeConfiguration_ThenInitializationFails(string configuredRuntimeState)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "DataStore", KnownDataStores.CosmosDb },
+                { RuntimeStateConfigurationKey, configuredRuntimeState },
+            };
+            IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+            var fhirServerBuilder = Substitute.For<IFhirServerBuilder>();
+            fhirServerBuilder.Services.Returns(new ServiceCollection());
+
+            TargetInvocationException exception = Assert.Throws<TargetInvocationException>(
+                () => InvokeAddRuntimeConfiguration(configuration, fhirServerBuilder));
+
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
 
         [Fact]
         public void GivenAppSettings_WhenTelemetrySectionIsAbsent_ThenTelemetryProviderShouldBeDisabled()
@@ -177,6 +247,17 @@ namespace Microsoft.Health.Fhir.Shared.Web.UnitTests
                 .AddInMemoryCollection(telemetrySettings)
                 .Build();
             return configuration;
+        }
+
+        private static void InvokeAddRuntimeConfiguration(
+            IConfiguration configuration,
+            IFhirServerBuilder fhirServerBuilder)
+        {
+            MethodInfo addRuntimeConfigurationMethod = typeof(Startup).GetMethod(
+                AddRuntimeConfigurationMethodName,
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            addRuntimeConfigurationMethod.Invoke(null, new object[] { configuration, fhirServerBuilder });
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -31,7 +31,6 @@ using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Telemetry;
 using Microsoft.Health.Fhir.Core.Logging.Metrics;
 using Microsoft.Health.Fhir.Core.Messages.Search;
-using Microsoft.Health.Fhir.Core.Messages.Storage;
 using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Shared.Web;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
@@ -48,7 +47,6 @@ namespace Microsoft.Health.Fhir.Web
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1515:Consider making public types internal", Justification = "Internal framework instantiation.")]
     public class Startup
     {
-        private const string RuntimeStateConfigurationKey = "FhirServer:CoreFeatures:RuntimeState";
         private static string instanceId;
 
         public Startup(IConfiguration configuration)
@@ -79,7 +77,6 @@ namespace Microsoft.Health.Fhir.Web
                 .AddAzureIntegrationDataStoreClient(Configuration)
                 .AddConvertData()
                 .AddMemberMatch();
-
             services.AddDevelopmentIdentityProvider(Configuration);
 
             // Set the runtime configuration for the up and running service.
@@ -145,22 +142,9 @@ namespace Microsoft.Health.Fhir.Web
 
         private static FhirRuntimeState GetRuntimeState(IConfiguration configuration)
         {
-            string configuredRuntimeState = configuration[RuntimeStateConfigurationKey];
-            if (string.IsNullOrWhiteSpace(configuredRuntimeState))
-            {
-                return FhirRuntimeState.Active;
-            }
+            string configuredRuntimeState = configuration["FhirServer:CoreFeatures:RuntimeState"];
 
-            string normalizedRuntimeState = configuredRuntimeState.Trim();
-            if (Enum.TryParse(normalizedRuntimeState, ignoreCase: true, out FhirRuntimeState runtimeState) &&
-                Enum.IsDefined(runtimeState) &&
-                string.Equals(normalizedRuntimeState, runtimeState.ToString(), StringComparison.OrdinalIgnoreCase))
-            {
-                return runtimeState;
-            }
-
-            throw new InvalidOperationException(
-                $"Invalid FHIR runtime state '{configuredRuntimeState}'. Supported values are '{FhirRuntimeState.Active}' and '{FhirRuntimeState.Deprecated}'.");
+            return Core.Extensions.ConfigurationExtensions.GetRuntimeStateConfiguration(configuredRuntimeState);
         }
 
         private void AddTaskHostingService(IServiceCollection services)

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Health.Fhir.Web
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1515:Consider making public types internal", Justification = "Internal framework instantiation.")]
     public class Startup
     {
+        private const string RuntimeStateConfigurationKey = "FhirServer:CoreFeatures:RuntimeState";
         private static string instanceId;
 
         public Startup(IConfiguration configuration)
@@ -119,14 +120,14 @@ namespace Microsoft.Health.Fhir.Web
             }
         }
 
-        private IFhirRuntimeConfiguration AddRuntimeConfiguration(IConfiguration configuration, IFhirServerBuilder fhirServerBuilder)
+        private static IFhirRuntimeConfiguration AddRuntimeConfiguration(IConfiguration configuration, IFhirServerBuilder fhirServerBuilder)
         {
             IFhirRuntimeConfiguration runtimeConfiguration = null;
 
-            string dataStore = Configuration["DataStore"];
+            string dataStore = configuration["DataStore"];
             if (KnownDataStores.IsCosmosDbDataStore(dataStore))
             {
-                runtimeConfiguration = new AzureApiForFhirRuntimeConfiguration();
+                runtimeConfiguration = new AzureApiForFhirRuntimeConfiguration(GetRuntimeState(configuration));
             }
             else if (KnownDataStores.IsSqlServerDataStore(dataStore))
             {
@@ -140,6 +141,26 @@ namespace Microsoft.Health.Fhir.Web
             fhirServerBuilder.Services.AddSingleton<IFhirRuntimeConfiguration>(runtimeConfiguration);
 
             return runtimeConfiguration;
+        }
+
+        private static FhirRuntimeState GetRuntimeState(IConfiguration configuration)
+        {
+            string configuredRuntimeState = configuration[RuntimeStateConfigurationKey];
+            if (string.IsNullOrWhiteSpace(configuredRuntimeState))
+            {
+                return FhirRuntimeState.Active;
+            }
+
+            string normalizedRuntimeState = configuredRuntimeState.Trim();
+            if (Enum.TryParse(normalizedRuntimeState, ignoreCase: true, out FhirRuntimeState runtimeState) &&
+                Enum.IsDefined(runtimeState) &&
+                string.Equals(normalizedRuntimeState, runtimeState.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return runtimeState;
+            }
+
+            throw new InvalidOperationException(
+                $"Invalid FHIR runtime state '{configuredRuntimeState}'. Supported values are '{FhirRuntimeState.Active}' and '{FhirRuntimeState.Deprecated}'.");
         }
 
         private void AddTaskHostingService(IServiceCollection services)
@@ -175,6 +196,10 @@ namespace Microsoft.Health.Fhir.Web
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public virtual void Configure(IApplicationBuilder app)
         {
+            IFhirRuntimeConfiguration runtimeConfiguration = app.ApplicationServices.GetRequiredService<IFhirRuntimeConfiguration>();
+            ILogger<Startup> logger = app.ApplicationServices.GetRequiredService<ILogger<Startup>>();
+            logger.LogInformation("The effective FHIR runtime state is {RuntimeState}.", runtimeConfiguration.RuntimeState);
+
             app.Use(async (context, next) =>
             {
                 if (instanceId != null)

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -22,6 +22,7 @@
             "SupportsAnonymizedExport": true
         },
         "CoreFeatures": {
+            "RuntimeState": "Active",
             "FhirSdkProvider": "Firely",
             "SupportsBatch": true,
             "SupportsTransaction": true,


### PR DESCRIPTION
Introduction of a runtime state configuration.
Currently, two values are going to be supported: active and deprecated. 

Future changes should leverage the use of both states. 

## Related issues
Addresses [AB#204631](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/204631).

## Testing
Tested using unit tests and manual validations. 

## FHIR Team Checklist
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
