### PR TITLE
Moved ACR E2E Tests to use Azure DevOps MI and Enable

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/AnonymizationConfigurationArtifactProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/AnonymizationConfigurationArtifactProviderTests.cs
@@ -7,19 +7,21 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Containers.ContainerRegistry;
+using Azure.Core;
+using Azure.Identity;
 using Azure.Storage.Blobs;
-using Microsoft.Azure.ContainerRegistry;
-using Microsoft.Azure.ContainerRegistry.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Azure.ContainerRegistry;
 using Microsoft.Health.Fhir.Azure.ExportDestinationClient;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient;
@@ -28,7 +30,6 @@ using Microsoft.Health.Fhir.TemplateManagement.Exceptions;
 using Microsoft.Health.Fhir.TemplateManagement.Utilities;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
-using Microsoft.Rest;
 using NSubstitute;
 using Xunit;
 
@@ -54,15 +55,15 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests
 
         public AnonymizationConfigurationArtifactProviderTests()
         {
-            var registry = GetTestContainerRegistryInfo();
-
-            // Use basic token here, which can work when there is no Managed Identity for container registry token.
-            AcrBasicToken acrTokenProvider = new AcrBasicToken(registry);
             var exportJobConfiguration = new ExportJobConfiguration();
             IOptions<ExportJobConfiguration> optionsExportConfig = Substitute.For<IOptions<ExportJobConfiguration>>();
             optionsExportConfig.Value.Returns(exportJobConfiguration);
             var logger = Substitute.For<ILogger<AzureConnectionStringClientInitializer>>();
             var azureAccessTokenClientInitializer = new AzureConnectionStringClientInitializer(optionsExportConfig, logger);
+
+            // Use federated managed identity (Azure Pipelines workload identity) to access ACR when configured;
+            // otherwise fall back to a mock for the argument-validation unit tests that never reach ACR.
+            IContainerRegistryTokenProvider acrTokenProvider = CreateAcrTokenProvider() ?? Substitute.For<IContainerRegistryTokenProvider>();
             _provider = new AnonymizationConfigurationArtifactProvider(azureAccessTokenClientInitializer, acrTokenProvider, optionsExportConfig, new NullLogger<AnonymizationConfigurationArtifactProvider>());
         }
 
@@ -251,12 +252,9 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests
         [SkippableFact]
         public async Task GivenAValidConfigName_WithValidAcrReference_WhenFetchAnonymizedConfig_TheConfigContentInAcrShouldBeRerturn()
         {
-            var registry = GetTestContainerRegistryInfo();
+            Skip.If(!IsAcrConfigured());
 
-            // Skip when there is no registry configuration
-            Skip.If(registry == null);
-
-            await PushConfigurationAsync(registry, TestRepositoryName, TestRepositoryTag, AnonymizationConfiguration);
+            await PushConfigurationAsync(TestRepositoryName, TestRepositoryTag, AnonymizationConfiguration);
             var jobRecord = new ExportJobRecord(
                 new Uri("https://localhost/$export"),
                 ExportJobType.All,
@@ -265,7 +263,7 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests
                 filters: null,
                 "hash",
                 rollingFileSizeInMB: 1,
-                anonymizationConfigurationCollectionReference: $"{registry.Server}/{TestRepositoryName}:{TestRepositoryTag}",
+                anonymizationConfigurationCollectionReference: $"{GetRegistryServer()}/{TestRepositoryName}:{TestRepositoryTag}",
                 anonymizationConfigurationLocation: TestConfigName);
             using (Stream stream = new MemoryStream())
             {
@@ -282,12 +280,9 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests
         [SkippableFact]
         public async Task GivenAValidAcrReference_WithInvalidConfigName_WhenFetchAnonymizedConfig_ExceptionShouldBeThrown()
         {
-            var registry = GetTestContainerRegistryInfo();
+            Skip.If(!IsAcrConfigured());
 
-            // Skip when there is no registry configuration
-            Skip.If(registry == null);
-
-            await PushConfigurationAsync(registry, TestRepositoryName, TestRepositoryTag, AnonymizationConfiguration);
+            await PushConfigurationAsync(TestRepositoryName, TestRepositoryTag, AnonymizationConfiguration);
             var jobRecord = new ExportJobRecord(
                 new Uri("https://localhost/$export"),
                 ExportJobType.All,
@@ -296,7 +291,7 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests
                 filters: null,
                 "hash",
                 rollingFileSizeInMB: 1,
-                anonymizationConfigurationCollectionReference: $"{registry.Server}/{TestRepositoryName}:{TestRepositoryTag}",
+                anonymizationConfigurationCollectionReference: $"{GetRegistryServer()}/{TestRepositoryName}:{TestRepositoryTag}",
                 anonymizationConfigurationLocation: "InvalidConfigName");
             using (Stream stream = new MemoryStream())
             {
@@ -304,116 +299,109 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests
             }
         }
 
-        private async Task PushConfigurationAsync(ContainerRegistryInfo registry, string repository, string tag, string configContent)
+        private static async Task PushConfigurationAsync(string repository, string tag, string configContent)
         {
-            AzureContainerRegistryClient acrClient = new AzureContainerRegistryClient(registry.Server, new AcrBasicToken(registry));
+            var client = new ContainerRegistryContentClient(new Uri($"https://{GetRegistryServer()}"), repository, CreateAzurePipelinesCredential());
 
-            int schemaV2 = 2;
-            string mediatypeV2Manifest = "application/vnd.docker.distribution.manifest.v2+json";
-            string mediatypeV1Manifest = "application/vnd.oci.image.config.v1+json";
-            string emptyConfigStr = "{}";
+            using var configStream = new MemoryStream("{}"u8.ToArray());
+            var configResult = await client.UploadBlobAsync(configStream);
 
-            // Upload config blob
-            byte[] originalConfigBytes = Encoding.UTF8.GetBytes(emptyConfigStr);
-            using var originalConfigStream = new MemoryStream(originalConfigBytes);
-            string originalConfigDigest = ComputeDigest(originalConfigStream);
-            await UploadBlob(acrClient, originalConfigStream, repository, originalConfigDigest);
-
-            // Upload memory blob
             byte[] configContentBytes = Encoding.UTF8.GetBytes(configContent);
+            byte[] tarGzBytes = StreamUtility.CompressToTarGz(new Dictionary<string, byte[]>() { { TestConfigName, configContentBytes } }, false);
+            using var layerStream = new MemoryStream(tarGzBytes);
+            var layerResult = await client.UploadBlobAsync(layerStream);
 
-            configContentBytes = StreamUtility.CompressToTarGz(new Dictionary<string, byte[]>() { { TestConfigName, configContentBytes } }, false);
-            using Stream byteStream = new MemoryStream(configContentBytes);
-            var blobLength = byteStream.Length;
-            string blobDigest = ComputeDigest(byteStream);
-            await UploadBlob(acrClient, byteStream, repository, blobDigest);
-
-            // Push manifest
-            List<Descriptor> layers = new List<Descriptor>
+            var manifest = new
             {
-                new Descriptor("application/vnd.oci.image.layer.v1.tar", blobLength, blobDigest),
-            };
-            var v2Manifest = new V2Manifest(schemaV2, mediatypeV2Manifest, new Descriptor(mediatypeV1Manifest, originalConfigBytes.Length, originalConfigDigest), layers);
-            await acrClient.Manifests.CreateAsync(repository, tag, v2Manifest);
-            acrClient.Dispose();
-        }
-
-        private static string ComputeDigest(Stream s)
-        {
-            s.Position = 0;
-            StringBuilder sb = new StringBuilder();
-
-            using (var hash = SHA256.Create())
-            {
-                byte[] result = hash.ComputeHash(s);
-                foreach (byte b in result)
+                schemaVersion = 2,
+                config = new
                 {
-                    sb.Append(b.ToString("x2"));
-                }
-            }
-
-            return "sha256:" + sb.ToString();
-        }
-
-        private async Task UploadBlob(AzureContainerRegistryClient acrClient, Stream stream, string repository, string digest)
-        {
-            stream.Position = 0;
-            var uploadInfo = await acrClient.Blob.StartUploadAsync(repository);
-            var uploadedLayer = await acrClient.Blob.UploadAsync(stream, uploadInfo.Location);
-            await acrClient.Blob.EndUploadAsync(digest, uploadedLayer.Location);
-        }
-
-        private ContainerRegistryInfo GetTestContainerRegistryInfo()
-        {
-            var containerRegistry = new ContainerRegistryInfo
-            {
-                Server = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer),
-                Username = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer)?.Split('.')[0],
-                Password = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryPassword),
+                    mediaType = "application/vnd.oci.image.config.v1+json",
+                    digest = configResult.Value.Digest,
+                    size = configResult.Value.SizeInBytes,
+                },
+                layers = new[]
+                {
+                    new
+                    {
+                        mediaType = "application/vnd.oci.image.layer.v1.tar",
+                        digest = layerResult.Value.Digest,
+                        size = layerResult.Value.SizeInBytes,
+                    },
+                },
             };
 
-            if (string.IsNullOrEmpty(containerRegistry.Server) || string.IsNullOrEmpty(containerRegistry.Password))
+            BinaryData manifestData = BinaryData.FromString(JsonSerializer.Serialize(manifest));
+            await client.SetManifestAsync(manifestData, tag, ManifestMediaType.OciImageManifest);
+        }
+
+        private static string GetRegistryServer()
+        {
+            return EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer);
+        }
+
+        private static bool IsAcrConfigured()
+        {
+            return !string.IsNullOrEmpty(GetRegistryServer()) && HasFederatedIdentityEnvironment();
+        }
+
+        private static bool HasFederatedIdentityEnvironment()
+        {
+            return !string.IsNullOrEmpty(EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.AzureSubscriptionTenantId))
+                && !string.IsNullOrEmpty(EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.AzureSubscriptionClientId))
+                && !string.IsNullOrEmpty(EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.AzureSubscriptionServiceConnectionId))
+                && !string.IsNullOrEmpty(EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.SystemAccessToken));
+        }
+
+        private static AzurePipelinesCredential CreateAzurePipelinesCredential()
+        {
+            string tenantId = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.AzureSubscriptionTenantId);
+            string clientId = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.AzureSubscriptionClientId);
+            string serviceConnectionId = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.AzureSubscriptionServiceConnectionId);
+            string systemAccessToken = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.SystemAccessToken);
+
+            return new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken);
+        }
+
+        private static IContainerRegistryTokenProvider CreateAcrTokenProvider()
+        {
+            if (!IsAcrConfigured())
             {
                 return null;
             }
 
-            return containerRegistry;
+            var aadTokenProvider = new AzurePipelinesAccessTokenProvider(CreateAzurePipelinesCredential());
+            return new AzureContainerRegistryAccessTokenProvider(
+                aadTokenProvider,
+                new SingleHttpClientFactory(),
+                Options.Create(new ConvertDataConfiguration()),
+                NullLogger<AzureContainerRegistryAccessTokenProvider>.Instance);
         }
 
-        internal class AcrBasicToken : ServiceClientCredentials, IContainerRegistryTokenProvider
+        private sealed class AzurePipelinesAccessTokenProvider : IAccessTokenProvider
         {
-            private ContainerRegistryInfo _registry;
+            private readonly AzurePipelinesCredential _credential;
 
-            public AcrBasicToken(ContainerRegistryInfo registry)
+            public AzurePipelinesAccessTokenProvider(AzurePipelinesCredential credential)
             {
-                _registry = registry;
+                _credential = credential;
             }
 
-            public Task<string> GetTokenAsync(string registryServer, CancellationToken cancellationToken)
-            {
-                return Task.FromResult("Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_registry.Username}:{_registry.Password}")));
-            }
+            public TokenCredential TokenCredential => _credential;
 
-            public override void InitializeServiceClient<T>(ServiceClient<T> client)
+            public async Task<string> GetAccessTokenForResourceAsync(Uri resourceUri, CancellationToken cancellationToken)
             {
-                base.InitializeServiceClient(client);
-            }
-
-            public override Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                var basicToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_registry.Username}:{_registry.Password}"));
-                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicToken);
-                return base.ProcessHttpRequestAsync(request, cancellationToken);
+                string scope = new Uri(resourceUri, "/.default").ToString();
+                AccessToken token = await _credential.GetTokenAsync(new TokenRequestContext(new[] { scope }), cancellationToken);
+                return token.Token;
             }
         }
 
-        internal class ContainerRegistryInfo
+        private sealed class SingleHttpClientFactory : IHttpClientFactory
         {
-            public string Server { get; set; }
+            private static readonly HttpClient SharedClient = new HttpClient();
 
-            public string Username { get; set; }
-
-            public string Password { get; set; }
+            public HttpClient CreateClient(string name) => SharedClient;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/Microsoft.Health.Fhir.Azure.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/Microsoft.Health.Fhir.Azure.UnitTests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Azure.Containers.ContainerRegistry" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Health.Test.Utilities" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/EnvironmentVariables.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/EnvironmentVariables.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Health.Fhir.Tests.Common
             { KnownEnvironmentVariableNames.CosmosDbUseManagedIdentity, string.Empty },
             { KnownEnvironmentVariableNames.SqlServerConnectionString, LocalSqlConnectionString },
             { KnownEnvironmentVariableNames.SystemAccessToken, string.Empty },
-            { KnownEnvironmentVariableNames.TestContainerRegistryPassword, string.Empty },
             { KnownEnvironmentVariableNames.TestContainerRegistryServer, string.Empty },
             { KnownEnvironmentVariableNames.TestEnvironmentName, string.Empty },
             { KnownEnvironmentVariableNames.TestEnvironmentUrl, string.Empty },

--- a/src/Microsoft.Health.Fhir.Tests.Common/KnownEnvironmentVariableNames.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/KnownEnvironmentVariableNames.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Health.Fhir.Tests.Common
         public const string CosmosDbUseManagedIdentity = "CosmosDb__UseManagedIdentity";
         public const string SqlServerConnectionString = "SqlServer:ConnectionString";
         public const string SystemAccessToken = "SYSTEM_ACCESSTOKEN";
-        public const string TestContainerRegistryPassword = "TestContainerRegistryPassword";
         public const string TestContainerRegistryServer = "TestContainerRegistryServer";
         public const string TestEnvironmentName = "TestEnvironmentName";
         public const string TestEnvironmentUrl = "TestEnvironmentUrl";

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/AnonymizedExportUsingAcrTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/AnonymizedExportUsingAcrTests.cs
@@ -9,17 +9,12 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage;
 using Azure.Storage.Blobs.Specialized;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
-using Microsoft.Azure.ContainerRegistry;
-using Microsoft.Azure.ContainerRegistry.Models;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Models;
@@ -306,111 +301,32 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
             return result;
         }
 
-        private ContainerRegistryInfo GetTestContainerRegistryInfo()
+        private static ContainerRegistryInfo GetTestContainerRegistryInfo()
         {
-            var containerRegistry = new ContainerRegistryInfo
-            {
-                Server = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer),
-                Username = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer)?.Split('.')[0],
-                Password = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryPassword),
-            };
+            string server = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.TestContainerRegistryServer);
 
-            if (string.IsNullOrEmpty(containerRegistry.Server) || string.IsNullOrEmpty(containerRegistry.Password))
+            if (string.IsNullOrEmpty(server))
             {
                 return null;
             }
 
-            return containerRegistry;
+            return new ContainerRegistryInfo { Server = server };
         }
 
-        private static string ComputeDigest(Stream s)
+        private static async Task PushConfigurationAsync(ContainerRegistryInfo registry, string repository, string tag, string configContent)
         {
-            s.Position = 0;
-            StringBuilder sb = new StringBuilder();
+            var uploader = ContainerRegistryTemplateUploader.CreateFromEnvironment(repository);
 
-            using (var hash = SHA256.Create())
-            {
-                byte[] result = hash.ComputeHash(s);
-                foreach (byte b in result)
-                {
-                    sb.Append(b.ToString("x2"));
-                }
-            }
-
-            return "sha256:" + sb.ToString();
-        }
-
-        private async Task UploadBlob(AzureContainerRegistryClient acrClient, Stream stream, string repository, string digest)
-        {
-            stream.Position = 0;
-            var uploadInfo = await acrClient.Blob.StartUploadAsync(repository);
-            var uploadedLayer = await acrClient.Blob.UploadAsync(stream, uploadInfo.Location);
-            await acrClient.Blob.EndUploadAsync(digest, uploadedLayer.Location);
-        }
-
-        private async Task PushConfigurationAsync(ContainerRegistryInfo registry, string repository, string tag, string configContent)
-        {
-            AzureContainerRegistryClient acrClient = new AzureContainerRegistryClient(registry.Server, new AcrBasicToken(registry));
-
-            int schemaV2 = 2;
-            string mediatypeV2Manifest = "application/vnd.docker.distribution.manifest.v2+json";
-            string mediatypeV1Manifest = "application/vnd.oci.image.config.v1+json";
-            string emptyConfigStr = "{}";
-
-            // Upload config blob
-            byte[] originalConfigBytes = Encoding.UTF8.GetBytes(emptyConfigStr);
-            using var originalConfigStream = new MemoryStream(originalConfigBytes);
-            string originalConfigDigest = ComputeDigest(originalConfigStream);
-            await UploadBlob(acrClient, originalConfigStream, repository, originalConfigDigest);
-
-            // Upload memory blob
             byte[] configContentBytes = Encoding.UTF8.GetBytes(configContent);
+            byte[] tarGzBytes = StreamUtility.CompressToTarGz(new Dictionary<string, byte[]>() { { TestConfigName, configContentBytes } }, false);
+            using Stream layerStream = new MemoryStream(tarGzBytes);
 
-            configContentBytes = StreamUtility.CompressToTarGz(new Dictionary<string, byte[]>() { { TestConfigName, configContentBytes } }, false);
-            using Stream byteStream = new MemoryStream(configContentBytes);
-            var blobLength = byteStream.Length;
-            string blobDigest = ComputeDigest(byteStream);
-            await UploadBlob(acrClient, byteStream, repository, blobDigest);
-
-            // Push manifest
-            List<Descriptor> layers = new List<Descriptor>
-            {
-                new Descriptor("application/vnd.oci.image.layer.v1.tar", blobLength, blobDigest),
-            };
-            var v2Manifest = new V2Manifest(schemaV2, mediatypeV2Manifest, new Descriptor(mediatypeV1Manifest, originalConfigBytes.Length, originalConfigDigest), layers);
-            await acrClient.Manifests.CreateAsync(repository, tag, v2Manifest);
-            acrClient.Dispose();
+            await uploader.UploadTemplateSetAsync(layerStream, tag);
         }
 
-        internal class ContainerRegistryInfo
+        internal sealed class ContainerRegistryInfo
         {
             public string Server { get; set; }
-
-            public string Username { get; set; }
-
-            public string Password { get; set; }
-        }
-
-        internal class AcrBasicToken : ServiceClientCredentials
-        {
-            private ContainerRegistryInfo _registry;
-
-            public AcrBasicToken(ContainerRegistryInfo registry)
-            {
-                _registry = registry;
-            }
-
-            public override void InitializeServiceClient<T>(ServiceClient<T> client)
-            {
-                base.InitializeServiceClient(client);
-            }
-
-            public override Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                var basicToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_registry.Username}:{_registry.Password}"));
-                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicToken);
-                return base.ProcessHttpRequestAsync(request, cancellationToken);
-            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -16,8 +16,10 @@
   <ItemGroup>
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\Export\AnonymizedExportUsingAcrTests.cs" Link="Rest\Export\AnonymizedExportUsingAcrTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\Export\AnonymizedExportTests.cs" Link="Rest\Export\AnonymizedExportTests.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ContainerRegistryTemplateUploader.cs" Link="Rest\ContainerRegistryTemplateUploader.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Containers.ContainerRegistry" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Azure.ContainerRegistry" />
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" />


### PR DESCRIPTION
## Description
Migrates the remaining Azure Container Registry (ACR) test setup — the anonymized $export tests — from static ACR admin connection keys to federated Managed Identity (Azure Pipelines workload identity). This completes the ACR MI work started for $convert-data (shipped in release/5.0.10), bringing ACR in line with the MI approach already used for Azure DevOps and SQL. The previously key-gated tests are now enabled to run under MI.

## Related issues
Addresses [AB#125246](https://dev.azure.com/microsofthealth/Health/_workitems/edit/125246).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
