### PR TITLE
Restore ToScopedNode() wrap in TypedElementSearchIndexer, lost in 2022

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
@@ -107,7 +107,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             CompiledExpression expression = _expressions.GetOrAdd(searchParameter.Expression, s => _compiler.Compile(s));
 
-            IEnumerable<ITypedElement> rootObjects = expression.Invoke(resource, context);
+            // ToScopedNode() is what Hl7.FhirPath's own Select()/Scalar() extension methods always apply
+            // before evaluating - it's what lets resolve() find a contained resource or a sibling Bundle
+            // entry from inside the instance, rather than only through the external IReferenceToElementResolver.
+            // Invoking the compiled delegate directly bypasses it unless applied explicitly; the wrap is
+            // idempotent (ToScopedNode() no-ops on a node that's already a ScopedNode), so this is safe to
+            // apply even where the input already went through it upstream. See PR description for why this
+            // was silently lost.
+            IEnumerable<ITypedElement> rootObjects = expression.Invoke(resource.ToScopedNode(), context);
 
             foreach (var rootObject in rootObjects)
             {
@@ -208,7 +215,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             {
                 CompiledExpression expression = _expressions.GetOrAdd(fhirPathExpression, s => _compiler.Compile(s));
 
-                extractedValues = expression.Invoke(element, context);
+                // See the matching comment in ProcessCompositeSearchParameter above.
+                extractedValues = expression.Invoke(element.ToScopedNode(), context);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/TypedElementSearchIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/TypedElementSearchIndexerTests.cs
@@ -8,7 +8,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
+using Hl7.FhirPath;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -104,6 +106,72 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var nameSearchValue = serachIndexEntry.First().Value as StringSearchValue;
             Assert.Equal(familyName, nameSearchValue.String);
          }
+
+        [Fact]
+        public void GivenAResourceWithAContainedReference_WhenExtractingAResolveBasedSearchParameter_ThenTheContainedResourceIsResolvedInInstance()
+        {
+            // TypedElementSearchIndexer historically bypassed the ToScopedNode() wrap that Hl7.FhirPath's own
+            // Select()/Scalar() extension methods always apply - see LightweightReferenceToElementResolverTests,
+            // which exercises resolve() through those extension methods directly and so never surfaced this
+            // gap. ToScopedNode() is what lets resolve() find a contained resource from inside the instance
+            // rather than only through the external IReferenceToElementResolver.
+            //
+            // No shipped search parameter is affected by this: every resolve() usage in the generated R4/R4B/R5
+            // definitions is shaped `.where(resolve() is X)` for type filtering only, and
+            // ResourceReferenceToReferenceSearchValueConverter drops '#'-prefixed references before they'd ever
+            // reach a SearchIndexEntry regardless of whether resolve() succeeds. This test therefore uses a
+            // synthetic non-Reference search parameter that navigates *past* resolve() into the resolved
+            // resource's own data - the case this fix actually protects: a custom search parameter that does
+            // more than type-filter.
+            FhirPathCompiler.DefaultSymbolTable.AddFhirExtensions();
+
+            var encounter = new Encounter
+            {
+                Contained = new List<Resource>
+                {
+                    new Practitioner { Id = "p1", Name = new List<HumanName> { new HumanName { Family = "Contained" } } },
+                },
+            };
+
+            var participant = new Encounter.ParticipantComponent();
+#if Stu3 || R4
+            participant.Individual = new ResourceReference("#p1");
+            const string participantPath = "Encounter.participant.individual";
+#else
+            participant.Actor = new ResourceReference("#p1");
+            const string participantPath = "Encounter.participant.actor";
+#endif
+            encounter.Participant = new List<Encounter.ParticipantComponent> { participant };
+
+            var supportedSearchParameterDefinitionManager = Substitute.For<ISupportedSearchParameterDefinitionManager>();
+            var referenceToElementResolver = Substitute.For<IReferenceToElementResolver>();
+
+            // No external resolver match - proves the fix cannot be relying on it. LightweightReferenceToElementResolver
+            // parses "#p1" into a reference with no resource type and would return null here in production too.
+            referenceToElementResolver.Resolve(Arg.Any<string>()).Returns((ITypedElement)null);
+
+            var searchParameterInfo = new SearchParameterInfo(
+                "contained-practitioner-name",
+                "contained-practitioner-name",
+                (ValueSets.SearchParamType)SearchParamType.String,
+                new Uri("http://example.org/SearchParameter/contained-practitioner-name"),
+                expression: $"{participantPath}.resolve().name.family",
+                baseResourceTypes: new List<string> { "Encounter" });
+            supportedSearchParameterDefinitionManager.GetSearchParameters(Arg.Any<string>()).Returns(new[] { searchParameterInfo });
+
+            var indexer = new TypedElementSearchIndexer(
+                supportedSearchParameterDefinitionManager,
+                GetTypeConverterAsync().Result,
+                referenceToElementResolver,
+                ModelInfoProvider.Instance,
+                Substitute.For<ILogger<TypedElementSearchIndexer>>());
+
+            var searchIndexEntries = indexer.Extract(encounter.ToResourceElement());
+
+            var stringSearchValue = Assert.Single(searchIndexEntries).Value as StringSearchValue;
+            Assert.NotNull(stringSearchValue);
+            Assert.Equal("Contained", stringSearchValue.String);
+        }
 
 #if !Stu3
         // For Stu3 - Coverage.status, Observation.status, and Claim.use are not required fields


### PR DESCRIPTION
## What broke, and when

`TypedElementSearchIndexer` invokes compiled FHIRPath expressions directly against a bare `ITypedElement`. Every one of `Hl7.FhirPath`'s own `Select()`/`Scalar()` extension methods wraps its input in `ToScopedNode()` before evaluating — and before [#2763](https://github.com/microsoft/fhir-server/pull/2763) ("SearchIndexer uses its own Expression Cache", Aug 2022), this indexer did too:

```diff
-IEnumerable<ITypedElement> rootObjects = resource.Select(searchParameter.Expression, context);
+CompiledExpression expression = _expressions.GetOrAdd(searchParameter.Expression, s => _compiler.Compile(s));
+IEnumerable<ITypedElement> rootObjects = expression.Invoke(resource, context);
```

That change is purely a caching optimization — nothing in its description mentions `resolve()` or contained resources — but hand-rolling the compiled-delegate invocation dropped the `ToScopedNode()` wrap as an undocumented side effect.

## Why it matters

`ScopedNode` is what lets FHIRPath's `resolve()` find a contained resource (`#id`) or a sibling Bundle entry from *inside* the instance, before falling back to the external `IReferenceToElementResolver`. This server's resolver, `LightweightReferenceToElementResolver`, only parses the reference *string* — it never had access to the instance being indexed, and its regex requires `ResourceType/ResourceId`, so `#p1` never matches and it returns `null`. Without the wrap, `resolve()` against a contained resource has therefore returned nothing during indexing since this commit — silently, four years ago.

## Scope: this does not change any shipped search parameter's output

I checked before writing this fix. Every `resolve()` occurrence in the generated R4/R4B/R5 `search-parameters.json` (76 across those three files; Stu3 has none) is shaped `.where(resolve() is X)` — pure type filtering, never navigation into the resolved resource's data:

```
$ python3 -c "... find resolve() not immediately followed by 'is' ..."
(no output — zero counter-examples)
```

And even where the fix changes which elements pass that `.where()` filter, `ResourceReferenceToReferenceSearchValueConverter.Convert` drops `#`/`urn:`-prefixed references unconditionally before they'd ever reach a `SearchIndexEntry`:

```csharp
// Contained resources will not be searchable.
if (reference.StartsWith('#') || reference.StartsWith("urn:", StringComparison.Ordinal))
{
    yield break;
}
```

So **no reindex is implied for any built-in search parameter.** The fix protects a narrower, real case: a custom search parameter that navigates *past* `resolve()` into the resolved resource's own data (e.g. `Encounter.participant.actor.resolve().name.family`), where the previous behavior silently returned an empty result instead of the contained resource's value.

## The fix

Two call sites, wrapped at the point of invocation rather than reverting the 2022 caching:

```diff
-IEnumerable<ITypedElement> rootObjects = expression.Invoke(resource, context);
+IEnumerable<ITypedElement> rootObjects = expression.Invoke(resource.ToScopedNode(), context);
```

`ToScopedNode()` is idempotent (`node as ScopedNode ?? new ScopedNode(node)`), so this doesn't double-wrap where an extension method already applied it upstream — e.g. a composite parameter's child expressions run against `rootObject`s that came out of the first `ToScopedNode()`-wrapped evaluation and are already `ScopedNode`s.

## Testing

New test constructs an `Encounter` with a contained `Practitioner`, a synthetic non-Reference search parameter (`{participant path}.resolve().name.family`), and an `IReferenceToElementResolver` mock returning `null` — so external resolution definitely cannot be what succeeds. Verified it actually pins the regression: **fails against the pre-fix code** (`Assert.Single() Failure: The collection was empty`), passes with the fix, on all four FHIR versions (R4/R4B/R5/Stu3).

- `TypedElementSearchIndexerTests`, all four versions — new test passes, confirmed to fail without the fix
- `Microsoft.Health.Fhir.R4.Core.UnitTests` full suite — 1723/1723
- `Microsoft.Health.Fhir.Core.UnitTests` full suite — 1044/1044

## Context

Found while investigating [ADR 2608](https://github.com/microsoft/fhir-server/blob/main/docs/arch/adr-2608-ignixa-fhirpath-seam.md) (the Ignixa FHIRPath migration seam, not yet merged) — landing this independently first means that PR's `TypedElementSearchIndexer` diff is a pure provider-abstraction change with no bundled behavior fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
