### PR TITLE
fix: parse Accept header media type to allow parameters like charset=utf-8

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
@@ -63,7 +63,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
             if (!context.HttpContext.Request.Headers.TryGetValue(HeaderNames.Accept, out var acceptHeaderValue) ||
                 acceptHeaderValue.Count != 1 ||
-                !string.Equals(acceptHeaderValue[0], KnownContentTypes.JsonContentType, StringComparison.OrdinalIgnoreCase))
+                !MediaTypeHeaderValue.TryParse(acceptHeaderValue[0], out var parsedMediaType) ||
+                !string.Equals(parsedMediaType.MediaType.Value, KnownContentTypes.JsonContentType, StringComparison.OrdinalIgnoreCase))
             {
                 throw new RequestNotValidException(string.Format(Api.Resources.UnsupportedHeaderValue, acceptHeaderValue.FirstOrDefault(), HeaderNames.Accept));
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
@@ -191,6 +191,21 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Theory]
+        [InlineData("application/fhir+json; charset=utf-8")]
+        [InlineData("application/fhir+json;charset=utf-8")]
+        [InlineData("application/fhir+json; charset=UTF-8")]
+        public void GivenARequestWithAcceptHeaderContainingMediaTypeParams_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful(string acceptHeader)
+        {
+            // .NET HttpClient automatically appends "; charset=utf-8" to the Accept header.
+            // Validate that media type parameters do not cause the request to be rejected.
+            var context = CreateContext();
+            context.HttpContext.Request.Headers[HeaderNames.Accept] = acceptHeader;
+            context.HttpContext.Request.Headers[PreferHeaderName] = CorrectPreferHeaderValue;
+
+            _filter.OnActionExecuting(context);
+        }
+
+        [Theory]
         [InlineData("respond-async", true)]
         [InlineData("respond-async,handling=strict", true)]
         [InlineData("  respond-async ,  handling    =   strict  ", true)]


### PR DESCRIPTION

Fixes #3876

## Description

  ---Problem

  The $export endpoint validates the Accept header using exact string comparison against application/fhir+json.
  When .NET's HttpClient makes the request, it automatically appends ; charset=utf-8, producing
  application/fhir+json; charset=utf-8 — which the exact match rejects with a 400 error.

  Fix

  Replaced string.Equals with MediaTypeHeaderValue.TryParse so only the media type portion is compared, ignoring
  any additional parameters such as charset.

  Tests Added

  Three new test cases in ValidateExportRequestFilterAttributeTests:
  - application/fhir+json; charset=utf-8
  - application/fhir+json;charset=utf-8 (no space after semicolon)
  - application/fhir+json; charset=UTF-8 (uppercase charset)

  All three now pass without throwing RequestNotValidException.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
