### PR TITLE
Refactoring runtime state configuration.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestRuntimeStateMiddlewareExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestRuntimeStateMiddlewareExtensions.cs
@@ -7,6 +7,7 @@ using EnsureThat;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.RuntimeState;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Registration;
 
 namespace Microsoft.Health.Fhir.Api.Features.Context
@@ -20,7 +21,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             // For Azure API for FHIR, runtime state can be 'Active' or 'Deprecated'.
             // For AHDS FHIR, runtime state is always 'Active'. Even if the configuration is set as 'Deprecated', it will be ignored and treated as 'Active'.
             // That logic is part of 'AzureHealthDataServicesRuntimeConfiguration' as a second of protection.
-            if (Core.Extensions.ConfigurationExtensions.GetRuntimeStateConfiguration(fhirServerConfiguration.CoreFeatures) == FhirRuntimeState.Deprecated)
+            if (RuntimeStateConfigurationExtensions.GetRuntimeStateConfiguration(fhirServerConfiguration.CoreFeatures) == FhirRuntimeState.Deprecated)
             {
                 builder.UseMiddleware<RuntimeStateMiddleware>();
             }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/RuntimeStateConfigurationExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/RuntimeStateConfigurationExtensionsTests.cs
@@ -3,18 +3,37 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
+using NSubstitute;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
-    [Trait(Traits.Category, Categories.Operations)]
-    public sealed class ConfigurationExtensionsTests
+    [Trait(Traits.Category, Categories.ServiceRuntimeState)]
+    public sealed class RuntimeStateConfigurationExtensionsTests
     {
+        [Theory]
+        [InlineData(null, FhirRuntimeState.Active)]
+        [InlineData("", FhirRuntimeState.Active)]
+        [InlineData("Active", FhirRuntimeState.Active)]
+        [InlineData(" active ", FhirRuntimeState.Active)]
+        [InlineData("DEPRECATED", FhirRuntimeState.Deprecated)]
+        [InlineData(" deprecated ", FhirRuntimeState.Deprecated)]
+        public void GivenAnConfiguration_WhenGettingRuntimeState_ThenProperRuntimeValueIsReturned(string configurationValue, FhirRuntimeState expected)
+        {
+            IConfiguration configuration = Substitute.For<IConfiguration>();
+            configuration["FhirServer:CoreFeatures:RuntimeState"].Returns(configurationValue);
+
+            FhirRuntimeState actual = RuntimeStateConfigurationExtensions.GetRuntimeStateConfiguration(configuration);
+
+            Assert.Equal(expected, actual);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -22,7 +41,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         [InlineData("\t\r\n")]
         public void GivenAnEmptyRuntimeStateConfiguration_WhenGettingRuntimeState_ThenActiveIsReturned(string configuredRuntimeState)
         {
-            FhirRuntimeState actual = ConfigurationExtensions.ParseRuntimeStateConfiguration(configuredRuntimeState);
+            FhirRuntimeState actual = RuntimeStateConfigurationExtensions.ParseRuntimeStateConfiguration(configuredRuntimeState);
 
             Assert.Equal(FhirRuntimeState.Active, actual);
         }
@@ -36,7 +55,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             string configuredRuntimeState,
             FhirRuntimeState expected)
         {
-            FhirRuntimeState actual = ConfigurationExtensions.ParseRuntimeStateConfiguration(configuredRuntimeState);
+            FhirRuntimeState actual = RuntimeStateConfigurationExtensions.ParseRuntimeStateConfiguration(configuredRuntimeState);
 
             Assert.Equal(expected, actual);
         }
@@ -47,7 +66,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         [InlineData("2")]
         public void GivenAnInvalidRuntimeStateConfiguration_WhenGettingRuntimeState_ThenActiveIsReturned(string configuredRuntimeState)
         {
-            FhirRuntimeState actual = ConfigurationExtensions.ParseRuntimeStateConfiguration(configuredRuntimeState);
+            FhirRuntimeState actual = RuntimeStateConfigurationExtensions.ParseRuntimeStateConfiguration(configuredRuntimeState);
 
             Assert.Equal(FhirRuntimeState.Active, actual);
         }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/RuntimeStateConfigurationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/RuntimeStateConfigurationExtensions.cs
@@ -4,13 +4,29 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Registration;
 
 namespace Microsoft.Health.Fhir.Core.Extensions
 {
-    public static class ConfigurationExtensions
+    public static class RuntimeStateConfigurationExtensions
     {
+        private const string RuntimeStateConfigurationKey = "FhirServer:CoreFeatures:RuntimeState";
+
+        /// <summary>
+        /// Gets the FHIR runtime state configuration.
+        /// </summary>
+        /// <param name="configuration">The configuration instance.</param>
+        /// <returns>The FHIR runtime state.</returns>
+        /// <remarks>Active is assumed as the default runtime state for invalid inputs.</remarks>
+        public static FhirRuntimeState GetRuntimeStateConfiguration(IConfiguration configuration)
+        {
+            string configuredRuntimeState = configuration[RuntimeStateConfigurationKey];
+
+            return ParseRuntimeStateConfiguration(configuredRuntimeState);
+        }
+
         /// <summary>
         /// Gets the FHIR runtime state configuration.
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -124,7 +124,8 @@ namespace Microsoft.Health.Fhir.Web
             string dataStore = configuration["DataStore"];
             if (KnownDataStores.IsCosmosDbDataStore(dataStore))
             {
-                runtimeConfiguration = new AzureApiForFhirRuntimeConfiguration(GetRuntimeState(configuration));
+                runtimeConfiguration = new AzureApiForFhirRuntimeConfiguration(
+                    RuntimeStateConfigurationExtensions.GetRuntimeStateConfiguration(configuration));
             }
             else if (KnownDataStores.IsSqlServerDataStore(dataStore))
             {
@@ -138,13 +139,6 @@ namespace Microsoft.Health.Fhir.Web
             fhirServerBuilder.Services.AddSingleton<IFhirRuntimeConfiguration>(runtimeConfiguration);
 
             return runtimeConfiguration;
-        }
-
-        private static FhirRuntimeState GetRuntimeState(IConfiguration configuration)
-        {
-            string configuredRuntimeState = configuration["FhirServer:CoreFeatures:RuntimeState"];
-
-            return Core.Extensions.ConfigurationExtensions.ParseRuntimeStateConfiguration(configuredRuntimeState);
         }
 
         private void AddTaskHostingService(IServiceCollection services)


### PR DESCRIPTION
## Description
Refactoring runtime state configuration to simplify the way how it's consumed by downstream services and avoid redundant code. 

## Related issues
Addresses [AB#205134](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/205134).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
