### PR TITLE
Fix 500 from $import status endpoint

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/GetImportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/GetImportRequestHandlerTests.cs
@@ -160,6 +160,109 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkImport
             await Assert.ThrowsAsync<ResourceNotFoundException>(async () => await _mediator.GetImportStatusAsync(1, CancellationToken.None));
         }
 
+        [Fact]
+        public async Task WhenStatusIsRequestedByProcessingJobId_ThenOrchestratorJobIsSkippedAndResponseCodeShouldBeOk()
+        {
+            var orchestratorResult = new ImportOrchestratorJobResult() { Request = "Request" };
+            var orchestrator = new JobInfo()
+            {
+                Id = 0,
+                Status = JobStatus.Completed,
+                Result = JsonConvert.SerializeObject(orchestratorResult),
+                Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition() { TypeId = (int)JobType.ImportOrchestrator }),
+            };
+
+            var workerResult = new ImportProcessingJobResult() { SucceededResources = 1, FailedResources = 1, ErrorLogLocation = "http://xyz" };
+            var worker = new JobInfo()
+            {
+                Id = 2,
+                Status = JobStatus.Completed,
+                Result = JsonConvert.SerializeObject(workerResult),
+                Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { TypeId = (int)JobType.ImportProcessing, ResourceLocation = "http://xyz" }),
+            };
+
+            // status is requested with the id of a processing job, so the orchestrator job is not filtered out of the group
+            var polled = new JobInfo()
+            {
+                Id = 1,
+                Status = JobStatus.Completed,
+                Result = JsonConvert.SerializeObject(workerResult),
+                Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { TypeId = (int)JobType.ImportProcessing, ResourceLocation = "http://xyz" }),
+            };
+
+            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(polled, [orchestrator, worker]);
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+            // The orchestrator job records no input file, so it is not reported. The job whose id was requested is excluded
+            // from its own group results, exactly as the orchestrator job is when its id is requested, so only the remaining
+            // processing job is reported.
+            var output = Assert.Single(result.JobResult.Output);
+            Assert.Equal(1L, output.Count);
+            Assert.Equal(new Uri("http://xyz"), output.InputUrl);
+            var error = Assert.Single(result.JobResult.Error);
+            Assert.Equal(1L, error.Count);
+        }
+
+        [Fact]
+        public async Task WhenCompletedJobHasNoInputLocation_ThenJobIsSkippedAndResponseCodeShouldBeOk()
+        {
+            var coordResult = new ImportOrchestratorJobResult() { Request = "Request" };
+            var coord = new JobInfo() { Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(coordResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition()) };
+            var workerResult = new ImportProcessingJobResult() { SucceededResources = 1, FailedResources = 1, ErrorLogLocation = "http://xyz" };
+            var workerWithoutLocation = new JobInfo() { Id = 1, Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(workerResult), Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition()) };
+            var worker = new JobInfo() { Id = 2, Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(workerResult), Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { ResourceLocation = "http://xyz" }) };
+
+            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(coord, [workerWithoutLocation, worker]);
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Single(result.JobResult.Output);
+            Assert.Single(result.JobResult.Error);
+        }
+
+        [Fact]
+        public async Task WhenCompletedJobHasNoDefinitionOrResult_ThenJobIsSkippedAndResponseCodeShouldBeOk()
+        {
+            var coordResult = new ImportOrchestratorJobResult() { Request = "Request" };
+            var coord = new JobInfo() { Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(coordResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition()) };
+            var worker = new JobInfo() { Id = 1, Status = JobStatus.Completed };
+
+            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(coord, [worker]);
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Empty(result.JobResult.Output);
+            Assert.Empty(result.JobResult.Error);
+        }
+
+        [Fact]
+        public async Task WhenCompletedJobHasNoResult_ThenJobIsSkippedAndResponseCodeShouldBeOk()
+        {
+            var coordResult = new ImportOrchestratorJobResult() { Request = "Request" };
+            var coord = new JobInfo() { Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(coordResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition()) };
+
+            // a completed job with no persisted result reports no counts, so it is not reported as a zero count outcome
+            var worker = new JobInfo() { Id = 1, Status = JobStatus.Completed, Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { TypeId = (int)JobType.ImportProcessing, ResourceLocation = "http://xyz" }) };
+
+            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(coord, [worker]);
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Empty(result.JobResult.Output);
+            Assert.Empty(result.JobResult.Error);
+        }
+
+        [Fact]
+        public async Task WhenGettingFailedJobWithoutInputLocation_ThenExceptionIsThrownWithoutErrorFile()
+        {
+            var coord = new JobInfo() { Status = JobStatus.Completed };
+            var workerResult = new ImportJobErrorResult() { ErrorMessage = "Error", HttpStatusCode = HttpStatusCode.BadRequest };
+            var worker = new JobInfo() { Id = 1, Status = JobStatus.Failed, Result = JsonConvert.SerializeObject(workerResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition() { TypeId = (int)JobType.ImportOrchestrator }) };
+
+            var ofe = await Assert.ThrowsAsync<OperationFailedException>(() => SetupAndExecuteGetBulkImportJobByIdAsync(coord, [worker]));
+
+            Assert.Equal(HttpStatusCode.BadRequest, ofe.ResponseStatusCode);
+            Assert.Equal(string.Format(Core.Resources.OperationFailed, OperationsConstants.Import, "Error"), ofe.Message);
+        }
+
         private async Task<GetImportResponse> SetupAndExecuteGetBulkImportJobByIdAsync(JobInfo coord, List<JobInfo> workers)
         {
             _queueClient.GetJobByIdAsync(Arg.Any<byte>(), Arg.Any<long>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(coord);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             }
             else if (coord.Status == JobStatus.Failed)
             {
-                var errorResult = JsonConvert.DeserializeObject<ImportJobErrorResult>(coord.Result);
+                var errorResult = DeserializeOrDefault<ImportJobErrorResult>(coord.Result);
                 if (errorResult.HttpStatusCode == 0)
                 {
                     errorResult.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -85,23 +85,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 else if (failedJobsExist)
                 {
                     var failed = jobs.First(x => x.Status == JobStatus.Failed && !x.CancelRequested);
-                    var errorResult = JsonConvert.DeserializeObject<ImportJobErrorResult>(failed.Result);
-                    var definition = JsonConvert.DeserializeObject<ImportProcessingJobDefinition>(failed.Definition);
+                    var errorResult = DeserializeOrDefault<ImportJobErrorResult>(failed.Result);
                     if (errorResult.HttpStatusCode == 0)
                     {
                         errorResult.HttpStatusCode = HttpStatusCode.InternalServerError;
                     }
 
-                    var resourceLocation = new Uri(definition.ResourceLocation);
-
                     // hide error message for InternalServerError
                     var failureReason = errorResult.HttpStatusCode == HttpStatusCode.InternalServerError ? HttpStatusCode.InternalServerError.ToString() : errorResult.ErrorMessage;
 
-                    throw new OperationFailedException(string.Format(Core.Resources.OperationFailedWithErrorFile, OperationsConstants.Import, failureReason, resourceLocation.OriginalString), errorResult.HttpStatusCode);
+                    // The input file location is not available on every job record in the group, so the error file cannot always be reported.
+                    var message = TryGetProcessingJobInput(failed, out _, out var resourceLocation)
+                        ? string.Format(Core.Resources.OperationFailedWithErrorFile, OperationsConstants.Import, failureReason, resourceLocation.OriginalString)
+                        : string.Format(Core.Resources.OperationFailed, OperationsConstants.Import, failureReason);
+
+                    throw new OperationFailedException(message, errorResult.HttpStatusCode);
                 }
                 else // no failures here
                 {
-                    var coordResult = JsonConvert.DeserializeObject<ImportOrchestratorJobResult>(coord.Result);
+                    var coordResult = DeserializeOrDefault<ImportOrchestratorJobResult>(coord.Result);
                     var result = new ImportJobResult() { Request = coordResult.Request, TransactionTime = coord.CreateDate, Output = results.Completed, Error = results.Failed };
                     return new GetImportResponse(!inFlightJobsExist ? HttpStatusCode.OK : HttpStatusCode.Accepted, result);
                 }
@@ -117,12 +119,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 var failed = new List<ImportFailedOperationOutcome>();
                 foreach (var job in jobs.Where(_ => _.Status == JobStatus.Completed))
                 {
-                    var definition = JsonConvert.DeserializeObject<ImportProcessingJobDefinition>(job.Definition);
-                    var result = JsonConvert.DeserializeObject<ImportProcessingJobResult>(job.Result);
-                    completed.Add(new ImportOperationOutcome() { Type = definition.ResourceType, Count = result.SucceededResources, InputUrl = new Uri(definition.ResourceLocation) });
+                    // The job group also contains the orchestrator job, which is returned here whenever status is requested
+                    // by a job id other than the orchestrator's. It records no input file url, and neither does a job whose
+                    // state was not persisted. Such records cannot be reported as a processed input file, so they are
+                    // skipped rather than allowed to fail the whole status request.
+                    if (!TryGetProcessingJobInput(job, out var definition, out var inputUrl) || string.IsNullOrWhiteSpace(job.Result))
+                    {
+                        continue;
+                    }
+
+                    var result = DeserializeOrDefault<ImportProcessingJobResult>(job.Result);
+                    completed.Add(new ImportOperationOutcome() { Type = definition.ResourceType, Count = result.SucceededResources, InputUrl = inputUrl });
                     if (result.FailedResources > 0)
                     {
-                        failed.Add(new ImportFailedOperationOutcome() { Type = definition.ResourceType, Count = result.FailedResources, InputUrl = new Uri(definition.ResourceLocation), Url = result.ErrorLogLocation });
+                        failed.Add(new ImportFailedOperationOutcome() { Type = definition.ResourceType, Count = result.FailedResources, InputUrl = inputUrl, Url = result.ErrorLogLocation });
                     }
                 }
 
@@ -136,6 +146,47 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
                 return (groupped, failed);
             }
+        }
+
+        /// <summary>
+        /// Resolves the import processing job definition and the url of the input file it processed.
+        /// </summary>
+        /// <param name="job">The job to inspect.</param>
+        /// <param name="definition">When this method returns true, the import processing job definition; otherwise null.</param>
+        /// <param name="inputUrl">When this method returns true, the url of the processed input file; otherwise null.</param>
+        /// <returns>True when the job records the url of an input file it processed; otherwise false.</returns>
+        private static bool TryGetProcessingJobInput(JobInfo job, out ImportProcessingJobDefinition definition, out Uri inputUrl)
+        {
+            // Recording an input file url is what separates a processing job from the orchestrator job, whose definition has
+            // no such property. Matching on the url rather than on the job type keeps every record the status response
+            // reported before, including any written before job types were persisted.
+            definition = DeserializeOrDefault<ImportProcessingJobDefinition>(job.Definition);
+
+            if (!Uri.TryCreate(definition.ResourceLocation, UriKind.Absolute, out inputUrl))
+            {
+                definition = null;
+                inputUrl = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Deserializes persisted job state, returning a default instance when the state is absent or null valued.
+        /// </summary>
+        /// <typeparam name="T">The type of the persisted job state.</typeparam>
+        /// <param name="json">The persisted job state.</param>
+        /// <returns>The deserialized job state, or a default instance.</returns>
+        private static T DeserializeOrDefault<T>(string json)
+            where T : new()
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new T();
+            }
+
+            return JsonConvert.DeserializeObject<T>(json) ?? new T();
         }
     }
 }


### PR DESCRIPTION
## Description

Polling the `$import` status endpoint with a processing job id (rather than the orchestrator's id) returns a 500 forever:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'uriString')
```

`GetJobByGroupIdAsync` hands back every job in the import group, orchestrator included, and the handler only filtered out `coord.Id`. When you poll by the orchestrator's own id that's enough, because the orchestrator's `Id` equals its `GroupId`. Poll by any other id in the group and the orchestrator record survives the filter, gets deserialized as an `ImportProcessingJobDefinition`, and comes back with a null `ResourceLocation` — `ImportOrchestratorJobDefinition` simply has no such property. `new Uri(null)` then throws, and since nothing about the stored state changes between polls, the caller is stuck on 500 with no way out.

Changes:

- Skip job records that don't carry an input file url, or whose result was never persisted, instead of letting one of them fail the whole status request. The url check is what distinguishes a processing job from the orchestrator, and it's deliberately used in place of a job-type check so that records written before job types were persisted still get reported exactly as before.
- Fall back to the `OperationFailed` message when a failed job has no input url, rather than throwing while building the `OperationFailedWithErrorFile` message.
- Route the three `JsonConvert.DeserializeObject` calls through a `DeserializeOrDefault<T>` helper. Newtonsoft returns null for absent, empty, or literal-`null` state, and every one of those call sites dereferenced it immediately.

Every input the new code skips is one the old code threw an unhandled exception on, so no request that previously succeeded returns anything different.

Worth calling out: this stops the 500, but polling by a processing job id still isn't semantically right — you get the group's status back with a null `request`. Arguably that should be a 404. That's a behavior change, so it's left for separate work.

## Related issues

Addresses [AB#204980](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/204980).

## Testing

Five regression tests added to `GetImportRequestHandlerTests`, covering status requested by a processing job id, a completed job with no input location, one with neither definition nor result, one with no result, and a failed job with no input location. All five fail on `main` with the original `ArgumentNullException` and pass with the fix.

Existing assertions on the group-status path were tightened to pin exact counts and input urls so the behavior is actually held in place rather than just not crashing.

Full `Microsoft.Health.Fhir.Core.UnitTests` suite compared against baseline: 1045 passed / 0 failed on `main`, 1050 passed / 0 failed on this branch. No new failures, clean build with no new warnings.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch
