### PR TITLE
Fixing a null-ref exception from SecurityProvider.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -73,6 +73,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             _linkGenerator = linkGenerator;
         }
 
+        /// <inheritdoc />
+        public bool CanResolve => _actionContextAccessor?.ActionContext != null;
+
         private HttpRequest Request
         {
             get

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
     public interface IUrlResolver
     {
         /// <summary>
+        /// Gets a value indicating whether the resolver can generate URLs in the current context.
+        /// Returns <c>false</c> when called outside an HTTP request pipeline (e.g., background tasks).
+        /// </summary>
+        bool CanResolve { get; }
+
+        /// <summary>
         /// Resolves the URL for the server metadata.
         /// </summary>
         /// <param name="includeSystemQueryString">A indicator if the system query string parameter should be included</param>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/SecurityProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/SecurityProviderTests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Security
                 Arg.Is<string>(x => string.Equals(x, RouteNames.AadSmartOnFhirProxyToken, StringComparison.OrdinalIgnoreCase)),
                 Arg.Any<IDictionary<string, object>>())
                 .Returns(new Uri(SmartTokenEndpointUri));
+            _urlResolver.CanResolve.Returns(true);
 
             _modelInfoProvider = Substitute.For<IModelInfoProvider>();
             _modelInfoProvider.Version.Returns(FhirSpecification.R4);
@@ -227,6 +228,48 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Security
                 revocation);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GivenConfiguration_WhenBuildingCapabilityStatementForBackgroundJob_ThenCapabilityStatementShouldNotHaveSmartEndpoints(
+            bool canResolve)
+        {
+            _urlResolver.CanResolve.Returns(canResolve);
+            _securityConfiguration.Enabled = true;
+            _securityConfiguration.EnableAadSmartOnFhirProxy = true;
+            _modelInfoProvider.Version.Returns(FhirSpecification.R4);
+
+            var restComponent = new ListedRestComponent()
+            {
+                Mode = ListedCapabilityStatement.ServerMode,
+            };
+
+            var capabilityStatement = new ListedCapabilityStatement();
+            capabilityStatement.Rest.Add(restComponent);
+
+            var builder = Substitute.For<ICapabilityStatementBuilder>();
+            builder
+                .When(x => x.Apply(Arg.Any<Action<ListedCapabilityStatement>>()))
+                .Do(
+                    x =>
+                    {
+                        var action = x.Arg<Action<ListedCapabilityStatement>>();
+                        action.Invoke(capabilityStatement);
+                    });
+            await _provider.BuildAsync(builder, CancellationToken.None);
+
+            ValidateOAuthUriExtension(
+                restComponent.Security.Extension,
+                canResolve ? SmartAuthorizationEndpointUri : null,
+                canResolve ? SmartTokenEndpointUri : null);
+            _urlResolver.Received(canResolve ? 1 : 0).ResolveRouteNameUrl(
+                Arg.Is<string>(x => string.Equals(x, RouteNames.AadSmartOnFhirProxyAuthorize, StringComparison.OrdinalIgnoreCase)),
+                Arg.Any<IDictionary<string, object>>());
+            _urlResolver.Received(canResolve ? 1 : 0).ResolveRouteNameUrl(
+                Arg.Is<string>(x => string.Equals(x, RouteNames.AadSmartOnFhirProxyToken, StringComparison.OrdinalIgnoreCase)),
+                Arg.Any<IDictionary<string, object>>());
+        }
+
         private static void Validate(
             bool enabled,
             ListedRestComponent component,
@@ -271,30 +314,47 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Security
             string management = null,
             string revocation = null)
         {
+            var checkUrls = !string.IsNullOrEmpty(authorize)
+                || !string.IsNullOrEmpty(token)
+                || !string.IsNullOrEmpty(introspection)
+                || !string.IsNullOrEmpty(management)
+                || !string.IsNullOrEmpty(revocation);
             var ext = extensions
                 .Where(x => string.Equals(x[Constants.UrlPropertyName]?.Value<string>(), Constants.SmartOAuthUriExtension, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault();
+            if (!checkUrls)
+            {
+                Assert.Null(ext);
+                return;
+            }
+
             Assert.NotNull(ext);
 
             var urls = ext[Constants.ExtensionPropertyName]?
                 .ToDictionary(x => x[Constants.UrlPropertyName]?.ToString(), x => x[Constants.ValueUriPropertyName]?.ToString());
-            Assert.True(urls.ContainsKey(Constants.SmartOAuthUriExtensionAuthorize));
-            Assert.Contains(
-                urls,
-                x =>
-                {
-                    return string.Equals(x.Key, Constants.SmartOAuthUriExtensionAuthorize, StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(x.Value, authorize, StringComparison.OrdinalIgnoreCase);
-                });
+            if (!string.IsNullOrEmpty(authorize))
+            {
+                Assert.Equal(authorize, urls[Constants.SmartOAuthUriExtensionAuthorize]);
+                Assert.Contains(
+                    urls,
+                    x =>
+                    {
+                        return string.Equals(x.Key, Constants.SmartOAuthUriExtensionAuthorize, StringComparison.OrdinalIgnoreCase)
+                            && string.Equals(x.Value, authorize, StringComparison.OrdinalIgnoreCase);
+                    });
+            }
 
-            Assert.True(urls.ContainsKey(Constants.SmartOAuthUriExtensionToken));
-            Assert.Contains(
-                urls,
-                x =>
-                {
-                    return string.Equals(x.Key, Constants.SmartOAuthUriExtensionToken, StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(x.Value, token, StringComparison.OrdinalIgnoreCase);
-                });
+            if (!string.IsNullOrEmpty(token))
+            {
+                Assert.True(urls.ContainsKey(Constants.SmartOAuthUriExtensionToken));
+                Assert.Contains(
+                    urls,
+                    x =>
+                    {
+                        return string.Equals(x.Key, Constants.SmartOAuthUriExtensionToken, StringComparison.OrdinalIgnoreCase)
+                            && string.Equals(x.Value, token, StringComparison.OrdinalIgnoreCase);
+                    });
+            }
 
             if (!string.IsNullOrEmpty(introspection))
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Security/SecurityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Security/SecurityProvider.cs
@@ -103,10 +103,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
                 ? Constants.RestfulSecurityServiceStu3OAuth
                 : Constants.RestfulSecurityServiceOAuth);
 
-            Uri tokenEndpoint = _urlResolver.ResolveRouteNameUrl(tokenRouteName, null);
-            Uri authorizationEndpoint = _urlResolver.ResolveRouteNameUrl(authorizeRouteName, null);
+            Uri tokenEndpoint = null;
+            Uri authorizationEndpoint = null;
+            if (_urlResolver.CanResolve)
+            {
+                tokenEndpoint = _urlResolver.ResolveRouteNameUrl(tokenRouteName, null);
+                authorizationEndpoint = _urlResolver.ResolveRouteNameUrl(authorizeRouteName, null);
+            }
 
-            var smartExtensions = CreateSmartExtensions(authorizationEndpoint.AbsoluteUri, tokenEndpoint.AbsoluteUri);
+            var smartExtensions = CreateSmartExtensions(authorizationEndpoint?.AbsoluteUri, tokenEndpoint?.AbsoluteUri);
             foreach (var extension in smartExtensions)
             {
                 security.Extension.Add(extension);
@@ -139,7 +144,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
         private List<JObject> CreateSmartExtensions(string authorizationEndpoint, string tokenEndpoint)
         {
             var extensions = new List<JObject>();
-            extensions.Add(GetUrlExtension(authorizationEndpoint, tokenEndpoint));
+            var uriExtension = GetUrlExtension(authorizationEndpoint, tokenEndpoint);
+            if (uriExtension != null)
+            {
+                extensions.Add(uriExtension);
+            }
+
             extensions.AddRange(GetAdditionalCapabilities());
             extensions.AddRange(GetClientCapabilities());
             extensions.AddRange(GetContextCapabilities());
@@ -177,20 +187,26 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
 
         private JObject GetUrlExtension(string authorizationEndpoint, string tokenEndpoint)
         {
-            var urls = new JArray(
-                new JObject[]
-                {
-                    new JObject
+            var urls = new JArray();
+            var authorizeUri = GetAuthorizationEndpoint(authorizationEndpoint);
+            var tokenUri = GetTokenEndpoint(tokenEndpoint);
+            if (!string.IsNullOrEmpty(authorizeUri) && !string.IsNullOrEmpty(tokenUri))
+            {
+                urls.Add(
+                    new JObject[]
                     {
-                        { Constants.UrlPropertyName, Constants.SmartOAuthUriExtensionToken },
-                        { Constants.ValueUriPropertyName, GetTokenEndpoint(tokenEndpoint) },
-                    },
-                    new JObject
-                    {
-                        { Constants.UrlPropertyName, Constants.SmartOAuthUriExtensionAuthorize },
-                        { Constants.ValueUriPropertyName, GetAuthorizationEndpoint(authorizationEndpoint) },
-                    },
-                });
+                        new JObject
+                        {
+                            { Constants.UrlPropertyName, Constants.SmartOAuthUriExtensionToken },
+                            { Constants.ValueUriPropertyName, tokenUri },
+                        },
+                        new JObject
+                        {
+                            { Constants.UrlPropertyName, Constants.SmartOAuthUriExtensionAuthorize },
+                            { Constants.ValueUriPropertyName, authorizeUri },
+                        },
+                    });
+            }
 
             if (!string.IsNullOrEmpty(_smartIdentityProviderConfiguration.Introspection))
             {
@@ -220,6 +236,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
                         { Constants.UrlPropertyName, Constants.SmartOAuthUriExtensionRevocation },
                         { Constants.ValueUriPropertyName, _smartIdentityProviderConfiguration.Revocation },
                     });
+            }
+
+            if (urls.Count == 0)
+            {
+                return null;
             }
 
             return new JObject


### PR DESCRIPTION
## Description
Fixed NullReferenceException in SecurityProvider during background jobs.

Background jobs requesting /metadata before the capability statement cache is built caused a NullReferenceException — SecurityProvider called IUrlResolver.ResolveRouteNameUrl(), which requires an ActionContext that doesn't exist outside the HTTP pipeline.

Added IUrlResolver.CanResolve to check if URL resolution is available. SecurityProvider now skips SMART endpoint URL resolution when CanResolve is false, omitting the OAuth URI extension gracefully. This aligns with SystemConformanceProvider's existing caching strategy: background jobs get a partial capability statement, and the first real HTTP request builds the full version with SMART endpoints.

## Related issues
Addresses [issue #204864].

[Bug 204864](https://microsofthealth.visualstudio.com/Health/_workitems/edit/204864): FHIR incident 836143433: UrlResolver.ResolveRouteNameUrl NullReferenceException when capability statement is built from a background job (EnableAadSmartOnFhirProxy accounts)

## Testing
Tested by manual testing and adding UTs.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
