### PR TITLE
Extend middleware with Inbound Request Logs

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Logging/HttpInboundRequestLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Logging/HttpInboundRequestLogger.cs
@@ -10,6 +10,7 @@ using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Core.Features;
 
 namespace Microsoft.Health.Fhir.Api.Features.Logging
 {
@@ -23,6 +24,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Logging
     /// </remarks>
     public sealed class HttpInboundRequestLogger : IHttpInboundRequestLogger
     {
+        internal const string DurationColumnName = "duration";
+        internal const string HttpHostColumnName = "httpHost";
+        internal const string HttpMethodColumnName = "httpMethod";
+        internal const string HttpPathColumnName = "httpPath";
+        internal const string HttpStatusCodeColumnName = "httpStatusCode";
+        internal const string XCorrelationIdColumnName = "XCorrelationId";
+
         private static readonly EventId RequestCompletedEventId = new EventId(1, "RequestCompleted");
         private static readonly EventId RequestProcessingErrorEventId = new EventId(2, "RequestProcessingError");
 
@@ -56,11 +64,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Logging
 
                 IReadOnlyList<KeyValuePair<string, object>> state =
                 [
-                    new KeyValuePair<string, object>("duration", GetElapsedMilliseconds(context)),
-                    new KeyValuePair<string, object>("httpHost", context.Request?.Host.Value ?? string.Empty),
-                    new KeyValuePair<string, object>("httpMethod", context.Request?.Method ?? string.Empty),
-                    new KeyValuePair<string, object>("httpPath", context.Request?.Path.Value ?? string.Empty),
-                    new KeyValuePair<string, object>("httpStatusCode", httpStatusCode),
+                    new KeyValuePair<string, object>(DurationColumnName, GetElapsedMilliseconds(context)),
+                    new KeyValuePair<string, object>(HttpHostColumnName, context.Request?.Host.Value ?? string.Empty),
+                    new KeyValuePair<string, object>(HttpMethodColumnName, context.Request?.Method ?? string.Empty),
+                    new KeyValuePair<string, object>(HttpPathColumnName, context.Request?.Path.Value ?? string.Empty),
+                    new KeyValuePair<string, object>(HttpStatusCodeColumnName, httpStatusCode),
+                    new KeyValuePair<string, object>(XCorrelationIdColumnName, GetCorrelationId(context)),
                 ];
 
                 _logger.Log(
@@ -75,6 +84,17 @@ namespace Microsoft.Health.Fhir.Api.Features.Logging
                 // Generic catch to intercept any logging errors and avoid breaking the request pipeline. The logger should not throw exceptions.
                 _logger.LogError(e, "An error occurred while logging the HTTP Inbound request.");
             }
+        }
+
+        private static string GetCorrelationId(HttpContext context)
+        {
+            // X-Correlation-ID is not always present in the request headers, so we need to check for its existence before attempting to retrieve it.
+            if (context.Request.Headers.TryGetValue(KnownHeaders.CorrelationId, out var correlationId) && !string.IsNullOrEmpty(correlationId))
+            {
+                return correlationId;
+            }
+
+            return string.Empty;
         }
 
         private static long GetElapsedMilliseconds(HttpContext context)

--- a/src/Microsoft.Health.Fhir.Api/Features/Logging/HttpInboundRequestLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Logging/HttpInboundRequestLogger.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Logging
                 IReadOnlyList<KeyValuePair<string, object>> state =
                 [
                     new KeyValuePair<string, object>("duration", GetElapsedMilliseconds(context)),
-                    new KeyValuePair<string, object>("httpHost", context.Request?.Host.Value ?? string.Empty),
-                    new KeyValuePair<string, object>("httpMethod", context.Request?.Method ?? string.Empty),
-                    new KeyValuePair<string, object>("httpPath", context.Request?.Path.Value ?? string.Empty),
+                    new KeyValuePair<string, object>("httpHost", SanitizeForLog(context.Request?.Host.Value)),
+                    new KeyValuePair<string, object>("httpMethod", SanitizeForLog(context.Request?.Method)),
+                    new KeyValuePair<string, object>("httpPath", SanitizeForLog(context.Request?.Path.Value)),
                     new KeyValuePair<string, object>("httpStatusCode", httpStatusCode),
                 ];
 
@@ -90,6 +90,18 @@ namespace Microsoft.Health.Fhir.Api.Features.Logging
                 : activity.Duration;
 
             return Math.Max(0, (long)duration.TotalMilliseconds);
+        }
+
+        private static string SanitizeForLog(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            return value
+                .Replace("\r", string.Empty, StringComparison.Ordinal)
+                .Replace("\n", string.Empty, StringComparison.Ordinal);
         }
 
         private static string FormatLogMessage(

--- a/src/Microsoft.Health.Fhir.Api/Features/Logging/HttpInboundRequestLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Logging/HttpInboundRequestLogger.cs
@@ -1,0 +1,102 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Health.Fhir.Api.Features.Logging
+{
+    /// <summary>
+    /// Logs an inbound request using the same structured record as the R9 HTTP logging middleware.
+    /// </summary>
+    /// <remarks>
+    /// The Geneva exporter maps this logger's category to the FhirInboundRequestLog table.
+    /// Timestamps, environment, trace, exception, and Kubernetes dimensions are supplied by
+    /// the OpenTelemetry logging pipeline.
+    /// </remarks>
+    public sealed class HttpInboundRequestLogger : IHttpInboundRequestLogger
+    {
+        private static readonly EventId RequestCompletedEventId = new EventId(1, "RequestCompleted");
+        private static readonly EventId RequestProcessingErrorEventId = new EventId(2, "RequestProcessingError");
+
+        private readonly ILogger<HttpInboundRequestLogger> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpInboundRequestLogger"/> class.
+        /// </summary>
+        /// <param name="logger">The logger that emits entries under the request logger category.</param>
+        public HttpInboundRequestLogger(ILogger<HttpInboundRequestLogger> logger)
+        {
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+        }
+
+        /// <summary>
+        /// Logs the current HTTP request and response dimensions.
+        /// </summary>
+        /// <remarks>
+        /// Call this method after assigning the final response status on a terminal middleware
+        /// branch that will not reach the R9 HTTP logging middleware.
+        /// </remarks>
+        /// <param name="context">The HTTP context to log.</param>
+        /// <param name="exception">The exception associated with the request, if any.</param>
+        public void LogRequest(HttpContext context, Exception exception = null)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            try
+            {
+                int httpStatusCode = context.Response?.StatusCode ?? 0;
+
+                IReadOnlyList<KeyValuePair<string, object>> state =
+                [
+                    new KeyValuePair<string, object>("duration", GetElapsedMilliseconds(context)),
+                    new KeyValuePair<string, object>("httpHost", context.Request?.Host.Value ?? string.Empty),
+                    new KeyValuePair<string, object>("httpMethod", context.Request?.Method ?? string.Empty),
+                    new KeyValuePair<string, object>("httpPath", context.Request?.Path.Value ?? string.Empty),
+                    new KeyValuePair<string, object>("httpStatusCode", httpStatusCode),
+                ];
+
+                _logger.Log(
+                    httpStatusCode >= 500 && exception != null ? LogLevel.Error : LogLevel.Information,
+                    exception != null ? RequestProcessingErrorEventId : RequestCompletedEventId,
+                    state,
+                    exception,
+                    FormatLogMessage);
+            }
+            catch (Exception e)
+            {
+                // Generic catch to intercept any logging errors and avoid breaking the request pipeline. The logger should not throw exceptions.
+                _logger.LogError(e, "An error occurred while logging the HTTP Inbound request.");
+            }
+        }
+
+        private static long GetElapsedMilliseconds(HttpContext context)
+        {
+            Activity activity = context.Features.Get<IHttpActivityFeature>()?.Activity;
+            if (activity is null)
+            {
+                return 0;
+            }
+
+            TimeSpan duration = activity.Duration == TimeSpan.Zero
+                ? DateTime.UtcNow - activity.StartTimeUtc
+                : activity.Duration;
+
+            return Math.Max(0, (long)duration.TotalMilliseconds);
+        }
+
+        private static string FormatLogMessage(
+            IReadOnlyList<KeyValuePair<string, object>> state,
+            Exception exception)
+        {
+            return exception is null ? string.Empty : "HTTP request processing failed.";
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Logging/IHttpInboundRequestLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Logging/IHttpInboundRequestLogger.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Health.Fhir.Api.Features.Logging
+{
+    public interface IHttpInboundRequestLogger
+    {
+        void LogRequest(HttpContext context, Exception exception = null);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/RuntimeState/RuntimeStateMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/RuntimeState/RuntimeStateMiddleware.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Api.Features.ContentTypes;
+using Microsoft.Health.Fhir.Api.Features.Logging;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Registration;
 using Newtonsoft.Json.Linq;
@@ -27,6 +28,7 @@ namespace Microsoft.Health.Fhir.Api.Features.RuntimeState
 
         private readonly RequestDelegate _next;
         private readonly IFhirRuntimeConfiguration _runtimeConfiguration;
+        private readonly IHttpInboundRequestLogger _inboundRequestLogger;
         private readonly ILogger<RuntimeStateMiddleware> _logger;
 
         /// <summary>
@@ -34,11 +36,17 @@ namespace Microsoft.Health.Fhir.Api.Features.RuntimeState
         /// </summary>
         /// <param name="next">The next request delegate.</param>
         /// <param name="runtimeConfiguration">The effective FHIR runtime configuration.</param>
+        /// <param name="inboundRequestLogger">The inbound request logger.</param>
         /// <param name="logger">Logger.</param>
-        public RuntimeStateMiddleware(RequestDelegate next, IFhirRuntimeConfiguration runtimeConfiguration, ILogger<RuntimeStateMiddleware> logger)
+        public RuntimeStateMiddleware(
+            RequestDelegate next,
+            IFhirRuntimeConfiguration runtimeConfiguration,
+            IHttpInboundRequestLogger inboundRequestLogger,
+            ILogger<RuntimeStateMiddleware> logger)
         {
             _next = EnsureArg.IsNotNull(next, nameof(next));
             _runtimeConfiguration = EnsureArg.IsNotNull(runtimeConfiguration, nameof(runtimeConfiguration));
+            _inboundRequestLogger = EnsureArg.IsNotNull(inboundRequestLogger, nameof(inboundRequestLogger));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
@@ -72,16 +80,21 @@ namespace Microsoft.Health.Fhir.Api.Features.RuntimeState
             const int MaximumRejectionDelayMilliseconds = 150;
 
             int delayMilliseconds = RandomNumberGenerator.GetInt32(MinimumRejectionDelayMilliseconds, MaximumRejectionDelayMilliseconds + 1);
-            await Task.Delay(delayMilliseconds, context.RequestAborted);
+
+            // Task.Delay does not use context.RequestAborted to avoid the risk of a client aborting the request and raising a different error.
+            await Task.Delay(delayMilliseconds);
         }
 
-        private static async Task WriteBlockingResponseAsync(HttpContext context)
+        private async Task WriteBlockingResponseAsync(HttpContext context)
         {
             context.Response.StatusCode = StatusCodes.Status410Gone;
             context.Response.ContentType = KnownContentTypes.JsonContentType;
             context.Response.ContentLength = _deprecatedServiceResponse.Length;
 
-            await context.Response.Body.WriteAsync(_deprecatedServiceResponse, context.RequestAborted);
+            _inboundRequestLogger.LogRequest(context);
+
+            // Task.Delay does not use context.RequestAborted to avoid the risk of a client aborting the request and raising a different error.
+            await context.Response.Body.WriteAsync(_deprecatedServiceResponse);
         }
 
         private static bool IsAllowedRequest(HttpRequest request)

--- a/src/Microsoft.Health.Fhir.Api/Features/RuntimeState/RuntimeStateMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/RuntimeState/RuntimeStateMiddleware.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Api.Features.RuntimeState
 
             int delayMilliseconds = RandomNumberGenerator.GetInt32(MinimumRejectionDelayMilliseconds, MaximumRejectionDelayMilliseconds + 1);
 
-            // Task.Delay does not use context.RequestAborted to avoid the risk of a client aborting the request and raising a different error.
+            // No use of context.RequestAborted to avoid the risk of a client aborting the request and raising a different error.
             await Task.Delay(delayMilliseconds);
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.Api.Features.RuntimeState
 
             _inboundRequestLogger.LogRequest(context);
 
-            // Task.Delay does not use context.RequestAborted to avoid the risk of a client aborting the request and raising a different error.
+            // No use of context.RequestAborted to avoid the risk of a client aborting the request and raising a different error.
             await context.Response.Body.WriteAsync(_deprecatedServiceResponse);
         }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -16,8 +16,8 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Headers;
+using Microsoft.Health.Fhir.Api.Features.Logging;
 using Microsoft.Health.Fhir.Core.Configs;
-using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 
@@ -43,6 +43,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
         private static readonly ReadOnlyMemory<byte> _throttledBody = CreateThrottledBody(Api.Resources.TooManyConcurrentRequests);
 
         private readonly RequestDelegate _next;
+        private readonly IHttpInboundRequestLogger _inboundRequestLogger;
         private readonly ILogger<ThrottlingMiddleware> _logger;
         private readonly HashSet<(string method, string path)> _excludedEndpoints;
         private readonly bool _securityEnabled;
@@ -63,9 +64,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             RequestDelegate next,
             IOptions<ThrottlingConfiguration> throttlingConfiguration,
             IOptions<SecurityConfiguration> securityConfiguration,
+            IHttpInboundRequestLogger inboundRequestLogger,
             ILogger<ThrottlingMiddleware> logger)
         {
             _next = EnsureArg.IsNotNull(next, nameof(next));
+            _inboundRequestLogger = EnsureArg.IsNotNull(inboundRequestLogger, nameof(inboundRequestLogger));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             ThrottlingConfiguration configuration = EnsureArg.IsNotNull(throttlingConfiguration?.Value, nameof(throttlingConfiguration));
             EnsureArg.IsNotNull(securityConfiguration?.Value, nameof(securityConfiguration));
@@ -293,6 +296,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             context.Response.ContentLength = _throttledBody.Length;
             context.Response.ContentType = ThrottledContentType;
 
+            _inboundRequestLogger.LogRequest(context);
+
             await context.Response.Body.WriteAsync(_throttledBody);
         }
 
@@ -308,6 +313,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
             context.Response.ContentLength = body.Length;
             context.Response.ContentType = ThrottledContentType;
+
+            _inboundRequestLogger.LogRequest(context, exception: exception);
 
             await context.Response.Body.WriteAsync(body);
         }

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             context.Response.ContentLength = body.Length;
             context.Response.ContentType = ThrottledContentType;
 
-            _inboundRequestLogger.LogRequest(context, exception: exception);
+            _inboundRequestLogger.LogRequest(context);
 
             await context.Response.Body.WriteAsync(body);
         }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/RuntimeStateConfigurationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/RuntimeStateConfigurationExtensions.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using EnsureThat;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Registration;
@@ -22,6 +23,8 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// <remarks>Active is assumed as the default runtime state for invalid inputs.</remarks>
         public static FhirRuntimeState GetRuntimeStateConfiguration(IConfiguration configuration)
         {
+            EnsureArg.IsNotNull(configuration, nameof(configuration));
+
             string configuredRuntimeState = configuration[RuntimeStateConfigurationKey];
 
             return ParseRuntimeStateConfiguration(configuredRuntimeState);

--- a/src/Microsoft.Health.Fhir.Core/Logging/LongRunningOperationStatistics.cs
+++ b/src/Microsoft.Health.Fhir.Core/Logging/LongRunningOperationStatistics.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading;
 using EnsureThat;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Logging/HttpInboundRequestLoggerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Logging/HttpInboundRequestLoggerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Api.Features.Logging;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
 using Xunit;
@@ -21,6 +22,20 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Logging
     public class HttpInboundRequestLoggerTests
     {
         /// <summary>
+        /// Verifies that the logging constants in the logger are in sync with the test.
+        /// </summary>
+        [Fact]
+        public void EnsureThatLoggingConstantsAreInSyncWithLogger()
+        {
+            Assert.Equal(HttpInboundRequestLogger.DurationColumnName, "duration");
+            Assert.Equal(HttpInboundRequestLogger.HttpHostColumnName, "httpHost");
+            Assert.Equal(HttpInboundRequestLogger.HttpMethodColumnName, "httpMethod");
+            Assert.Equal(HttpInboundRequestLogger.HttpPathColumnName, "httpPath");
+            Assert.Equal(HttpInboundRequestLogger.HttpStatusCodeColumnName, "httpStatusCode");
+            Assert.Equal(HttpInboundRequestLogger.XCorrelationIdColumnName, "XCorrelationId");
+        }
+
+        /// <summary>
         /// Verifies that a completed request contains only the selected HTTP dimensions.
         /// </summary>
         [Fact]
@@ -29,9 +44,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Logging
             var innerLogger = new CapturingLogger();
             var inboundRequestLogger = new HttpInboundRequestLogger(innerLogger);
             var context = new DefaultHttpContext();
+
+            // Request
             context.Request.Host = new HostString("fhir.example.com");
             context.Request.Method = HttpMethods.Post;
             context.Request.Path = "/Patient";
+            context.Request.Headers[KnownHeaders.CorrelationId] = "correlation-id";
+
+            // Response
             context.Response.StatusCode = StatusCodes.Status201Created;
 
             inboundRequestLogger.LogRequest(context);
@@ -46,6 +66,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Logging
                     ["httpMethod"] = HttpMethods.Post,
                     ["httpPath"] = "/Patient",
                     ["httpStatusCode"] = StatusCodes.Status201Created,
+                    ["XCorrelationId"] = "correlation-id",
                 },
                 innerLogger.State);
         }
@@ -64,7 +85,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Logging
             var innerLogger = new CapturingLogger();
             var inboundRequestLogger = new HttpInboundRequestLogger(innerLogger);
             var context = new DefaultHttpContext();
+
+            // Request
+            context.Request.Headers[KnownHeaders.RequestId] = "request-id";
+            context.Request.Headers[KnownHeaders.CorrelationId] = "correlation-id";
+
+            // Response
             context.Response.StatusCode = responseStatusCode;
+
             var exception = new InvalidOperationException("Request failed");
 
             inboundRequestLogger.LogRequest(context, exception: exception);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Logging/HttpInboundRequestLoggerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Logging/HttpInboundRequestLoggerTests.cs
@@ -1,0 +1,128 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Api.Features.Logging;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Logging
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.ServiceRuntimeState)]
+    [Trait(Traits.Category, Categories.Throttling)]
+    [Trait(Traits.Category, Categories.Web)]
+    public class HttpInboundRequestLoggerTests
+    {
+        /// <summary>
+        /// Verifies that a completed request contains only the selected HTTP dimensions.
+        /// </summary>
+        [Fact]
+        public void GivenHttpContext_WhenLoggingRequest_ThenSelectedRequestDimensionsAreLogged()
+        {
+            var innerLogger = new CapturingLogger();
+            var inboundRequestLogger = new HttpInboundRequestLogger(innerLogger);
+            var context = new DefaultHttpContext();
+            context.Request.Host = new HostString("fhir.example.com");
+            context.Request.Method = HttpMethods.Post;
+            context.Request.Path = "/Patient";
+            context.Response.StatusCode = StatusCodes.Status201Created;
+
+            inboundRequestLogger.LogRequest(context);
+
+            Assert.Equal(LogLevel.Information, innerLogger.LogLevel);
+            Assert.Null(innerLogger.Exception);
+            Assert.Equal(
+                new Dictionary<string, object>
+                {
+                    ["duration"] = 0L,
+                    ["httpHost"] = "fhir.example.com",
+                    ["httpMethod"] = HttpMethods.Post,
+                    ["httpPath"] = "/Patient",
+                    ["httpStatusCode"] = StatusCodes.Status201Created,
+                },
+                innerLogger.State);
+        }
+
+        /// <summary>
+        /// Verifies that an exception is attached and changes a success status to 500.
+        /// </summary>
+        [Theory]
+        [InlineData(StatusCodes.Status200OK, StatusCodes.Status200OK)]
+        [InlineData(StatusCodes.Status403Forbidden, StatusCodes.Status403Forbidden)]
+        [InlineData(StatusCodes.Status503ServiceUnavailable, StatusCodes.Status503ServiceUnavailable)]
+        public void GivenException_WhenLoggingRequest_ThenProcessingErrorStatusIsNormalized(
+            int responseStatusCode,
+            int expectedLogStatusCode)
+        {
+            var innerLogger = new CapturingLogger();
+            var inboundRequestLogger = new HttpInboundRequestLogger(innerLogger);
+            var context = new DefaultHttpContext();
+            context.Response.StatusCode = responseStatusCode;
+            var exception = new InvalidOperationException("Request failed");
+
+            inboundRequestLogger.LogRequest(context, exception: exception);
+
+            if (responseStatusCode >= 500 && exception != null)
+            {
+                Assert.Equal(LogLevel.Error, innerLogger.LogLevel);
+            }
+            else
+            {
+                Assert.Equal(LogLevel.Information, innerLogger.LogLevel);
+            }
+
+            Assert.Same(exception, innerLogger.Exception);
+            Assert.Equal(expectedLogStatusCode, innerLogger.State["httpStatusCode"]);
+        }
+
+        private sealed class CapturingLogger : ILogger<HttpInboundRequestLogger>
+        {
+            public LogLevel LogLevel { get; private set; }
+
+            public Exception Exception { get; private set; }
+
+            public IReadOnlyDictionary<string, object> State { get; private set; }
+
+            public IDisposable BeginScope<TState>(TState state)
+                where TState : notnull
+            {
+                return null;
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                LogLevel = logLevel;
+                Exception = exception;
+
+                var stateDictionary = new Dictionary<string, object>();
+
+                if (state is IEnumerable<KeyValuePair<string, object>> convertedState)
+                {
+                    foreach (var item in convertedState)
+                    {
+                        stateDictionary.Add(item.Key, item.Value);
+                    }
+                }
+
+                State = stateDictionary;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/RuntimeState/RuntimeStateMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/RuntimeState/RuntimeStateMiddlewareTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Api.Features.ContentTypes;
+using Microsoft.Health.Fhir.Api.Features.Logging;
 using Microsoft.Health.Fhir.Api.Features.RuntimeState;
 using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -135,9 +136,11 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.RuntimeState
             IFhirRuntimeConfiguration configuration = Substitute.For<IFhirRuntimeConfiguration>();
             configuration.RuntimeState.Returns(runtimeState);
 
+            IHttpInboundRequestLogger inboundRequestLogger = Substitute.For<IHttpInboundRequestLogger>();
+
             ILogger<RuntimeStateMiddleware> logger = Substitute.For<ILogger<RuntimeStateMiddleware>>();
 
-            return new RuntimeStateMiddleware(next, configuration, logger);
+            return new RuntimeStateMiddleware(next, configuration, inboundRequestLogger, logger);
         }
 
         private static DefaultHttpContext CreateContext(string method, string path)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Api.Features.Logging;
 using Microsoft.Health.Fhir.Api.Features.Throttling;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -61,6 +62,8 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
 
             _throttlingConfiguration.ExcludedEndpoints.Add(new ExcludedEndpoint { Method = "get", Path = "/health/check" });
 
+            IHttpInboundRequestLogger inboundRequestLogger = Substitute.For<IHttpInboundRequestLogger>();
+
             _middleware = new Lazy<ThrottlingMiddleware>(
                 () => new ThrottlingMiddleware(
                     async x =>
@@ -86,6 +89,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
                     },
                     Options.Create(_throttlingConfiguration),
                     Options.Create(new SecurityConfiguration { Enabled = _securityEnabled }),
+                    inboundRequestLogger,
                     NullLogger<ThrottlingMiddleware>.Instance));
 
             IActionResultExecutor<ObjectResult> executor = Substitute.For<IActionResultExecutor<ObjectResult>>();
@@ -259,10 +263,12 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
         public async Task GivenARequest_ThatResultsInRequestRateExceeded_Returns429(int numberOfConcurrentRequests)
         {
             _throttlingConfiguration.ConcurrentRequestLimit = numberOfConcurrentRequests - 1;
+            IHttpInboundRequestLogger inboundRequestLogger = Substitute.For<IHttpInboundRequestLogger>();
             var throttlingMiddleware = new ThrottlingMiddleware(
                 context => throw new RequestRateExceededException(TimeSpan.FromSeconds(1)),
                 Options.Create(_throttlingConfiguration),
                 Options.Create(new SecurityConfiguration()),
+                inboundRequestLogger,
                 NullLogger<ThrottlingMiddleware>.Instance);
 
             await throttlingMiddleware.Invoke(_httpContext);
@@ -278,10 +284,12 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
         public async Task GivenARequest_ThatResultsInRequestRateExceeded_ReturnsValidFhirResource(int numberOfConcurrentRequests)
         {
             _throttlingConfiguration.ConcurrentRequestLimit = numberOfConcurrentRequests - 1;
+            IHttpInboundRequestLogger inboundRequestLogger = Substitute.For<IHttpInboundRequestLogger>();
             var throttlingMiddleware = new ThrottlingMiddleware(
                 context => throw new RequestRateExceededException(TimeSpan.FromSeconds(1)),
                 Options.Create(_throttlingConfiguration),
                 Options.Create(new SecurityConfiguration()),
+                inboundRequestLogger,
                 NullLogger<ThrottlingMiddleware>.Instance);
 
             _httpContext.Response.Body = new MemoryStream();

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -75,6 +75,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\FhirResultExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Health\ImproperBehaviorHealthCheckTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Health\StorageInitializedHealthCheckTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Logging\HttpInboundRequestLoggerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Metrics\AuthenticationFailureExceptionMetricEmissionFilterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Metrics\SecurityAbuseExceptionMetricEmissionFilterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\MediationModuleTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ using Microsoft.Health.Fhir.Api.Features.BackgroundJobService;
 using Microsoft.Health.Fhir.Api.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.ExceptionNotifications;
 using Microsoft.Health.Fhir.Api.Features.Exceptions;
+using Microsoft.Health.Fhir.Api.Features.Logging;
 using Microsoft.Health.Fhir.Api.Features.Metrics;
 using Microsoft.Health.Fhir.Api.Features.Operations.Import;
 using Microsoft.Health.Fhir.Api.Features.Routing;
-using Microsoft.Health.Fhir.Api.Features.RuntimeState;
 using Microsoft.Health.Fhir.Api.Features.Security;
 using Microsoft.Health.Fhir.Api.Features.Throttling;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -126,6 +126,11 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ArtifactStore));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ImplementationGuides));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ImplementationGuides.USCore));
+
+            // Extended HTTP Inbound Request logging for FHIR server.
+            services.AddSingleton<IHttpInboundRequestLogger, HttpInboundRequestLogger>();
+
+            // IStartupFilter registering.
             services.AddTransient<IStartupFilter, FhirServerStartupFilter>((x) => new FhirServerStartupFilter(fhirServerConfiguration));
 
             // Register global instance configuration for storing base URI and instance ID

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.BackgroundJobService;
+using Microsoft.Health.Fhir.Api.Features.Logging;
 using Microsoft.Health.Fhir.Api.Modules;
 using Microsoft.Health.Fhir.Api.OpenIddict.Extensions;
 using Microsoft.Health.Fhir.Api.OpenIddict.FeatureProviders;
@@ -355,6 +356,8 @@ namespace Microsoft.Health.Fhir.Web
                     Startup.AddAzureMonitorOpenTelemetry(services, configuration);
                     break;
             }
+
+            services.AddSingleton<IHttpInboundRequestLogger, HttpInboundRequestLogger>();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.BackgroundJobService;
-using Microsoft.Health.Fhir.Api.Features.Logging;
 using Microsoft.Health.Fhir.Api.Modules;
 using Microsoft.Health.Fhir.Api.OpenIddict.Extensions;
 using Microsoft.Health.Fhir.Api.OpenIddict.FeatureProviders;
@@ -356,8 +355,6 @@ namespace Microsoft.Health.Fhir.Web
                     Startup.AddAzureMonitorOpenTelemetry(services, configuration);
                     break;
             }
-
-            services.AddSingleton<IHttpInboundRequestLogger, HttpInboundRequestLogger>();
         }
     }
 }


### PR DESCRIPTION
Extend middleware with Inbound Request Logs

## Related issues
Addresses [AB#204637](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/204637).

## Testing
Tested these changes with unit and ad-hoc tests. 

## FHIR Team Checklist
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
