### PR TITLE
Extract shared collection definitions and add unit test manifest guard

### DIFF
--- a/build/jobs/scripts/Assert-UnitTestProjectsDiscovered.ps1
+++ b/build/jobs/scripts/Assert-UnitTestProjectsDiscovered.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Fails when the unit test leg's project glob matches fewer projects than expected.
+
+.DESCRIPTION
+    The unit test leg does not name its projects: it runs whatever '**/*UnitTests/*.csproj'
+    matches. Every other leg guards against running a fraction of its tests by counting the tests
+    a filter discovers, but that shape does not fit here, because this leg's failure is a whole
+    project leaving the glob - renamed, moved, or a directory suffix quietly changed - rather than
+    a filter selecting too little. Nothing notices: the remaining projects run, every one of them
+    passes, and the leg reports success with an entire assembly's tests missing.
+
+    --minimum-expected-tests cannot cover this either. It is applied per assembly, so it says
+    nothing about an assembly that was never run, and it has to stay at 1 because the runner
+    re-applies it to the much smaller pass that --retry-failed-tests starts.
+
+    Each expected project is checked by path rather than by counting them, because a count only
+    notices projects leaving while none arrive: renaming one project and adding another in the same
+    change leaves the count where it was, and the renamed project stops being tested silently.
+
+    Adding projects is fine; only losing one that is listed fails.
+
+.PARAMETER SourcesDirectory
+    The repository root to search.
+
+.PARAMETER ManifestPath
+    The file listing the repository-relative path of every project this leg is expected to run.
+#>
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $SourcesDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ManifestPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $SourcesDirectory)) {
+    throw "Sources directory '$SourcesDirectory' does not exist."
+}
+
+if (-not (Test-Path -LiteralPath $ManifestPath)) {
+    throw "The expected project list '$ManifestPath' does not exist, so there is nothing to check the leg's projects against."
+}
+
+$expected = @(
+    Get-Content -LiteralPath $ManifestPath |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -and -not $_.StartsWith('#') })
+
+if ($expected.Count -eq 0) {
+    throw "The expected project list '$ManifestPath' names no projects, so it would accept a leg that ran nothing."
+}
+
+$root = (Resolve-Path -LiteralPath $SourcesDirectory).Path.TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+
+# Mirrors the 'projects' pattern of the leg's test task: any .csproj in a directory whose name
+# ends in UnitTests.
+$matched = @(
+    Get-ChildItem -LiteralPath $root -Recurse -Filter '*.csproj' -File |
+        Where-Object { $_.Directory.Name -like '*UnitTests' } |
+        ForEach-Object { $_.FullName.Substring($root.Length + 1).Replace([System.IO.Path]::DirectorySeparatorChar, '/') } |
+        Sort-Object)
+
+# Paths are compared without regard to case because the repository is developed on Windows and
+# built on Linux, and a case-only difference is not a project leaving the leg.
+$comparer = [System.StringComparer]::OrdinalIgnoreCase
+$matchedSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$matched, $comparer)
+$expectedSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$expected, $comparer)
+
+Write-Host "Matched $($matched.Count) unit test project(s) against $($expected.Count) expected:"
+foreach ($project in $matched) {
+    Write-Host "  $project"
+}
+
+$missing = @($expected | Where-Object { -not $matchedSet.Contains($_) })
+
+if ($missing.Count -gt 0) {
+    $detail = ($missing | ForEach-Object { "  $_" }) -join [Environment]::NewLine
+    throw @"
+These projects are expected to run in the unit test leg but no longer match its project glob:
+$detail
+
+The leg runs whatever the glob matches, so it would have run without them and reported success. If
+a project was renamed or moved on purpose, update '$ManifestPath' to say so.
+"@
+}
+
+$unlisted = @($matched | Where-Object { -not $expectedSet.Contains($_) })
+
+if ($unlisted.Count -gt 0) {
+    # An unlisted project still runs. Naming it here is what keeps the list from drifting so far
+    # behind that a later loss is hard to tell from a rename.
+    Write-Host "These projects run in this leg but are not listed in '$ManifestPath':"
+    foreach ($project in $unlisted) {
+        Write-Host "  $project"
+    }
+}

--- a/build/jobs/scripts/UnitTestProjects.txt
+++ b/build/jobs/scripts/UnitTestProjects.txt
@@ -1,0 +1,29 @@
+# The unit test leg runs whatever '**/*UnitTests/*.csproj' matches, so a project that leaves the
+# glob - renamed, moved, or its directory suffix quietly changed - stops being tested without
+# anything failing. This is the list of projects that leg is expected to run, checked against what
+# the glob actually matches before the tests start.
+#
+# Paths are relative to the repository root and use forward slashes. Adding a project here is not
+# required for it to run, but a project listed here that no longer matches fails the leg.
+#
+# Microsoft.Health.Fhir.Api.UnitTests holds a project named for R4; the directory and the project
+# names differ, which is why it does not look like the rest.
+src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
+src/Microsoft.Health.Fhir.Azure.UnitTests/Microsoft.Health.Fhir.Azure.UnitTests.csproj
+src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
+src/Microsoft.Health.Fhir.CosmosDb.Initialization.UnitTests/Microsoft.Health.Fhir.CosmosDb.Initialization.UnitTests.csproj
+src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
+src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
+src/Microsoft.Health.Fhir.R4.Web.UnitTests/Microsoft.Health.Fhir.R4.Web.UnitTests.csproj
+src/Microsoft.Health.Fhir.R4B.Api.UnitTests/Microsoft.Health.Fhir.R4B.Api.UnitTests.csproj
+src/Microsoft.Health.Fhir.R4B.Core.UnitTests/Microsoft.Health.Fhir.R4B.Core.UnitTests.csproj
+src/Microsoft.Health.Fhir.R4B.Web.UnitTests/Microsoft.Health.Fhir.R4B.Web.UnitTests.csproj
+src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
+src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
+src/Microsoft.Health.Fhir.R5.Web.UnitTests/Microsoft.Health.Fhir.R5.Web.UnitTests.csproj
+src/Microsoft.Health.Fhir.SchemaManager.UnitTests/Microsoft.Health.Fhir.SchemaManager.UnitTests.csproj
+src/Microsoft.Health.Fhir.SqlServer.UnitTests/Microsoft.Health.Fhir.SqlServer.UnitTests.csproj
+src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
+src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
+src/Microsoft.Health.Fhir.Stu3.Web.UnitTests/Microsoft.Health.Fhir.Stu3.Web.UnitTests.csproj
+src/Microsoft.Health.TaskManagement.UnitTests/Microsoft.Health.TaskManagement.UnitTests.csproj

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/CustomQueriesTestsCollection.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/CustomQueriesTestsCollection.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
+{
+    /// <summary>
+    /// Disables parallelization for CustomQueries tests due to shared static state.
+    /// </summary>
+    [CollectionDefinition("CustomQueriesTests", DisableParallelization = true)]
+    public sealed class CustomQueriesTestsCollection
+    {
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/CustomQueriesUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/CustomQueriesUnitTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
+    [Collection("CustomQueriesTests")]
     public class CustomQueriesUnitTests
     {
         [Fact]

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
+    [Collection(ModelInfoProviderCollection.Name)]
     public class ScalarTemporalEqualityRewriterTests : IClassFixture<ModelInfoProviderFixture>
     {
         private static readonly DateTimeOffset StartOfDay = new DateTimeOffset(2016, 7, 6, 0, 0, 0, TimeSpan.Zero);

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/Visitors/QueryGenerators/CompartmentQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/Visitors/QueryGenerators/CompartmentQueryGeneratorTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions.
     /// </summary>
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
+    [Collection(ModelInfoProviderCollection.Name)]
     public class CompartmentQueryGeneratorTests : IClassFixture<ModelInfoProviderFixture>
     {
         private readonly ISqlServerFhirModel _model;

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.DataSourceValidation)]
+    [Collection(ModelInfoProviderCollection.Name)]
     public class SqlServerFhirDataStoreUnitTests
     {
         public static IEnumerable<object[]> RemoveTrailingZerosTestCases()

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/ModelInfoProviderCollection.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/ModelInfoProviderCollection.cs
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests
+{
+    /// <summary>
+    /// Serializes the test classes that read or write the process-global <c>ModelInfoProvider</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>ModelInfoProvider</c> is a plain static, so a class that replaces it races any class that
+    /// is relying on it. Concretely, <c>SqlServerFhirDataStoreUnitTests</c> installs a provider that
+    /// knows only the <c>Group</c> resource type and no compartments, while
+    /// <c>CompartmentQueryGeneratorTests</c> and <c>ScalarTemporalEqualityRewriterTests</c> need the
+    /// compartment-aware provider their class fixture installs. When those run concurrently the
+    /// compartment tests fail with "Expected an expression that evaluates to true", and which tests
+    /// fail varies from run to run.
+    ///
+    /// A class fixture cannot fix this, because it only orders the classes that share it and does
+    /// nothing about a third class overwriting the same static. Sharing one collection is what
+    /// actually serializes them: xUnit runs the classes within a collection one after another.
+    /// <c>DisableParallelization</c> additionally keeps the collection from overlapping other
+    /// collections, so a future class that touches the provider cannot reintroduce the race without
+    /// also being added here.
+    ///
+    /// The race is latent rather than new, but xUnit v3 schedules these classes concurrently where
+    /// v2 did not, so the migration is what makes it reproduce.
+    /// </remarks>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class ModelInfoProviderCollection
+    {
+        /// <summary>
+        /// The collection name to put on every test class that reads or writes the global provider.
+        /// </summary>
+        public const string Name = "ModelInfoProviderTests";
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
@@ -82,6 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\HttpIntegrationTestFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\HttpIntegrationTestFixture{TStartup}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ExceptionTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\IndexAndReindexCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\InProcTestFhirServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\MetadataTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Metric\MetricHandler.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/IndexAndReindexCollection.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/IndexAndReindexCollection.cs
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Tests.Common;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// Serialises the test classes that add, reindex, or delete search parameters, which share the
+    /// server's search parameter registry and cannot run alongside each other.
+    /// </summary>
+    /// <remarks>
+    /// This class deliberately carries no traits. xunit v3 puts a collection's traits on the tests of
+    /// every class in the collection, so a category declared here would be inherited by every member
+    /// - including members that only joined to be serialised. CI legs that exclude a category would
+    /// then skip those members as well, and an exclusion filter reports success for what it did not
+    /// select, so nothing in the leg's output would say the tests were dropped. Categories therefore
+    /// belong on the individual test classes, never here.
+    /// </remarks>
+    [CollectionDefinition(Categories.IndexAndReindex, DisableParallelization = true)]
+    public class IndexAndReindexCollection
+    {
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -36,7 +36,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 {
-    [CollectionDefinition(Categories.IndexAndReindex, DisableParallelization = true)]
+    [Collection(Categories.IndexAndReindex)]
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.IndexAndReindex)]
     [Trait(Traits.Category, Categories.ReindexOperation)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -25,7 +25,6 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    [CollectionDefinition(Categories.IndexAndReindex, DisableParallelization = true)]
     [Collection(Categories.IndexAndReindex)]
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]


### PR DESCRIPTION
## Description

Preparatory refactor ahead of the xUnit v2 → v3 migration. **Everything here is inert on xUnit v2** — it is split out so the migration itself reviews as a single mechanical change.

This is the **bottom layer of a 3-PR stack**:

| Layer | Contents | Status |
|---|---|---|
| **1 (this PR)** | Shared collection definitions + unit test project manifest guard | ← you are here |
| 2 | Core migration: `Extensions.Xunit` rewrite, CPM/props switch, ~109 test sources, 27 csproj, Tests.Common guards, **CI pipeline YAML** | #5758 |
| 3 | `Extensions.Xunit.UnitTests` harness + `.TestAssets` | follows |

Layer 2 is irreducible: `Directory.Packages.props` deletes the xUnit v2 package versions globally under Central Package Management, `Directory.Build.props` fans the MTP references out to every project matching `Contains('Test')`, and `Microsoft.Health.Extensions.Xunit` binds a single xUnit major that every test project references. Those three jointly force one atomic flip, which is why this prep layer contains only changes that are already correct on v2. The CI pipeline YAML rides with layer 2 for a related reason: `main` already runs xUnit v2 under Microsoft Testing Platform via the `YTest.MTP.XUnit2` shim, which accepts VSTest-style `--filter`, whereas xUnit v3's MTP requires `--filter-query`. Swapping the shim without flipping the YAML would leave every integration and E2E leg selecting nothing.

### Collection definitions

Collection definitions are moved out of the test classes that declared them, onto dedicated trait-free definition classes:

- **`ModelInfoProviderCollection`** — serialises the SqlServer unit test classes that read or write the process-global `ModelInfoProvider`. A class fixture only orders the classes that share it, so it cannot stop a third class overwriting the same static; one shared collection can.
- **`CustomQueriesTestsCollection`** — serialises the CustomQueries tests, which share static state.
- **`IndexAndReindexCollection`** — replaces the duplicate `[CollectionDefinition]` that `ReindexTests` and `CustomSearchParamTests` *each* declared for the same collection name. The definition deliberately carries **no traits**: a trait on a shared definition is inherited by every member of the collection, and a CI leg filtering that category out would silently drop members that only joined to be serialised.

### Manifest guard

Adds `build/jobs/scripts/Assert-UnitTestProjectsDiscovered.ps1` and its manifest. The unit test leg runs whatever `**/*UnitTests/*.csproj` matches, so a project that leaves the glob — renamed, moved, or its directory suffix quietly changed — stops being tested without anything failing. The script checks the glob against the manifest before the tests start.

It is **not wired into the pipeline yet**; the YAML that calls it lands with the migration. Its automated tests live in the harness project in layer 3, so this script ships here without them.

## Related issues

Addresses [AB#189958](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/189958).

## Testing

Verified by execution on the unmodified v2 tree:

- `Microsoft.Health.Fhir.SqlServer.UnitTests` — **1053 passed / 0 failed, both with and without this change**, confirming the collection extraction is a true no-op (identical totals rule out silently-dropped tests).
- `Assert-UnitTestProjectsDiscovered.ps1` — prints `Matched 19 unit test project(s) against 19 expected`, exit code 0. The manifest reads 19 here and goes to 20 in layer 3, when the harness project exists.
- `Microsoft.Health.Fhir.R4.Tests.E2E` — compiles clean (0 warnings, 0 errors) with `IndexAndReindexCollection.cs` explicitly registered in `Microsoft.Health.Fhir.Shared.Tests.E2E.projitems`, so the new shared file genuinely compiles into consumers rather than being silently skipped.

Note: `dotnet build` of the E2E projects trips the repo's `VerifyExactSdkVersion` target locally because the installed SDK is 10.0.303 while `global.json` pins 10.0.302. That is a pre-existing local-environment condition unrelated to this change, so `global.json` was left untouched and the E2E verification was run via the `Compile` target instead.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Skip (test-only preparatory refactor, no product code or behavior change)