### PR TITLE
Pass etag in conditional patch requests

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Patch/ConditionalPatchResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Patch/ConditionalPatchResourceHandlerTests.cs
@@ -174,6 +174,48 @@ public class ConditionalPatchResourceHandlerTests
         await Assert.ThrowsAsync<UnauthorizedFhirActionException>(() => _conditionalPatchHandler.HandleAsync(request, CancellationToken.None));
     }
 
+    [Fact]
+    public async Task GivenAConditionalPatchResourceHandler_WhenRequestContainsAMatchingWeakETag_ThenPatchShouldSucceed()
+    {
+        // Arrange
+        _authService
+            .CheckAccess(DataActions.Read | DataActions.Write | DataActions.Search | DataActions.Update, CancellationToken.None)
+            .Returns(DataActions.Search | DataActions.Update);
+
+        var conditionalParameters = new List<Tuple<string, string>> { new("name", "John") };
+        var weakETag = WeakETag.FromVersionId("1");
+        var request = new ConditionalPatchResourceRequest("Patient", new FhirPathPatchPayload(new Parameters()), conditionalParameters, weakETag: weakETag);
+
+        // Act & Assert - Should not throw PreconditionFailedException
+        await _conditionalPatchHandler.HandleAsync(request, CancellationToken.None);
+
+        await _mediator
+            .Received()
+            .SendAsync<UpsertResourceResponse>(
+                Arg.Is<UpsertResourceRequest>(r => r.WeakETag == weakETag && r.WeakETag.VersionId == "1"),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenAConditionalPatchResourceHandler_WhenRequestContainsANonMatchingWeakETag_ThenPreconditionFailedExceptionIsThrown()
+    {
+        // Arrange
+        _authService
+            .CheckAccess(DataActions.Read | DataActions.Write | DataActions.Search | DataActions.Update, CancellationToken.None)
+            .Returns(DataActions.Search | DataActions.Update);
+
+        var conditionalParameters = new List<Tuple<string, string>> { new("name", "John") };
+        var weakETag = WeakETag.FromVersionId("2");
+        var request = new ConditionalPatchResourceRequest("Patient", new FhirPathPatchPayload(new Parameters()), conditionalParameters, weakETag: weakETag);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<PreconditionFailedException>(() => _conditionalPatchHandler.HandleAsync(request, CancellationToken.None));
+
+        await _mediator
+            .DidNotReceive()
+            .SendAsync<UpsertResourceResponse>(Arg.Any<UpsertResourceRequest>(), Arg.Any<CancellationToken>());
+    }
+
     private static IReadOnlyCollection<SearchResultEntry> GenerateSearchResult(string resourceType)
     {
         var entries = new List<SearchResultEntry>();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/ConditionalPatchResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/ConditionalPatchResourceHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
             }
 
             var patchedResource = request.Payload.Patch(match.Resource);
-            return await _mediator.SendAsync<UpsertResourceResponse>(new UpsertResourceRequest(patchedResource, bundleResourceContext: null, metaHistory: request.MetaHistory), cancellationToken);
+            return await _mediator.SendAsync<UpsertResourceResponse>(new UpsertResourceRequest(patchedResource, bundleResourceContext: null, metaHistory: request.MetaHistory, weakETag: request.WeakETag), cancellationToken);
         }
 
         public override Task<bool> CheckAccess(CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
Fixes support for conditional patches when etags are required.

## Related issues
Addresses [Bug 205140](https://microsofthealth.visualstudio.com/Health/_workitems/edit/205140)

## Testing
New unit tests were added.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
