### PR TITLE
Fix flaky SQL statistics test

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
@@ -193,9 +193,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             // and must NOT fan out a stat for every base resource type of the parameter.
             const string resourceType = "Patient";
             var query = new[] { Tuple.Create("gender:missing", "true") };
+            var statsBefore = SqlServerSearchService.GetStatsFromCache().ToHashSet();
+
             await _fixture.SearchService.SearchAsync(resourceType, query, CancellationToken.None);
 
             var statsFromCache = SqlServerSearchService.GetStatsFromCache();
+            var newStatsFromCache = statsFromCache.Where(stat => !statsBefore.Contains(stat));
             foreach (var stat in statsFromCache)
             {
                 _output.WriteLine($"cache {stat}");
@@ -212,8 +215,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                   && _.SearchParamId == genderParamId);
 
             // The BaseResourceTypes fallback is intentionally not used for NotExists, so the gender stat is
-            // never created for any resource type other than the one in the search URL.
-            Assert.DoesNotContain(statsFromCache, _ => _.TableName == VLatest.TokenSearchParam.TableName
+            // not newly created for any resource type other than the one in the search URL. Existing entries
+            // are ignored because the statistics cache is process-wide and populated by other test classes.
+            Assert.DoesNotContain(newStatsFromCache, _ => _.TableName == VLatest.TokenSearchParam.TableName
                   && _.ColumnName == "Code"
                   && _.ResourceTypeId != patientResourceTypeId
                   && _.SearchParamId == genderParamId);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
@@ -216,7 +216,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             // The BaseResourceTypes fallback is intentionally not used for NotExists, so the gender stat is
             // not newly created for any resource type other than the one in the search URL. Existing entries
-            // are ignored because the statistics cache is process-wide and populated by other test classes.
+            // are ignored because earlier tests may populate the process-wide cache. This test class belongs
+            // to a non-parallel collection, so no other test can modify the cache between the two snapshots.
             Assert.DoesNotContain(newStatsFromCache, _ => _.TableName == VLatest.TokenSearchParam.TableName
                   && _.ColumnName == "Code"
                   && _.ResourceTypeId != patientResourceTypeId

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerCreateStatsTests.cs
@@ -197,8 +197,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             await _fixture.SearchService.SearchAsync(resourceType, query, CancellationToken.None);
 
-            var statsFromCache = SqlServerSearchService.GetStatsFromCache();
-            var newStatsFromCache = statsFromCache.Where(stat => !statsBefore.Contains(stat));
+            var statsFromCache = SqlServerSearchService.GetStatsFromCache().ToList();
+            var newStatsFromCache = statsFromCache.Where(stat => !statsBefore.Contains(stat)).ToList();
             foreach (var stat in statsFromCache)
             {
                 _output.WriteLine($"cache {stat}");


### PR DESCRIPTION
## Description
Fixes an intermittent failure in `GivenMissingTrueSearchForPatientByGender_NotExistsStatsAreCreated`.

The SQL search statistics cache is process-wide and may already contain valid `individual-gender` statistics for non-Patient resource types created by other test classes. The test now snapshots the cache before executing the Patient `gender:missing=true` search and scopes its negative assertion to newly added statistics. The positive assertion still verifies that the expected Patient statistic exists after the search.

## Related issues
Addresses [AB205695](https://microsofthealth.visualstudio.com/Health/_workitems/edit/205695)

## Testing

Result: 1 passed, 0 failed.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Skip