### PR TITLE
Handling InvalidOperationExceptions for non-thread-safe objects

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ExportResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ExportResult.cs
@@ -5,6 +5,7 @@
 
 using System.Net;
 using EnsureThat;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
@@ -14,13 +15,13 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
     /// </summary>
     public class ExportResult : ResourceActionResult<ExportJobResult>
     {
-        public ExportResult(HttpStatusCode statusCode)
-            : base(null, statusCode)
+        public ExportResult(HttpStatusCode statusCode, ILogger logger)
+            : base(null, statusCode, logger)
         {
         }
 
-        public ExportResult(ExportJobResult jobResult, HttpStatusCode statusCode)
-            : base(jobResult, statusCode)
+        public ExportResult(ExportJobResult jobResult, HttpStatusCode statusCode, ILogger logger)
+            : base(jobResult, statusCode, logger)
         {
             EnsureArg.IsNotNull(jobResult, nameof(jobResult));
         }
@@ -28,18 +29,19 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// <summary>
         /// Creates an ExportResult with HttpStatusCode Accepted.
         /// </summary>
-        public static ExportResult Accepted()
+        public static ExportResult Accepted(ILogger logger)
         {
-            return new ExportResult(HttpStatusCode.Accepted);
+            return new ExportResult(HttpStatusCode.Accepted, logger);
         }
 
         /// <summary>
         /// Creates an ExportResult with HttpStatusCode Ok.
         /// </summary>
         /// <param name="jobResult">The job payload that must be returned as part of the ExportResult.</param>
-        public static ExportResult Ok(ExportJobResult jobResult)
+        /// <param name="logger">The logger.</param>
+        public static ExportResult Ok(ExportJobResult jobResult, ILogger logger)
         {
-            return new ExportResult(jobResult, HttpStatusCode.OK);
+            return new ExportResult(jobResult, HttpStatusCode.OK, logger);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ImportResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ImportResult.cs
@@ -5,6 +5,7 @@
 
 using System.Net;
 using EnsureThat;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Operations.Import;
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
@@ -14,13 +15,13 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
     /// </summary>
     public class ImportResult : ResourceActionResult<ImportJobResult>
     {
-        public ImportResult(HttpStatusCode statusCode)
-            : base(null, statusCode)
+        public ImportResult(HttpStatusCode statusCode, ILogger logger)
+            : base(null, statusCode, logger)
         {
         }
 
-        public ImportResult(ImportJobResult jobResult, HttpStatusCode statusCode)
-            : base(jobResult, statusCode)
+        public ImportResult(ImportJobResult jobResult, HttpStatusCode statusCode, ILogger logger)
+            : base(jobResult, statusCode, logger)
         {
             EnsureArg.IsNotNull(jobResult, nameof(jobResult));
         }
@@ -28,31 +29,33 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// <summary>
         /// Creates an ImportResult with HttpStatusCode Accepted.
         /// </summary>
-        public static ImportResult Accepted()
+        public static ImportResult Accepted(ILogger logger)
         {
-            return new ImportResult(HttpStatusCode.Accepted);
+            return new ImportResult(HttpStatusCode.Accepted, logger);
         }
 
         /// <summary>
         /// Creates an ImportResult with HttpStatusCode Accepted.
         /// </summary>
         /// <param name="taskResult">The job payload that must be returned as part of the ImportResult.</param>
-        public static ImportResult Accepted(ImportJobResult taskResult)
+        /// <param name="logger">The logger.</param>
+        public static ImportResult Accepted(ImportJobResult taskResult, ILogger logger)
         {
             EnsureArg.IsNotNull(taskResult, nameof(taskResult));
 
-            return new ImportResult(taskResult, HttpStatusCode.Accepted);
+            return new ImportResult(taskResult, HttpStatusCode.Accepted, logger);
         }
 
         /// <summary>
         /// Creates an ImportResult with HttpStatusCode Ok.
         /// </summary>
         /// <param name="taskResult">The job payload that must be returned as part of the ImportResult.</param>
-        public static ImportResult Ok(ImportJobResult taskResult)
+        /// <param name="logger">The logger.</param>
+        public static ImportResult Ok(ImportJobResult taskResult, ILogger logger)
         {
             EnsureArg.IsNotNull(taskResult, nameof(taskResult));
 
-            return new ImportResult(taskResult, HttpStatusCode.OK);
+            return new ImportResult(taskResult, HttpStatusCode.OK, logger);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/JobResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/JobResult.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Net;
 using EnsureThat;
 using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
@@ -16,18 +17,18 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
     public class JobResult : ResourceActionResult<Parameters>
     {
-        public JobResult(HttpStatusCode statusCode)
-            : base(null, statusCode)
+        public JobResult(HttpStatusCode statusCode, ILogger logger)
+            : base(null, statusCode, logger)
         {
         }
 
-        public JobResult(Parameters jobResult, HttpStatusCode statusCode)
-            : base(jobResult, statusCode)
+        public JobResult(Parameters jobResult, HttpStatusCode statusCode, ILogger logger)
+            : base(jobResult, statusCode, logger)
         {
             EnsureArg.IsNotNull(jobResult, nameof(jobResult));
         }
 
-        public static JobResult FromResults(ICollection<Parameters.ParameterComponent> results, ICollection<OperationOutcomeIssue> issues, HttpStatusCode statusCode)
+        public static JobResult FromResults(ICollection<Parameters.ParameterComponent> results, ICollection<OperationOutcomeIssue> issues, HttpStatusCode statusCode, ILogger logger)
         {
             var resource = new Parameters();
 
@@ -54,15 +55,15 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
                 }
             }
 
-            return new JobResult(resource, statusCode);
+            return new JobResult(resource, statusCode, logger);
         }
 
         /// <summary>
         /// Creates a JobResult with HttpStatusCode Accepted.
         /// </summary>
-        public static JobResult Accepted()
+        public static JobResult Accepted(ILogger logger)
         {
-            return new JobResult(HttpStatusCode.Accepted);
+            return new JobResult(HttpStatusCode.Accepted, logger);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/OperationOutcomeResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/OperationOutcomeResult.cs
@@ -6,6 +6,7 @@
 using System.Net;
 using EnsureThat;
 using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
@@ -15,8 +16,8 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
     /// </summary>
     public class OperationOutcomeResult : ResourceActionResult<OperationOutcome>
     {
-        public OperationOutcomeResult(OperationOutcome outcome, HttpStatusCode statusCode)
-            : base(outcome, statusCode)
+        public OperationOutcomeResult(OperationOutcome outcome, HttpStatusCode statusCode, ILogger logger)
+            : base(outcome, statusCode, logger)
         {
             EnsureArg.IsNotNull(outcome, nameof(outcome));
         }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
@@ -11,6 +11,7 @@ using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Core.Features.Context;
@@ -21,19 +22,22 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
     public abstract class ResourceActionResult<TResult> : ActionResult, IResourceActionResult
     {
-        protected ResourceActionResult()
+        private readonly ILogger _logger;
+
+        protected ResourceActionResult(ILogger logger)
         {
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             Headers = new HeaderDictionary();
         }
 
-        protected ResourceActionResult(TResult result)
-            : this()
+        protected ResourceActionResult(TResult result, ILogger logger)
+            : this(logger)
         {
             Result = result;
         }
 
-        protected ResourceActionResult(TResult result, HttpStatusCode statusCode)
-            : this(result)
+        protected ResourceActionResult(TResult result, HttpStatusCode statusCode, ILogger logger)
+            : this(result, logger)
         {
             StatusCode = statusCode;
         }
@@ -91,8 +95,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 
                     if (context.HttpContext is DefaultHttpContext)
                     {
-                        // Should we ignore it? Open for discussion.
-                        // Otherwise, add log to all the places inheriting from ResourceActionResult and log the exception.
+                        _logger.LogWarning(ioe, "Failed to set response header {HeaderName} because the HTTP headers collection was modified concurrently.", header.Key);
                     }
                     else
                     {

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
@@ -88,7 +88,16 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
                 catch (InvalidOperationException ioe)
                 {
                     // Catching operations that change non-concurrent collections.
-                    throw new InvalidOperationException($"Failed to set header '{header.Key}'.", ioe);
+
+                    if (context.HttpContext is DefaultHttpContext)
+                    {
+                        // Should we ignore it? Open for discussion.
+                        // Otherwise, add log to all the places inheriting from ResourceActionResult and log the exception.
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Failed to set header '{header.Key}'.", ioe)
+                    }
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
                     }
                     else
                     {
-                        throw new InvalidOperationException($"Failed to set header '{header.Key}'.", ioe)
+                        throw new InvalidOperationException($"Failed to set header '{header.Key}'.", ioe);
                     }
                 }
             }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/TooManyRequestsActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/TooManyRequestsActionResult.cs
@@ -4,21 +4,21 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Net;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
     public class TooManyRequestsActionResult : ResourceActionResult<OperationOutcomeIssue>
     {
-        public static readonly TooManyRequestsActionResult TooManyRequests = new TooManyRequestsActionResult();
-
-        public TooManyRequestsActionResult()
+        public TooManyRequestsActionResult(ILogger logger)
             : base(
                   new OperationOutcomeIssue(
                         OperationOutcomeConstants.IssueSeverity.Error,
                         OperationOutcomeConstants.IssueType.Throttled,
                         Api.Resources.TooManyConcurrentRequests),
-                  HttpStatusCode.TooManyRequests)
+                  HttpStatusCode.TooManyRequests,
+                  logger)
         {
         }
     }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -170,22 +170,31 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         {
             IFhirRequestContext requestContext = _fhirRequestContextAccessor.RequestContext;
 
-            lock (requestContext.ResponseHeaders)
+            try
             {
-                // If there has already been a request to the database for this request, then we want to add to it.
-                if (requestContext.ResponseHeaders.TryGetValue(CosmosDbHeaders.RequestCharge, out StringValues existingHeaderValue))
+                lock (requestContext.ResponseHeaders)
                 {
-                    if (double.TryParse(existingHeaderValue.ToString(), out double existing))
+                    // If there has already been a request to the database for this request, then we want to add to it.
+                    if (requestContext.ResponseHeaders.TryGetValue(CosmosDbHeaders.RequestCharge, out StringValues existingHeaderValue))
                     {
-                        responseRequestCharge += existing;
+                        if (double.TryParse(existingHeaderValue.ToString(), out double existing))
+                        {
+                            responseRequestCharge += existing;
+                        }
+                        else
+                        {
+                            _logger.LogWarning("Unable to parse request charge header: {Request change}", existingHeaderValue);
+                        }
                     }
-                    else
-                    {
-                        _logger.LogWarning("Unable to parse request charge header: {Request change}", existingHeaderValue);
-                    }
-                }
 
-                requestContext.ResponseHeaders[CosmosDbHeaders.RequestCharge] = responseRequestCharge.ToString(CultureInfo.InvariantCulture);
+                    requestContext.ResponseHeaders[CosmosDbHeaders.RequestCharge] = responseRequestCharge.ToString(CultureInfo.InvariantCulture);
+                }
+            }
+            catch (Exception e)
+            {
+                // InvalidOperationException can be thrown if the headers collection is read-only.
+                // Adding this catch to avoid potential crashes in such scenarios and track how often this occurs.
+                _logger.LogWarning(e, "Error setting request charge in response headers.");
             }
 
             var cosmosMetrics = new CosmosStorageRequestMetricsNotification(requestContext.AuditEventType, requestContext.ResourceType)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -143,7 +143,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 var sessionToken = responseMessage.Headers.Session;
                 if (!string.IsNullOrEmpty(sessionToken))
                 {
-                    fhirRequestContext.ResponseHeaders[CosmosDbHeaders.SessionToken] = sessionToken;
+                    lock (fhirRequestContext.ResponseHeaders)
+                    {
+                        fhirRequestContext.ResponseHeaders[CosmosDbHeaders.SessionToken] = sessionToken;
+                    }
                 }
             }
             catch (InvalidOperationException e)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -114,8 +114,55 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         /// <param name="cancellationToken">Cancellation token</param>
         public async Task ProcessResponseAsync(CosmosResponseMessage responseMessage, CancellationToken cancellationToken)
         {
-            var responseRequestCharge = responseMessage.Headers.RequestCharge;
+            // Logic Handling Exceptions:
+            //   InvalidOperationException can be thrown if the headers collection is read-only.
+            //   Adding catch blocks for InvalidOperationException to avoid potential crashes in such scenarios and track how often this occurs.
+            //   Adopting multiple try-catch blocks to ensure that if one operation fails, it doesn't prevent the execution of subsequent operations.
 
+            double responseRequestCharge = 0D;
+
+            try
+            {
+                responseRequestCharge = responseMessage.Headers.RequestCharge;
+
+                LogQueryResults(responseMessage);
+            }
+            catch (InvalidOperationException e)
+            {
+                _logger.LogWarning(e, "Error logging query execution results.");
+            }
+
+            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
+            if (fhirRequestContext == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var sessionToken = responseMessage.Headers.Session;
+                if (!string.IsNullOrEmpty(sessionToken))
+                {
+                    fhirRequestContext.ResponseHeaders[CosmosDbHeaders.SessionToken] = sessionToken;
+                }
+            }
+            catch (InvalidOperationException e)
+            {
+                _logger.LogWarning(e, "Error setting session token in response headers.");
+            }
+
+            if (fhirRequestContext.Properties.TryGetValue(Constants.CosmosDbResponseMessagesProperty, out object propertyValue))
+            {
+                // This is planted in FhirCosmosSearchService in order for us to relay the individual responses
+                // back for analysis of the selectivity of the search.
+                ((ConcurrentBag<CosmosResponseMessage>)propertyValue).Add(responseMessage);
+            }
+
+            await AddRequestChargeToFhirRequestContextAsync(responseRequestCharge, responseMessage.StatusCode, cancellationToken);
+        }
+
+        private void LogQueryResults(CosmosResponseMessage responseMessage)
+        {
             _queryLogger.LogQueryExecutionResult(
                 responseMessage.Headers.ActivityId,
                 responseMessage.Headers.RequestCharge,
@@ -133,37 +180,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             {
                 _queryLogger.LogQueryClientElapsedTime(responseMessage.Headers.ActivityId, responseMessage.Diagnostics.GetClientElapsedTime().ToString());
             }
-
-            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
-            if (fhirRequestContext == null)
-            {
-                return;
-            }
-
-            var sessionToken = responseMessage.Headers.Session;
-
-            if (!string.IsNullOrEmpty(sessionToken))
-            {
-                try
-                {
-                    fhirRequestContext.ResponseHeaders[CosmosDbHeaders.SessionToken] = sessionToken;
-                }
-                catch (InvalidOperationException e)
-                {
-                    // InvalidOperationException can be thrown if the headers collection is read-only.
-                    // Adding this catch to avoid potential crashes in such scenarios and track how often this occurs.
-                    _logger.LogWarning(e, "Error setting session token in response headers.");
-                }
-            }
-
-            if (fhirRequestContext.Properties.TryGetValue(Constants.CosmosDbResponseMessagesProperty, out object propertyValue))
-            {
-                // This is planted in FhirCosmosSearchService in order for us to relay the individual responses
-                // back for analysis of the selectivity of the search.
-                ((ConcurrentBag<CosmosResponseMessage>)propertyValue).Add(responseMessage);
-            }
-
-            await AddRequestChargeToFhirRequestContextAsync(responseRequestCharge, responseMessage.StatusCode, cancellationToken);
         }
 
         private async Task AddRequestChargeToFhirRequestContextAsync(double responseRequestCharge, HttpStatusCode? statusCode, CancellationToken cancellationToken)
@@ -190,7 +206,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                     requestContext.ResponseHeaders[CosmosDbHeaders.RequestCharge] = responseRequestCharge.ToString(CultureInfo.InvariantCulture);
                 }
             }
-            catch (Exception e)
+            catch (InvalidOperationException e)
             {
                 // InvalidOperationException can be thrown if the headers collection is read-only.
                 // Adding this catch to avoid potential crashes in such scenarios and track how often this occurs.

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -81,7 +82,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
             _controller = new BulkDeleteController(
                 _mediator,
-                urlResolver);
+                urlResolver,
+                NullLogger<BulkDeleteController>.Instance);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
                     httpContext,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkUpdateControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkUpdateControllerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -71,7 +72,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 _mediator,
                 urlResolver,
                 Options.Create(_operationConfiguration),
-                _fhirRuntimeConfiguration);
+                _fhirRuntimeConfiguration,
+                NullLogger<BulkUpdateController>.Instance);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
                     Substitute.For<HttpContext>(),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/DocRefControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/DocRefControllerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -44,7 +45,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             _configuration = new USCoreConfiguration();
             _controller = new DocRefController(
                 _converter,
-                Options.Create(_configuration));
+                Options.Create(_configuration),
+                NullLogger<DocRefController>.Instance);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
                     Substitute.For<HttpContext>(),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/EverythingControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/EverythingControllerTests.cs
@@ -9,6 +9,7 @@ using Hl7.Fhir.Model;
 using Medino;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -35,7 +36,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         public EverythingControllerTests()
         {
-            _everythingController = new EverythingController(_mediator, _fhirRequestContextAccessor)
+            _everythingController = new EverythingController(_mediator, _fhirRequestContextAccessor, NullLogger<EverythingController>.Instance)
             {
                 ControllerContext = new ControllerContext
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Context;
@@ -628,7 +629,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 optionsOperationConfiguration,
                 optionsArtifactStoreConfiguration,
                 optionsFeatures,
-                fhirConfig ?? Substitute.For<IFhirRuntimeConfiguration>());
+                fhirConfig ?? Substitute.For<IFhirRuntimeConfiguration>(),
+                NullLogger<ExportController>.Instance);
         }
 
         // Configures mocks so the controller can dispatch through MediatR without throwing.

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
@@ -94,7 +95,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 _urlResolver,
                 _configuration,
                 _authorizationService,
-                _searchParameterOperations);
+                _searchParameterOperations,
+                NullLogger<FhirController>.Instance);
             _fhirController.ControllerContext = new ControllerContext(
                 new ActionContext(
                     Substitute.For<HttpContext>(),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/IncludesControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/IncludesControllerTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -44,7 +45,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             _coreFeatureConfiguration = new CoreFeatureConfiguration();
             _controller = new IncludesController(
                 _mediator,
-                Options.Create(_coreFeatureConfiguration));
+                Options.Create(_coreFeatureConfiguration),
+                NullLogger<IncludesController>.Instance);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
                     Substitute.For<HttpContext>(),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/OperationDefinitionControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/OperationDefinitionControllerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Controllers;
@@ -61,7 +62,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 Options.Create(_featureConfiguration),
                 Options.Create(_coreFeatureConfiguration),
                 Options.Create(_implementationGuidesConfiguration),
-                _fhirRuntimeConfiguration);
+                _fhirRuntimeConfiguration,
+                NullLogger<OperationDefinitionController>.Instance);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
                     Substitute.For<HttpContext>(),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/SearchParameterControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/SearchParameterControllerTests.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Model;
 using Medino;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -55,7 +56,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             _controller = new SearchParameterController(
                 _mediator,
                 Options.Create(_coreFeaturesConfiguration),
-                _fhirConfiguration);
+                _fhirConfiguration,
+                NullLogger<SearchParameterController>.Instance);
             _controller.ControllerContext = controllerContext;
         }
 
@@ -65,7 +67,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             CoreFeatureConfiguration coreFeaturesConfiguration = new CoreFeatureConfiguration();
             coreFeaturesConfiguration.SupportsSelectableSearchParameters = false;
 
-            SearchParameterController controller = new SearchParameterController(_mediator, Options.Create(coreFeaturesConfiguration), _fhirConfiguration);
+            SearchParameterController controller = new SearchParameterController(_mediator, Options.Create(coreFeaturesConfiguration), _fhirConfiguration, NullLogger<SearchParameterController>.Instance);
 
             Func<Task> act = () => controller.GetSearchParametersStatus(default(CancellationToken));
 
@@ -102,7 +104,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             CoreFeatureConfiguration coreFeaturesConfiguration = new CoreFeatureConfiguration();
             coreFeaturesConfiguration.SupportsSelectableSearchParameters = false;
 
-            SearchParameterController controller = new SearchParameterController(_mediator, Options.Create(coreFeaturesConfiguration), _fhirConfiguration);
+            SearchParameterController controller = new SearchParameterController(_mediator, Options.Create(coreFeaturesConfiguration), _fhirConfiguration, NullLogger<SearchParameterController>.Instance);
             var requestBody = CreateValidRequestBody();
             Func<System.Threading.Tasks.Task> act = () => controller.UpdateSearchParametersStatus(requestBody, default(CancellationToken));
 
@@ -113,7 +115,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         public async Task GivenAValidSearchParameterStatusUpdateRequest_WhenServiceIsAzureApiForFhir_ThenRequestNotValidExceptionShouldBeReturned()
         {
             AzureApiForFhirRuntimeConfiguration azureApiForFhirConfiguration = new AzureApiForFhirRuntimeConfiguration();
-            SearchParameterController controller = new SearchParameterController(_mediator, Options.Create(_coreFeaturesConfiguration), azureApiForFhirConfiguration);
+            SearchParameterController controller = new SearchParameterController(_mediator, Options.Create(_coreFeaturesConfiguration), azureApiForFhirConfiguration, NullLogger<SearchParameterController>.Instance);
             var requestBody = CreateValidRequestBody();
             Func<System.Threading.Tasks.Task> act = () => controller.UpdateSearchParametersStatus(requestBody, default(CancellationToken));
 
@@ -161,7 +163,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             fhirRuntimeConfiguration.IsSelectiveSearchParameterSupported.Returns(true);
             _coreFeaturesConfiguration.SupportsSelectableSearchParameters = true;
 
-            var controller = new SearchParameterController(_mediator, Options.Create(_coreFeaturesConfiguration), fhirRuntimeConfiguration);
+            var controller = new SearchParameterController(_mediator, Options.Create(_coreFeaturesConfiguration), fhirRuntimeConfiguration, NullLogger<SearchParameterController>.Instance);
             var requestBody = emptyParameters ? new Parameters() : null;
             var act = () => controller.UpdateSearchParametersStatus(requestBody, default(CancellationToken));
             await Assert.ThrowsAsync<RequestNotValidException>(act);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/TerminologyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/TerminologyControllerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -50,7 +51,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
             _controller = new TerminologyController(
                 _mediator,
-                Options.Create(_configuration));
+                Options.Create(_configuration),
+                NullLogger<TerminologyController>.Instance);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
                     Substitute.For<HttpContext>(),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ValidateControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ValidateControllerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -68,7 +69,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
             _controller = new ValidateController(
                 _mediator,
-                _resourceDeserializer);
+                _resourceDeserializer,
+                NullLogger<ValidateController>.Instance);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
                     Substitute.For<HttpContext>(),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ActionResults/FhirResultTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ActionResults/FhirResultTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.ActionResults
             await result.ExecuteResultAsync(context);
 
             var logCall = Assert.Single(logger.ReceivedCalls(), call => call.GetMethodInfo().Name == nameof(ILogger.Log));
-            Assert.Equal(LogLevel.Error, logCall.GetArguments()[0]);
+            Assert.Equal(LogLevel.Warning, logCall.GetArguments()[0]);
             Assert.Same(exception, logCall.GetArguments()[3]);
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ActionResults/FhirResultTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ActionResults/FhirResultTests.cs
@@ -3,12 +3,16 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -27,7 +31,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.ActionResults
         [Fact]
         public void GivenAGoneStatus_WhenReturningAResult_ThenTheContentShouldBeEmpty()
         {
-            var result = FhirResult.Gone();
+            var result = FhirResult.Gone(NullLogger.Instance);
             var context = new ActionContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -43,7 +47,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.ActionResults
         [Fact]
         public void GivenANoContentStatus_WhenReturningAResult_ThenTheStatusCodeIsSetCorrectly()
         {
-            var result = FhirResult.NoContent();
+            var result = FhirResult.NoContent(NullLogger.Instance);
             var context = new ActionContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -58,7 +62,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.ActionResults
         [Fact]
         public void GivenANotFoundStatus_WhenReturningAResult_ThenTheStatusCodeIsSetCorrectly()
         {
-            var result = FhirResult.NotFound();
+            var result = FhirResult.NotFound(NullLogger.Instance);
             var context = new ActionContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -73,7 +77,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.ActionResults
         [Fact]
         public async Task GivenAFhirResult_WhenHeadersThatAlreadyExistsInResponseArePassed_ThenDuplicteHeadersAreRemoved()
         {
-            var result = FhirResult.Gone();
+            var result = FhirResult.Gone(NullLogger.Instance);
             var context = new ActionContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -106,6 +110,35 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.ActionResults
             Assert.True(context.HttpContext.Response.Headers.TryGetValue("testKey2", out StringValues testKey2));
             Assert.Equal(new StringValues("3"), testKey1);
             Assert.Equal(new StringValues("2"), testKey2);
+        }
+
+        [Fact]
+        public async Task GivenDefaultHttpContext_WhenResponseHeadersAreModifiedConcurrently_ThenExceptionIsLogged()
+        {
+            ILogger logger = Substitute.For<ILogger>();
+            var result = FhirResult.Gone(logger);
+            var context = new ActionContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+
+            IHeaderDictionary responseHeaders = Substitute.For<IHeaderDictionary>();
+            var exception = new InvalidOperationException("Collection was modified.");
+            responseHeaders
+                .When(headers => headers[Arg.Any<string>()] = Arg.Any<StringValues>())
+                .Do(_ => throw exception);
+            context.HttpContext.Features.Set<IHttpResponseFeature>(new HttpResponseFeature { Headers = responseHeaders });
+
+            ServiceCollection collection = new ServiceCollection();
+            collection.AddSingleton(Substitute.For<RequestContextAccessor<IFhirRequestContext>>());
+            context.HttpContext.RequestServices = collection.BuildServiceProvider();
+            result.Headers["test"] = "value";
+
+            await result.ExecuteResultAsync(context);
+
+            var logCall = Assert.Single(logger.ReceivedCalls(), call => call.GetMethodInfo().Name == nameof(ILogger.Log));
+            Assert.Equal(LogLevel.Error, logCall.GetArguments()[0]);
+            Assert.Same(exception, logCall.GetArguments()[3]);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ActionResults/OperationVersionsResultTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ActionResults/OperationVersionsResultTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Core.Features.Operations.Versions;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -32,7 +33,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.ActionResults
                 "1.0");
             _result = new OperationVersionsResult(
                 _versionsResult,
-                HttpStatusCode.Accepted);
+                HttpStatusCode.Accepted,
+                NullLogger.Instance);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -57,7 +58,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         [Fact]
         public void GivenAController_WhenExecutedAction_ThenAuditLogShouldBeLogged()
         {
-            var fhirResult = new FhirResult(new Patient() { Name = { new HumanName() { Text = "TestPatient" } } }.ToResourceElement());
+            var fhirResult = new FhirResult(new Patient() { Name = { new HumanName() { Text = "TestPatient" } } }.ToResourceElement(), NullLogger.Instance);
             _httpContext.Items["timer"] = Stopwatch.StartNew();
 
             var resultExecutedContext = new ResultExecutedContext(

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Filters;
@@ -73,7 +74,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             _fhirRequestContext.CorrelationId = _correlationId;
             _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
-            _filterAttribute = new FhirRequestContextRouteDataPopulatingFilterAttribute(_fhirRequestContextAccessor, _auditEventTypeMapping);
+            _filterAttribute = new FhirRequestContextRouteDataPopulatingFilterAttribute(_fhirRequestContextAccessor, _auditEventTypeMapping, NullLogger<FhirRequestContextRouteDataPopulatingFilterAttribute>.Instance);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/ExportResultExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/ExportResultExtensionsTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -31,7 +32,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
             var urlResolver = Substitute.For<IUrlResolver>();
             urlResolver.ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>()).Returns(exportOperationUrl);
 
-            var exportResult = ExportResult.Accepted().SetContentLocationHeader(urlResolver, opName, id);
+            var exportResult = ExportResult.Accepted(NullLogger.Instance).SetContentLocationHeader(urlResolver, opName, id);
 
             Assert.Equal(exportOperationUrl.AbsoluteUri, exportResult.Headers[HeaderNames.ContentLocation]);
         }
@@ -40,7 +41,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         public void GivenAnExportResult_WhenSettingAContentTypeHeader_ThenExportResultHasAContentTypeHeader()
         {
             string contentTypeValue = "application/json";
-            var exportResult = ExportResult.Accepted().SetContentTypeHeader(contentTypeValue);
+            var exportResult = ExportResult.Accepted(NullLogger.Instance).SetContentTypeHeader(contentTypeValue);
 
             Assert.Equal(contentTypeValue, exportResult.Headers[HeaderNames.ContentType]);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/FhirResultExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/FhirResultExtensionsTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -55,7 +56,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
             var urlResolver = Substitute.For<IUrlResolver>();
             urlResolver.ResolveResourceUrl(Arg.Any<ResourceElement>(), Arg.Any<bool>()).Returns(locationUrl);
 
-            var fhirResult = FhirResult.Create(_mockResource).SetLocationHeader(urlResolver);
+            var fhirResult = FhirResult.Create(NullLogger.Instance, _mockResource).SetLocationHeader(urlResolver);
 
             Assert.Equal(locationUrl.AbsoluteUri, fhirResult.Headers[HeaderNames.Location]);
         }
@@ -64,7 +65,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         public void WhenSettingAnETagHeader_ThenFhirResultHasAnETagHeader()
         {
             var version = _mockResource.VersionId;
-            var fhirResult = FhirResult.Create(_mockResource).SetETagHeader();
+            var fhirResult = FhirResult.Create(NullLogger.Instance, _mockResource).SetETagHeader();
 
             Assert.Equal(string.Format(ETagFormat, version), fhirResult.Headers[HeaderNames.ETag]);
         }
@@ -72,7 +73,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         [Fact]
         public void WhenSettingALastModifiedHeader_ThenFhirResultHasALastModifierHeader()
         {
-            var fhirResult = FhirResult.Create(_mockResource).SetLastModifiedHeader();
+            var fhirResult = FhirResult.Create(NullLogger.Instance, _mockResource).SetLastModifiedHeader();
 
             Assert.Equal(_mockResource.LastUpdated?.ToString("r", CultureInfo.InvariantCulture), fhirResult.Headers[HeaderNames.LastModified]);
         }
@@ -80,7 +81,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         [Fact]
         public void WhenCreatingAFhirResultAndNotSettingHeaders_ThenThereIsNoHeaders()
         {
-            var fhirResult = FhirResult.Create(_mockResource);
+            var fhirResult = FhirResult.Create(NullLogger.Instance, _mockResource);
 
             Assert.Empty(fhirResult.Headers);
         }
@@ -88,7 +89,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         [Fact]
         public void WhenAddingTwoHeaders_ThenFhirResultHasAtLeastTwoHeaders()
         {
-            var fhirResult = FhirResult.Create(_mockResource).SetLastModifiedHeader().SetETagHeader();
+            var fhirResult = FhirResult.Create(NullLogger.Instance, _mockResource).SetLastModifiedHeader().SetETagHeader();
 
             Assert.Equal(2, fhirResult.Headers.Count);
         }
@@ -96,7 +97,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         [Fact]
         public void WhenAddingSameHeaderTwice_ThenOnlyOneHeaderIsPresent()
         {
-            var result = FhirResult.Create(_mockResource)
+            var result = FhirResult.Create(NullLogger.Instance, _mockResource)
                 .SetLastModifiedHeader()
                 .SetLastModifiedHeader();
 
@@ -106,7 +107,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         [Fact]
         public void WhenAddingStringEtag_ThenStringETagIsReturned()
         {
-            var fhirResult = FhirResult.Create(_mockResource).SetETagHeader(WeakETag.FromVersionId("etag"));
+            var fhirResult = FhirResult.Create(NullLogger.Instance, _mockResource).SetETagHeader(WeakETag.FromVersionId("etag"));
 
             Assert.Equal("W/\"etag\"", fhirResult.Headers[HeaderNames.ETag]);
         }
@@ -125,6 +126,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
             urlResolver.ResolveResourceUrl(Arg.Any<ResourceElement>(), Arg.Any<bool>()).Returns(locationUrl);
 
             var fhirResult = FhirResult.Create(
+                NullLogger.Instance,
                 _mockResource,
                 HttpStatusCode.OK,
                 true,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/ImportResultExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/ImportResultExtensionsTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -31,7 +32,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
             var urlResolver = Substitute.For<IUrlResolver>();
             urlResolver.ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>()).Returns(bulkImportOperationUrl);
 
-            var bulkImportResult = ImportResult.Accepted().SetContentLocationHeader(urlResolver, opName, id);
+            var bulkImportResult = ImportResult.Accepted(NullLogger.Instance).SetContentLocationHeader(urlResolver, opName, id);
 
             Assert.Equal(bulkImportOperationUrl.AbsoluteUri, bulkImportResult.Headers[HeaderNames.ContentLocation]);
         }
@@ -40,7 +41,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         public void GivenAnImportResult_WhenSettingAContentTypeHeader_ThenImportResultHasAContentTypeHeader()
         {
             string contentTypeValue = "application/json";
-            var bulkImportResult = ImportResult.Accepted().SetContentTypeHeader(contentTypeValue);
+            var bulkImportResult = ImportResult.Accepted(NullLogger.Instance).SetContentTypeHeader(contentTypeValue);
 
             Assert.Equal(contentTypeValue, bulkImportResult.Headers[HeaderNames.ContentType]);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Medino;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Extensions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -38,6 +39,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly IUrlResolver _urlResolver;
+        private readonly ILogger<BulkDeleteController> _logger;
 
         private readonly HashSet<string> _excludedParameters = new(new PropertyEqualityComparer<string>(StringComparison.OrdinalIgnoreCase, s => s))
         {
@@ -50,10 +52,12 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
         public BulkDeleteController(
             IMediator mediator,
-            IUrlResolver urlResolver)
+            IUrlResolver urlResolver,
+            ILogger<BulkDeleteController> logger)
         {
             _mediator = EnsureArg.IsNotNull(mediator, nameof(mediator));
             _urlResolver = EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
         [HttpDelete]
@@ -107,7 +111,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         public async Task<IActionResult> GetBulkDeleteStatusById(long idParameter)
         {
             var result = await _mediator.GetBulkDeleteStatusAsync(idParameter, HttpContext.RequestAborted);
-            var actionResult = JobResult.FromResults(result.Results, result.Issues, result.HttpStatusCode);
+            var actionResult = JobResult.FromResults(result.Results, result.Issues, result.HttpStatusCode, _logger);
             if (result.HttpStatusCode == System.Net.HttpStatusCode.Accepted)
             {
                 actionResult.Headers[KnownHeaders.Progress] = Resources.InProgress;
@@ -122,7 +126,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         public async Task<IActionResult> CancelBulkDelete(long idParameter)
         {
             var result = await _mediator.CancelBulkDeleteAsync(idParameter, HttpContext.RequestAborted);
-            return new JobResult(result.StatusCode);
+            return new JobResult(result.StatusCode, _logger);
         }
 
         private async Task<IActionResult> SendDeleteRequest(string typeParameter, bool hardDelete, bool purgeHistory, bool softDeleteCleanup, string excludedResourceTypes, bool removeReferences)
@@ -151,7 +155,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             CreateBulkDeleteResponse result = await _mediator.BulkDeleteAsync(deleteOperation, typeParameter, searchParameters, softDeleteCleanup, excludedResourceTypesList, removeReferences, HttpContext.RequestAborted);
 
-            var response = JobResult.Accepted();
+            var response = JobResult.Accepted(_logger);
             response.SetContentLocationHeader(_urlResolver, OperationsConstants.BulkDelete, result.Id.ToString());
             return response;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkUpdateController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkUpdateController.cs
@@ -11,6 +11,7 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Medino;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Extensions;
@@ -43,17 +44,20 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private readonly IUrlResolver _urlResolver;
         private readonly IFhirRuntimeConfiguration _fhirRuntimeConfiguration;
         private readonly OperationsConfiguration _operationConfiguration;
+        private readonly ILogger<BulkUpdateController> _logger;
 
         public BulkUpdateController(
             IMediator mediator,
             IUrlResolver urlResolver,
             IOptions<OperationsConfiguration> operationConfiguration,
-            IFhirRuntimeConfiguration fhirRuntimeConfiguration)
+            IFhirRuntimeConfiguration fhirRuntimeConfiguration,
+            ILogger<BulkUpdateController> logger)
         {
             _mediator = EnsureArg.IsNotNull(mediator, nameof(mediator));
             _urlResolver = EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
             _operationConfiguration = EnsureArg.IsNotNull(operationConfiguration.Value, nameof(operationConfiguration));
             _fhirRuntimeConfiguration = EnsureArg.IsNotNull(fhirRuntimeConfiguration, nameof(fhirRuntimeConfiguration));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
         [HttpPatch]
@@ -83,7 +87,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             CheckIfOperationIsSupported();
             var result = await _mediator.GetBulkUpdateStatusAsync(idParameter, HttpContext.RequestAborted);
-            var actionResult = JobResult.FromResults(result.Results, result.Issues, result.HttpStatusCode);
+            var actionResult = JobResult.FromResults(result.Results, result.Issues, result.HttpStatusCode, _logger);
             if (result.HttpStatusCode == System.Net.HttpStatusCode.Accepted)
             {
                 actionResult.Headers[KnownHeaders.Progress] = Resources.InProgress;
@@ -99,7 +103,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             CheckIfOperationIsSupported();
             var result = await _mediator.CancelBulkUpdateAsync(idParameter, HttpContext.RequestAborted);
-            return new JobResult(result.StatusCode);
+            return new JobResult(result.StatusCode, _logger);
         }
 
         private async Task<IActionResult> SendUpdateRequest(string typeParameter, Parameters parameters, bool? isParallel, uint maxCount = 0, bool metaHistory = true)
@@ -108,7 +112,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             CreateBulkUpdateResponse result = await _mediator.BulkUpdateAsync(typeParameter, searchParameters, parameters, isParallel ?? true, maxCount, metaHistory, HttpContext.RequestAborted);
 
-            var response = JobResult.Accepted();
+            var response = JobResult.Accepted(_logger);
             response.SetContentLocationHeader(_urlResolver, OperationsConstants.BulkUpdate, result.Id.ToString());
             return response;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/DocRefController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/DocRefController.cs
@@ -11,6 +11,7 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Extensions;
@@ -30,16 +31,20 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IDocRefRequestConverter _converter;
         private readonly USCoreConfiguration _configuration;
+        private readonly ILogger<DocRefController> _logger;
 
         public DocRefController(
             IDocRefRequestConverter converter,
-            IOptions<USCoreConfiguration> configuration)
+            IOptions<USCoreConfiguration> configuration,
+            ILogger<DocRefController> logger)
         {
             EnsureArg.IsNotNull(converter, nameof(converter));
             EnsureArg.IsNotNull(configuration?.Value, nameof(configuration));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _converter = converter;
             _configuration = configuration.Value;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -56,7 +61,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var response = await _converter.ConvertAsync(
                 Request.GetQueriesForSearch(),
                 HttpContext.RequestAborted);
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         [HttpPost]
@@ -76,7 +81,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var response = await _converter.ConvertAsync(
                 parameterList,
                 HttpContext.RequestAborted);
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         private static string Convert(DataType value)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
@@ -12,6 +12,7 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Medino;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -35,6 +36,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
+        private readonly ILogger<EverythingController> _logger;
         private static readonly HashSet<string> _supportedParameters = new()
         {
             EverythingOperationParameterNames.Start,
@@ -46,13 +48,16 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
         public EverythingController(
             IMediator mediator,
-            RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor)
+            RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor,
+            ILogger<EverythingController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
+            _logger = logger;
         }
 
         /// <summary>
@@ -79,7 +84,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             EverythingOperationResponse result = await _mediator.SendAsync(new EverythingOperationRequest(ResourceType.Patient.ToString(), idParameter, start, end, since, type, ct, unsupportedParameters), HttpContext.RequestAborted);
 
-            return FhirResult.Create(result.Bundle);
+            return FhirResult.Create(_logger, result.Bundle);
         }
 
         private List<Tuple<string, string>> ReadUnsupportedParameters()

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private readonly ArtifactStoreConfiguration _artifactStoreConfig;
         private readonly FeatureConfiguration _features;
         private readonly IFhirRuntimeConfiguration _fhirConfig;
+        private readonly ILogger<ExportController> _logger;
 
         public ExportController(
             IMediator mediator,
@@ -70,7 +71,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             IOptions<OperationsConfiguration> operationsConfig,
             IOptions<ArtifactStoreConfiguration> artifactStoreConfig,
             IOptions<FeatureConfiguration> features,
-            IFhirRuntimeConfiguration fhirConfig)
+            IFhirRuntimeConfiguration fhirConfig,
+            ILogger<ExportController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
@@ -79,6 +81,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             EnsureArg.IsNotNull(operationsConfig?.Value?.Export, nameof(operationsConfig));
             EnsureArg.IsNotNull(features?.Value, nameof(features));
             EnsureArg.IsNotNull(fhirConfig, nameof(fhirConfig));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
@@ -88,6 +91,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             _artifactStoreConfig = artifactStoreConfig.Value;
             _features = features.Value;
             _fhirConfig = fhirConfig;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -231,12 +235,12 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             ExportResult exportActionResult;
             if (getExportResult.StatusCode == HttpStatusCode.OK)
             {
-                exportActionResult = ExportResult.Ok(getExportResult.JobResult);
+                exportActionResult = ExportResult.Ok(getExportResult.JobResult, _logger);
                 exportActionResult.SetContentTypeHeader(OperationsConstants.ExportContentTypeHeaderValue);
             }
             else
             {
-                exportActionResult = ExportResult.Accepted();
+                exportActionResult = ExportResult.Accepted(_logger);
             }
 
             return exportActionResult;
@@ -249,7 +253,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             CancelExportResponse response = await _mediator.CancelExportAsync(idParameter, HttpContext.RequestAborted);
 
-            return new ExportResult(response.StatusCode);
+            return new ExportResult(response.StatusCode, _logger);
         }
 
         private async Task<IActionResult> SendExportRequest(
@@ -290,7 +294,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 anonymizationConfigFileETag,
                 HttpContext.RequestAborted);
 
-            var exportResult = ExportResult.Accepted();
+            var exportResult = ExportResult.Accepted(_logger);
             exportResult.SetContentLocationHeader(_urlResolver, OperationsConstants.Export, response.JobId);
             return exportResult;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Api.Features.AnonymousOperation;
@@ -70,6 +71,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
         private readonly IUrlResolver _urlResolver;
         private readonly ISearchParameterOperations _searchParameterOperations;
+        private readonly ILogger<FhirController> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FhirController" /> class.
@@ -80,13 +82,15 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <param name="uiConfiguration">The UI configuration.</param>
         /// <param name="authorizationService">The authorization service.</param>
         /// <param name="searchParameterOperations">The search parameter operations.</param>
+        /// <param name="logger">The logger.</param>
         public FhirController(
             IMediator mediator,
             RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor,
             IUrlResolver urlResolver,
             IOptions<FeatureConfiguration> uiConfiguration,
             IAuthorizationService authorizationService,
-            ISearchParameterOperations searchParameterOperations)
+            ISearchParameterOperations searchParameterOperations,
+            ILogger<FhirController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
@@ -95,11 +99,13 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             EnsureArg.IsNotNull(uiConfiguration.Value, nameof(uiConfiguration));
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
             EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _urlResolver = urlResolver;
             _searchParameterOperations = searchParameterOperations;
+            _logger = logger;
         }
 
         [ApiExplorerSettings(IgnoreApi = true)]
@@ -141,6 +147,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
 
             return FhirResult.Create(
+                _logger,
                 new OperationOutcome
                 {
                     Id = _fhirRequestContextAccessor.RequestContext.CorrelationId,
@@ -175,7 +182,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                     HttpContext.RequestAborted),
                 "Create");
 
-            return FhirResult.Create(response, HttpStatusCode.Created)
+            return FhirResult.Create(_logger, response, HttpStatusCode.Created)
                 .SetETagHeader()
                 .SetLastModifiedHeader()
                 .SetLocationHeader(_urlResolver);
@@ -221,6 +228,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
 
             return FhirResult.Create(
+                _logger,
                 response.Outcome.RawResourceElement,
                 statusCode,
                 true,
@@ -286,17 +294,17 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             switch (saveOutcome.Outcome)
             {
                 case SaveOutcomeType.Created:
-                    return FhirResult.Create(saveOutcome.RawResourceElement, HttpStatusCode.Created)
+                    return FhirResult.Create(_logger, saveOutcome.RawResourceElement, HttpStatusCode.Created)
                         .SetETagHeader()
                         .SetLastModifiedHeader()
                         .SetLocationHeader(_urlResolver);
                 case SaveOutcomeType.Updated:
-                    return FhirResult.Create(saveOutcome.RawResourceElement, HttpStatusCode.OK)
+                    return FhirResult.Create(_logger, saveOutcome.RawResourceElement, HttpStatusCode.OK)
                         .SetETagHeader()
                         .SetLastModifiedHeader();
             }
 
-            return FhirResult.Create(saveOutcome.RawResourceElement, HttpStatusCode.BadRequest);
+            return FhirResult.Create(_logger, saveOutcome.RawResourceElement, HttpStatusCode.BadRequest);
         }
 
         /// <summary>
@@ -315,7 +323,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 new GetResourceRequest(new ResourceKey(typeParameter, idParameter), GetBundleResourceContext()),
                 HttpContext.RequestAborted);
 
-            return FhirResult.Create(response)
+            return FhirResult.Create(_logger, response)
                 .SetETagHeader()
                 .SetLastModifiedHeader();
         }
@@ -340,7 +348,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 historyModel.Sort,
                 HttpContext.RequestAborted);
 
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         /// <summary>
@@ -367,7 +375,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 historyModel.Sort,
                 HttpContext.RequestAborted);
 
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         /// <summary>
@@ -397,7 +405,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 historyModel.Sort,
                 HttpContext.RequestAborted);
 
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         /// <summary>
@@ -417,7 +425,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 new GetResourceRequest(new ResourceKey(typeParameter, idParameter, vidParameter), GetBundleResourceContext()),
                 HttpContext.RequestAborted);
 
-            return FhirResult.Create(response, HttpStatusCode.OK)
+            return FhirResult.Create(_logger, response, HttpStatusCode.OK)
                 .SetETagHeader()
                 .SetLastModifiedHeader();
         }
@@ -448,7 +456,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                     HttpContext.RequestAborted),
                 "Delete");
 
-            return FhirResult.NoContent().SetETagHeader(response.WeakETag);
+            return FhirResult.NoContent(_logger).SetETagHeader(response.WeakETag);
         }
 
         /// <summary>
@@ -471,7 +479,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                     allowPartialSuccess),
                 HttpContext.RequestAborted);
 
-            return FhirResult.NoContent().SetETagHeader(response.WeakETag);
+            return FhirResult.NoContent(_logger).SetETagHeader(response.WeakETag);
         }
 
         /// <summary>
@@ -507,7 +515,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 Response.Headers[KnownHeaders.ItemsDeleted] = (response?.ResourcesDeleted ?? 0).ToString(CultureInfo.InvariantCulture);
             }
 
-            return FhirResult.NoContent().SetETagHeader(response?.WeakETag);
+            return FhirResult.NoContent(_logger).SetETagHeader(response?.WeakETag);
         }
 
         /// <summary>
@@ -664,14 +672,14 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             ResourceElement response = await _mediator.SearchResourceCompartmentAsync(compartmentType, compartmentId, resourceType, queries, HttpContext.RequestAborted);
 
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         private async Task<IActionResult> PerformSearch(string type, IReadOnlyList<Tuple<string, string>> queries)
         {
             ResourceElement response = await _mediator.SearchResourceAsync(type, queries, HttpContext.RequestAborted);
 
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         /// <summary>
@@ -685,7 +693,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             ResourceElement response = await _mediator.GetCapabilitiesAsync(HttpContext.RequestAborted);
 
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
 
         /// <summary>
@@ -711,7 +719,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             VersionsResult response = await _mediator.GetOperationVersionsAsync(HttpContext.RequestAborted);
 
-            return new OperationVersionsResult(response, HttpStatusCode.OK);
+            return new OperationVersionsResult(response, HttpStatusCode.OK, _logger);
         }
 
         /// <summary>
@@ -726,7 +734,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             ResourceElement bundleResponse = await _mediator.PostBundle(bundle.ToResourceElement(), HttpContext.RequestAborted);
 
-            return FhirResult.Create(bundleResponse);
+            return FhirResult.Create(_logger, bundleResponse);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                  importRequest.ProcessingUnitBytesToRead,
                  HttpContext.RequestAborted);
 
-            var bulkImportResult = ImportResult.Accepted();
+            var bulkImportResult = ImportResult.Accepted(_logger);
             bulkImportResult.SetContentLocationHeader(_urlResolver, OperationsConstants.Import, response.TaskId);
             return bulkImportResult;
         }
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             CancelImportResponse response = await _mediator.CancelImportAsync(idParameter, HttpContext.RequestAborted);
 
             _logger.LogInformation("CancelImport {StatusCode}", response.StatusCode);
-            return new ImportResult(response.StatusCode);
+            return new ImportResult(response.StatusCode, _logger);
         }
 
         [HttpGet]
@@ -158,18 +158,18 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             ImportResult bulkImportActionResult;
             if (getBulkImportResult.StatusCode == HttpStatusCode.OK)
             {
-                bulkImportActionResult = ImportResult.Ok(getBulkImportResult.JobResult);
+                bulkImportActionResult = ImportResult.Ok(getBulkImportResult.JobResult, _logger);
                 bulkImportActionResult.SetContentTypeHeader(OperationsConstants.BulkImportContentTypeHeaderValue);
             }
             else
             {
                 if (getBulkImportResult.JobResult == null)
                 {
-                    bulkImportActionResult = ImportResult.Accepted();
+                    bulkImportActionResult = ImportResult.Accepted(_logger);
                 }
                 else
                 {
-                    bulkImportActionResult = ImportResult.Accepted(getBulkImportResult.JobResult);
+                    bulkImportActionResult = ImportResult.Accepted(getBulkImportResult.JobResult, _logger);
                     bulkImportActionResult.SetContentTypeHeader(OperationsConstants.BulkImportContentTypeHeaderValue);
                 }
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/IncludesController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/IncludesController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Medino;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Extensions;
@@ -29,16 +30,20 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly CoreFeatureConfiguration _coreFeaturesConfiguration;
+        private readonly ILogger<IncludesController> _logger;
 
         public IncludesController(
             IMediator mediator,
-            IOptions<CoreFeatureConfiguration> coreFeaturesConfiguration)
+            IOptions<CoreFeatureConfiguration> coreFeaturesConfiguration,
+            ILogger<IncludesController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(coreFeaturesConfiguration?.Value, nameof(coreFeaturesConfiguration));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _coreFeaturesConfiguration = coreFeaturesConfiguration.Value;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -56,7 +61,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 Request.GetQueriesForSearch(),
                 HttpContext.RequestAborted);
 
-            return FhirResult.Create(response);
+            return FhirResult.Create(_logger, response);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/MemberMatchController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/MemberMatchController.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var response = await _mediator.SendAsync<MemberMatchResponse>(new MemberMatchRequest(coverage, patient), HttpContext.RequestAborted);
             var parameters = new Parameters();
             parameters.Add(Patient, response.Patient.ToPoco<Patient>());
-            return MemberMatchResult.Ok(parameters);
+            return MemberMatchResult.Ok(parameters, _logger);
         }
 
         private void ValidateParams(Parameters inputParams, out ResourceElement coverage, out ResourceElement patient)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
@@ -10,6 +10,7 @@ using EnsureThat;
 using Medino;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -40,6 +41,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private readonly CoreFeatureConfiguration _coreFeatureConfiguration;
         private readonly ImplementationGuidesConfiguration _implementationGuidesConfiguration;
         private readonly IFhirRuntimeConfiguration _fhirRuntimeConfiguration;
+        private readonly ILogger<OperationDefinitionController> _logger;
 
         public OperationDefinitionController(
             IMediator mediator,
@@ -47,7 +49,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             IOptions<FeatureConfiguration> featureConfig,
             IOptions<CoreFeatureConfiguration> coreFeatureConfig,
             IOptions<ImplementationGuidesConfiguration> implementationGuidesConfig,
-            IFhirRuntimeConfiguration fhirRuntimeConfiguration)
+            IFhirRuntimeConfiguration fhirRuntimeConfiguration,
+            ILogger<OperationDefinitionController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(operationsConfig?.Value, nameof(operationsConfig));
@@ -55,6 +58,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             EnsureArg.IsNotNull(coreFeatureConfig?.Value, nameof(coreFeatureConfig));
             EnsureArg.IsNotNull(implementationGuidesConfig?.Value, nameof(implementationGuidesConfig));
             EnsureArg.IsNotNull(fhirRuntimeConfiguration, nameof(fhirRuntimeConfiguration));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _operationConfiguration = operationsConfig.Value;
@@ -62,6 +66,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             _coreFeatureConfiguration = coreFeatureConfig.Value;
             _implementationGuidesConfiguration = implementationGuidesConfig.Value;
             _fhirRuntimeConfiguration = fhirRuntimeConfiguration;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -203,7 +208,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             OperationDefinitionResponse response = await _mediator.GetOperationDefinitionAsync(operationName, HttpContext.RequestAborted);
 
-            return FhirResult.Create(response.OperationDefinition, HttpStatusCode.OK);
+            return FhirResult.Create(_logger, response.OperationDefinition, HttpStatusCode.OK);
         }
 
         private void CheckIfOperationIsEnabledAndRespond(string operationName)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 targetSearchParamTypes,
                 HttpContext.RequestAborted);
 
-            var result = FhirResult.Create(response, HttpStatusCode.Created)
+            var result = FhirResult.Create(_logger, response, HttpStatusCode.Created)
                 .SetETagHeader()
                 .SetLastModifiedHeader();
 
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             ReindexSingleResourceResponse response = await _mediator.SendReindexSingleResourceRequestAsync(Request.Method, typeParameter, idParameter, HttpContext.RequestAborted);
 
-            var result = FhirResult.Create(response.ParameterResource, HttpStatusCode.OK);
+            var result = FhirResult.Create(_logger, response.ParameterResource, HttpStatusCode.OK);
 
             return result;
         }
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             ResourceElement response = await _mediator.GetReindexJobAsync(null, HttpContext.RequestAborted);
 
-            return FhirResult.Create(response, HttpStatusCode.OK)
+            return FhirResult.Create(_logger, response, HttpStatusCode.OK)
                 .SetETagHeader()
                 .SetLastModifiedHeader();
         }
@@ -130,7 +130,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             ResourceElement response = await _mediator.GetReindexJobAsync(idParameter, HttpContext.RequestAborted);
 
-            return FhirResult.Create(response, HttpStatusCode.OK)
+            return FhirResult.Create(_logger, response, HttpStatusCode.OK)
                 .SetETagHeader()
                 .SetLastModifiedHeader();
         }
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             ResourceElement response = await _mediator.CancelReindexAsync(idParameter, HttpContext.RequestAborted);
 
-            return FhirResult.Create(response, HttpStatusCode.Accepted)
+            return FhirResult.Create(_logger, response, HttpStatusCode.Accepted)
                 .SetETagHeader()
                 .SetLastModifiedHeader();
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
@@ -12,6 +12,7 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Medino;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Extensions;
@@ -37,16 +38,19 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly CoreFeatureConfiguration _coreFeaturesConfig;
+        private readonly ILogger<SearchParameterController> _logger;
         private bool _isSelectSearchParameterSupported;
 
-        public SearchParameterController(IMediator mediator, IOptions<CoreFeatureConfiguration> coreFeatures, IFhirRuntimeConfiguration fhirConfig)
+        public SearchParameterController(IMediator mediator, IOptions<CoreFeatureConfiguration> coreFeatures, IFhirRuntimeConfiguration fhirConfig, ILogger<SearchParameterController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(coreFeatures?.Value, nameof(coreFeatures));
             EnsureArg.IsNotNull(fhirConfig, nameof(fhirConfig));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _coreFeaturesConfig = coreFeatures.Value;
+            _logger = logger;
 
             // Used to prevent Azure Api for Fhir from using this controller.
             _isSelectSearchParameterSupported = fhirConfig.IsSelectiveSearchParameterSupported;
@@ -68,7 +72,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             SearchParameterStateRequest request = new SearchParameterStateRequest(GetQueriesForSearch());
             SearchParameterStateResponse result = await _mediator.SendAsync(request, cancellationToken);
 
-            return FhirResult.Create(result.SearchParameters, System.Net.HttpStatusCode.OK);
+            return FhirResult.Create(_logger, result.SearchParameters, System.Net.HttpStatusCode.OK);
         }
 
         /// <summary>
@@ -87,7 +91,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             SearchParameterStateRequest request = new SearchParameterStateRequest(GetQueriesForSearch());
             SearchParameterStateResponse result = await _mediator.SendAsync(request, cancellationToken);
 
-            return FhirResult.Create(result.SearchParameters, System.Net.HttpStatusCode.OK);
+            return FhirResult.Create(_logger, result.SearchParameters, System.Net.HttpStatusCode.OK);
         }
 
         /// <summary>
@@ -105,7 +109,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             SearchParameterStateUpdateRequest updateRequest = ParseUpdateRequestBody(inputParams);
             SearchParameterStateUpdateResponse result = await _mediator.SendAsync(updateRequest, cancellationToken);
 
-            return FhirResult.Create(result.UpdateStatus, System.Net.HttpStatusCode.OK);
+            return FhirResult.Create(_logger, result.UpdateStatus, System.Net.HttpStatusCode.OK);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/TerminologyController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/TerminologyController.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Medino;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Extensions;
@@ -46,16 +47,20 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
         private readonly IMediator _mediator;
         private readonly TerminologyConfiguration _configuration;
+        private readonly ILogger<TerminologyController> _logger;
 
         public TerminologyController(
             IMediator mediator,
-            IOptions<TerminologyConfiguration> configuration)
+            IOptions<TerminologyConfiguration> configuration,
+            ILogger<TerminologyController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(configuration?.Value, nameof(configuration));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _configuration = configuration.Value;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -76,7 +81,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var response = await _mediator.SendAsync<ExpandResponse>(
                 request,
                 HttpContext.RequestAborted);
-            return FhirResult.Create(response.Resource);
+            return FhirResult.Create(_logger, response.Resource);
         }
 
         [HttpGet]
@@ -102,7 +107,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var response = await _mediator.SendAsync<ExpandResponse>(
                 request,
                 HttpContext.RequestAborted);
-            return FhirResult.Create(response.Resource);
+            return FhirResult.Create(_logger, response.Resource);
         }
 
         [HttpPost]
@@ -124,7 +129,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var response = await _mediator.SendAsync<ExpandResponse>(
                 request,
                 HttpContext.RequestAborted);
-            return FhirResult.Create(response.Resource);
+            return FhirResult.Create(_logger, response.Resource);
         }
 
         private static string Convert(DataType value)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ValidateController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ValidateController.cs
@@ -10,6 +10,7 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Medino;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Filters;
@@ -31,13 +32,16 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly ResourceDeserializer _resourceDeserializer;
+        private readonly ILogger<ValidateController> _logger;
 
-        public ValidateController(IMediator mediator, ResourceDeserializer resourceDeserializer)
+        public ValidateController(IMediator mediator, ResourceDeserializer resourceDeserializer, ILogger<ValidateController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _resourceDeserializer = resourceDeserializer;
+            _logger = logger;
         }
 
         [HttpPost]
@@ -131,7 +135,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private async Task<IActionResult> RunValidationAsync(ResourceElement resource, Uri profile)
         {
             var response = await _mediator.SendAsync<ValidateOperationResponse>(new ValidateOperationRequest(resource, profile));
-            return FhirResult.Create(new OperationOutcome { Issue = response.Issues.Select(x => x.ToPoco()).ToList() }.ToResourceElement());
+            return FhirResult.Create(_logger, new OperationOutcome { Issue = response.Issues.Select(x => x.ToPoco()).ToList() }.ToResourceElement());
         }
 
         private static Uri GetProfile(string profile)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/FhirResult.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/FhirResult.cs
@@ -8,6 +8,7 @@ using System.Net;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Routing;
@@ -23,7 +24,8 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// <summary>
         /// Initializes a new instance of the <see cref="FhirResult" /> class.
         /// </summary>
-        public FhirResult()
+        public FhirResult(ILogger logger)
+            : base(logger)
         {
         }
 
@@ -31,14 +33,16 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// Initializes a new instance of the <see cref="FhirResult" /> class.
         /// </summary>
         /// <param name="resource">The resource.</param>
-        public FhirResult(IResourceElement resource)
-            : base(resource)
+        /// <param name="logger">The logger.</param>
+        public FhirResult(IResourceElement resource, ILogger logger)
+            : base(resource, logger)
         {
         }
 
         /// <summary>
         /// Creates a FHIR result with the specified parameters
         /// </summary>
+        /// <param name="logger">The logger.</param>
         /// <param name="resource">The resource.</param>
         /// <param name="statusCode">The status code.</param>
         /// <param name="setETagheader">The value indicating whether to add the ETag header.</param>
@@ -48,6 +52,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// <param name="returnPreference">The return preference.</param>
         /// <param name="operationOutcomeMessage">The operation outcome message.</param>
         public static FhirResult Create(
+            ILogger logger,
             IResourceElement resource,
             HttpStatusCode statusCode = HttpStatusCode.OK,
             bool setETagheader = false,
@@ -58,8 +63,9 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
             string operationOutcomeMessage = null)
         {
             EnsureArg.IsNotNull(resource, nameof(resource));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
-            var result = new FhirResult(resource)
+            var result = new FhirResult(resource, logger)
             {
                 StatusCode = statusCode,
             };
@@ -83,7 +89,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
             {
                 if (returnPreference == ReturnPreference.Minimal)
                 {
-                    var minimalResult = new FhirResult(null)
+                    var minimalResult = new FhirResult(null, logger)
                     {
                         StatusCode = statusCode,
                     };
@@ -109,7 +115,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
                             },
                         });
 
-                    var operationOutcomeResult = new FhirResult(operationOutcome.ToResourceElement())
+                    var operationOutcomeResult = new FhirResult(operationOutcome.ToResourceElement(), logger)
                     {
                         StatusCode = statusCode,
                     };
@@ -129,9 +135,9 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// <summary>
         /// Creates a Gone response
         /// </summary>
-        public static FhirResult Gone()
+        public static FhirResult Gone(ILogger logger)
         {
-            return new FhirResult
+            return new FhirResult(logger)
             {
                 StatusCode = HttpStatusCode.Gone,
             };
@@ -140,9 +146,9 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// <summary>
         /// Returns a NotFound response
         /// </summary>
-        public static FhirResult NotFound()
+        public static FhirResult NotFound(ILogger logger)
         {
-            return new FhirResult
+            return new FhirResult(logger)
             {
                 StatusCode = HttpStatusCode.NotFound,
             };
@@ -151,9 +157,9 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// <summary>
         /// Returns a NoContent response
         /// </summary>
-        public static FhirResult NoContent()
+        public static FhirResult NoContent(ILogger logger)
         {
-            return new FhirResult
+            return new FhirResult(logger)
             {
                 StatusCode = HttpStatusCode.NoContent,
             };

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/MemberMatchResult.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/MemberMatchResult.cs
@@ -6,13 +6,14 @@
 using System.Net;
 using EnsureThat;
 using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
     public sealed class MemberMatchResult : ResourceActionResult<Parameters>
     {
-        private MemberMatchResult(Parameters parameters, HttpStatusCode statusCode)
-            : base(parameters, statusCode)
+        private MemberMatchResult(Parameters parameters, HttpStatusCode statusCode, ILogger logger)
+            : base(parameters, statusCode, logger)
         {
             EnsureArg.IsNotNull(parameters, nameof(parameters));
         }
@@ -21,9 +22,10 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// Creates an <see cref="MemberMatchResult"/> with <see cref="HttpStatusCode.OK"/>
         /// </summary>
         /// <param name="parameters">Parameters object containing Patient with identifier.</param>
-        public static MemberMatchResult Ok(Parameters parameters)
+        /// <param name="logger">The logger.</param>
+        public static MemberMatchResult Ok(Parameters parameters, ILogger logger)
         {
-            return new MemberMatchResult(parameters, HttpStatusCode.OK);
+            return new MemberMatchResult(parameters, HttpStatusCode.OK, logger);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/OperationVersionsResult.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/OperationVersionsResult.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Operations.Versions;
 using Microsoft.Net.Http.Headers;
 using Task = System.Threading.Tasks.Task;
@@ -33,8 +34,9 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
         /// </summary>
         /// <param name="versionsResult">The result for the versions operation.</param>
         /// <param name="statusCode">The HTTP status code.</param>
-        public OperationVersionsResult(VersionsResult versionsResult, HttpStatusCode statusCode)
-            : base(versionsResult, statusCode)
+        /// <param name="logger">The logger.</param>
+        public OperationVersionsResult(VersionsResult versionsResult, HttpStatusCode statusCode, ILogger logger)
+            : base(versionsResult, statusCode, logger)
         {
             EnsureArg.IsNotNull(versionsResult, nameof(versionsResult));
             _versionsResult = versionsResult;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Exceptions/BaseExceptionMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Exceptions/BaseExceptionMiddleware.cs
@@ -110,7 +110,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Exceptions
 
                 var result = new OperationOutcomeResult(
                     operationOutcome,
-                    exception is ServiceUnavailableException ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.InternalServerError);
+                    exception is ServiceUnavailableException ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.InternalServerError,
+                    _logger);
 
                 doesOperationOutcomeHaveError = true;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttribute.cs
@@ -11,6 +11,7 @@ using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
@@ -26,16 +27,20 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
     {
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
         private readonly IAuditEventTypeMapping _auditEventTypeMapping;
+        private readonly ILogger<FhirRequestContextRouteDataPopulatingFilterAttribute> _logger;
 
         public FhirRequestContextRouteDataPopulatingFilterAttribute(
             RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor,
-            IAuditEventTypeMapping auditEventTypeMapping)
+            IAuditEventTypeMapping auditEventTypeMapping,
+            ILogger<FhirRequestContextRouteDataPopulatingFilterAttribute> logger)
         {
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(auditEventTypeMapping, nameof(auditEventTypeMapping));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _auditEventTypeMapping = auditEventTypeMapping;
+            _logger = logger;
         }
 
         public override void OnActionExecuting(ActionExecutingContext context)
@@ -107,7 +112,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                                         },
                                     },
                                 },
-                                HttpStatusCode.BadRequest);
+                                HttpStatusCode.BadRequest,
+                                _logger);
                             return;
                         }
                     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                             LastUpdated = Clock.UtcNow,
                         },
                     },
-                    HttpStatusCode.BadRequest);
+                    HttpStatusCode.BadRequest,
+                    _logger);
 
                 switch (fhirException)
                 {
@@ -304,7 +305,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                         LastUpdated = Clock.UtcNow,
                     },
                 },
-                httpStatusCode);
+                httpStatusCode,
+                _logger);
         }
     }
 }


### PR DESCRIPTION
## Description
Small changes to address errors noticed in production.
* InvalidOperationExceptions can happen in CosmosDbProcessor, because the HttpHeader is not thread-safe.
* Adding logs to ResourceActionResult.

## Related issues
Addresses [AB#188019](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/188019) and [AB#205408](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/205408)

## FHIR Team Checklist
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
