### PR TITLE
Fix delete search param by url

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
@@ -3,22 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
-using Hl7.Fhir.ElementModel;
 using Medino;
-using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Exceptions;
-using Microsoft.Health.Fhir.Core.Extensions;
-using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
-using Microsoft.Health.Fhir.Core.Features.Search.Registry;
-using Microsoft.Health.Fhir.Core.Features.Validation;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -27,34 +19,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
     public class DeleteSearchParameterBehavior<TDeleteResourceRequest, TDeleteResourceResponse> : IPipelineBehavior<TDeleteResourceRequest, TDeleteResourceResponse>
         where TDeleteResourceRequest : DeleteResourceRequest, IRequest<TDeleteResourceResponse>
     {
-        private readonly ISearchParameterOperations _searchParameterOperations;
         private readonly IFhirDataStore _fhirDataStore;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
-        private readonly RequestContextAccessor<IFhirRequestContext> _requestContextAccessor;
-        private readonly IModelInfoProvider _modelInfoProvider;
 
         public DeleteSearchParameterBehavior(
-            ISearchParameterOperations searchParameterOperations,
             IFhirDataStore fhirDataStore,
-            ISearchParameterDefinitionManager searchParameterDefinitionManager,
-            ISearchParameterStatusManager searchParameterStatusManager,
-            RequestContextAccessor<IFhirRequestContext> requestContextAccessor,
-            IModelInfoProvider modelInfoProvider)
+            ISearchParameterDefinitionManager searchParameterDefinitionManager)
         {
-            EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
             EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
-            EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
-            EnsureArg.IsNotNull(requestContextAccessor, nameof(requestContextAccessor));
-            EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
 
-            _searchParameterOperations = searchParameterOperations;
             _fhirDataStore = fhirDataStore;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
-            _searchParameterStatusManager = searchParameterStatusManager;
-            _requestContextAccessor = requestContextAccessor;
-            _modelInfoProvider = modelInfoProvider;
         }
 
         public async Task<TDeleteResourceResponse> HandleAsync(TDeleteResourceRequest request, RequestHandlerDelegate<TDeleteResourceResponse> next, CancellationToken cancellationToken)
@@ -76,54 +52,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 {
                     throw new ResourceNotFoundException(string.Format(Core.Resources.ResourceNotFoundById, deleteRequest.ResourceKey.ResourceType, deleteRequest.ResourceKey.Id));
                 }
-
-                // If the search parameter exists and is not already deleted, update status to pending delete
-                if (!searchParamResource.IsDeleted)
-                {
-                    var typed = _modelInfoProvider.ToTypedElement(searchParamResource.RawResource);
-                    await QueuePendingDeleteStatusAsync(typed.GetStringScalar("url"), deleteRequest.DeleteOperation, cancellationToken);
-                }
-
-                return await next();
             }
 
             return await next();
-        }
-
-        private async Task QueuePendingDeleteStatusAsync(string url, DeleteOperation deleteOperation, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrWhiteSpace(url))
-            {
-                return;
-            }
-
-            var context = _requestContextAccessor.RequestContext;
-            if (context == null)
-            {
-                return;
-            }
-
-            var lastUpdated = _requestContextAccessor.RequestContext.GetSearchParameterLastUpdated();
-            if (!lastUpdated.HasValue)
-            {
-                await _searchParameterOperations.GetAndApplySearchParameterUpdates(cancellationToken);
-                lastUpdated = _searchParameterOperations.SearchParamLastUpdated;
-            }
-
-            _searchParameterDefinitionManager.TryGetSearchParameter(url, out var existing);
-
-            var status = deleteOperation == DeleteOperation.HardDelete ? SearchParameterStatus.PendingHardDelete : SearchParameterStatus.PendingDelete;
-
-            var update = new ResourceSearchParameterStatus
-            {
-                Uri = new Uri(url),
-                Status = status,
-                LastUpdated = lastUpdated.Value,
-                IsPartiallySupported = existing?.IsPartiallySupported ?? false,
-                SortStatus = existing?.SortStatus ?? SortParameterStatus.Disabled,
-            };
-
-            context.Properties[SearchParameterRequestContextPropertyNames.PendingStatus] = update;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
     {
         DateTimeOffset SearchParamLastUpdated { get; }
 
-        Task DeleteSearchParameterAsync(RawResource searchParamResource, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, bool isHardDelete = false);
+        Task DeleteSearchParameterAsync(RawResource searchParamResource, CancellationToken cancellationToken, bool isHardDelete = false);
 
         Task<DateTimeOffset> ValidateSearchParameterAsync(ITypedElement searchParam, CancellationToken cancellationToken, DateTimeOffset? lastUpdated = null);
 
-        Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false);
+        Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken);
 
         /// <summary>
         /// This method should be called to get any updates to search param cache

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -168,9 +168,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         /// </summary>
         /// <param name="searchParamResource">Search Parameter to update to Pending Delete status.</param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        /// <param name="ignoreSearchParameterNotSupportedException">The value indicating whether to ignore SearchParameterNotSupportedException.</param>
         /// <param name="isHardDelete">True for hard delete (PendingHardDelete), false for soft delete (PendingDelete).</param>
-        public async Task DeleteSearchParameterAsync(RawResource searchParamResource, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, bool isHardDelete = false)
+        public async Task DeleteSearchParameterAsync(RawResource searchParamResource, CancellationToken cancellationToken, bool isHardDelete = false)
         {
             var searchParam = _modelInfoProvider.ToTypedElement(searchParamResource);
             var searchParameterUrl = searchParam.GetStringScalar("url");
@@ -185,7 +184,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     new[] { searchParameterUrl },
                     status,
                     cancellationToken,
-                    ignoreSearchParameterNotSupportedException: ignoreSearchParameterNotSupportedException,
                     lastUpdated: SearchParamLastUpdated);
             }
             catch (FhirException fex)
@@ -211,9 +209,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
         }
 
-        public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false)
+        public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken)
         {
-            await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(searchParameterUris, status, cancellationToken, ignoreSearchParameterNotSupportedException);
+            await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(searchParameterUris, status, cancellationToken);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -181,7 +181,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 await GetAndApplySearchParameterUpdates(cancellationToken);
                 var status = isHardDelete ? SearchParameterStatus.PendingHardDelete : SearchParameterStatus.PendingDelete;
                 _logger.LogInformation("DeleteSearchParameterAsync: Deleting the search parameter '{Url}' with status {Status}", searchParameterUrl, status);
-                await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new[] { searchParameterUrl }, status, cancellationToken, lastUpdated: SearchParamLastUpdated);
+                await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(
+                    new[] { searchParameterUrl },
+                    status,
+                    cancellationToken,
+                    ignoreSearchParameterNotSupportedException: ignoreSearchParameterNotSupportedException,
+                    lastUpdated: SearchParamLastUpdated);
             }
             catch (FhirException fex)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
         Task HandleAsync(SearchParameterDefinitionManagerInitialized notification, CancellationToken cancellationToken);
 
-        Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, long? reindexId = null, DateTimeOffset? lastUpdated = null);
+        Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, long? reindexId = null, DateTimeOffset? lastUpdated = null);
 
         Task<CacheConsistencyResult> CheckCacheConsistencyAsync(DateTime updateEventsSince, DateTime activeHostsSince, CancellationToken cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -149,7 +149,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 // This makes sense only for status other than Deleted.
                 if (status != SearchParameterStatus.Deleted)
                 {
-                    _searchParameterDefinitionManager.GetSearchParameter(uri);
+                    if (ignoreSearchParameterNotSupportedException)
+                    {
+                        _searchParameterDefinitionManager.TryGetSearchParameter(uri, out _);
+                    }
+                    else
+                    {
+                        _searchParameterDefinitionManager.GetSearchParameter(uri);
+                    }
                 }
 
                 // It does not make sense to keep any of existing ResourceSearchParameterStatus components as results do not depend on them.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             await EnsureInitializedAsync(cancellationToken);
         }
 
-        public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, long? reindexId = null, DateTimeOffset? lastUpdated = null)
+        public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, long? reindexId = null, DateTimeOffset? lastUpdated = null)
         {
             EnsureArg.IsNotNull(searchParameterUris);
 
@@ -149,14 +149,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 // This makes sense only for status other than Deleted.
                 if (status != SearchParameterStatus.Deleted)
                 {
-                    if (ignoreSearchParameterNotSupportedException)
-                    {
-                        _searchParameterDefinitionManager.TryGetSearchParameter(uri, out _);
-                    }
-                    else
-                    {
-                        _searchParameterDefinitionManager.GetSearchParameter(uri);
-                    }
+                    _searchParameterDefinitionManager.GetSearchParameter(uri);
                 }
 
                 // It does not make sense to keep any of existing ResourceSearchParameterStatus components as results do not depend on them.

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -308,22 +308,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         {
             EnsureArg.IsNotNull(resource, nameof(resource));
 
-            // Skip write for SearchParameter in pending delete - just return existing
-            if (resource.ResourceTypeName == KnownResourceTypes.SearchParameter && resource.IsDeleted)
-            {
-                var pending = GetPendingSearchParameterStatus();
-                if (pending?.Status == SearchParameterStatus.PendingDelete || pending?.Status == SearchParameterStatus.PendingHardDelete)
-                {
-                    var existing = await GetAsync(new ResourceKey(resource.ResourceTypeName, resource.ResourceId), cancellationToken);
-                    if (existing == null)
-                    {
-                        throw new ResourceNotFoundException(string.Format(Fhir.Core.Resources.ResourceNotFoundById, resource.ResourceTypeName, resource.ResourceId));
-                    }
-
-                    return new UpsertOutcome(existing, SaveOutcomeType.Updated);
-                }
-            }
-
             var cosmosWrapper = new FhirCosmosResourceWrapper(resource);
             UpdateSortIndex(cosmosWrapper);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
@@ -987,7 +987,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                         Arg.Is<IReadOnlyCollection<string>>(l => l.Contains(searchParam.Url.ToString())),
                         SearchParameterStatus.Disabled,
                         Arg.Any<CancellationToken>(),
-                        Arg.Any<bool>(),
                         Arg.Any<long?>(),
                         Arg.Any<DateTimeOffset?>());
         }
@@ -1038,7 +1037,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                     urls.Contains(orphanCustom.Url.OriginalString)),
                 SearchParameterStatus.Deleted,
                 Arg.Any<CancellationToken>(),
-                Arg.Any<bool>(),
                 Arg.Is<long?>(id => id == jobInfo.Id),
                 Arg.Any<DateTimeOffset?>());
         }
@@ -1088,7 +1086,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Arg.Any<IReadOnlyCollection<string>>(),
                 SearchParameterStatus.Deleted,
                 Arg.Any<CancellationToken>(),
-                Arg.Any<bool>(),
                 Arg.Is<long?>(id => id == jobInfo.Id),
                 Arg.Any<DateTimeOffset?>());
         }
@@ -1125,7 +1122,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Arg.Any<IReadOnlyCollection<string>>(),
                 SearchParameterStatus.Deleted,
                 Arg.Any<CancellationToken>(),
-                Arg.Any<bool>(),
                 Arg.Is<long?>(id => id == jobInfo.Id),
                 Arg.Any<DateTimeOffset?>());
         }
@@ -1177,7 +1173,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Arg.Is<List<string>>(l => l.Contains(searchParam.Url.ToString())),
                 SearchParameterStatus.Deleted,
                 Arg.Any<CancellationToken>(),
-                Arg.Any<bool>(),
                 Arg.Any<long?>());
         }
 
@@ -1828,7 +1823,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                             l.Contains(patientBirthdateParam.Url.ToString())),
                         SearchParameterStatus.Enabled,
                         Arg.Any<CancellationToken>(),
-                        false,
                         Arg.Is<long?>(id => id == jobInfo.Id));
 
                     receivedCall = true;
@@ -2064,7 +2058,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Arg.Any<IReadOnlyCollection<string>>(),
                 SearchParameterStatus.Enabled,
                 Arg.Any<CancellationToken>(),
-                false,
                 Arg.Is<long?>(id => id == jobInfo.Id));
         }
 
@@ -2233,13 +2226,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                         Arg.Is<IReadOnlyCollection<string>>(l => l.Contains(searchParamLowercase.Url.ToString())),
                         SearchParameterStatus.Enabled,
                         Arg.Any<CancellationToken>(),
-                        false,
                         Arg.Is<long?>(id => id == jobInfo.Id));
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
                         Arg.Is<IReadOnlyCollection<string>>(l => l.Contains(searchParamMixedCase.Url.ToString())),
                         SearchParameterStatus.Deleted,
                         Arg.Any<CancellationToken>(),
-                        false,
                         Arg.Is<long?>(id => id == jobInfo.Id));
         }
 
@@ -2314,14 +2305,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                         Arg.Is<IReadOnlyCollection<string>>(l => l.Contains(searchParam1.Url.ToString())),
                         SearchParameterStatus.Disabled,
                         Arg.Any<CancellationToken>(),
-                        false,
                         Arg.Is<long?>(id => id == jobInfo.Id));
 
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
                         Arg.Is<IReadOnlyCollection<string>>(l => l.Contains(searchParam2.Url.ToString())),
                         SearchParameterStatus.Disabled,
                         Arg.Any<CancellationToken>(),
-                        false,
                         Arg.Is<long?>(id => id == jobInfo.Id));
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
             _cancellationToken = CancellationToken.None;
 
             _authorizationService.CheckAccess(DataActions.SearchParameter, _cancellationToken).Returns(DataActions.SearchParameter);
-            _searchParameterOperations.UpdateSearchParameterStatusAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<SearchParameterStatus>(), Arg.Any<CancellationToken>(), Arg.Any<bool>()).Returns(Task.CompletedTask);
+            _searchParameterOperations.UpdateSearchParameterStatusAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<SearchParameterStatus>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
             var searchParamDefinitionStore = new List<SearchParameterInfo>
             {
@@ -239,7 +239,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
             var statusPart = resourceResponse.Parameter[0].Part.Where(p => p.Name == SearchParameterStateProperties.Status).First();
             Assert.True(urlPart.Value.ToString() == ResourceId);
             Assert.True(statusPart.Value.ToString() == SearchParameterStatus.Supported.ToString());
-            await _searchParameterOperations.Received(1).UpdateSearchParameterStatusAsync(Arg.Is<IReadOnlyCollection<string>>(x => x.Count == 1 && x.First() == ResourceId), SearchParameterStatus.Supported, Arg.Any<CancellationToken>(), false);
+            await _searchParameterOperations.Received(1).UpdateSearchParameterStatusAsync(Arg.Is<IReadOnlyCollection<string>>(x => x.Count == 1 && x.First() == ResourceId), SearchParameterStatus.Supported, Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -303,7 +303,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
             var statusPart = resourceResponse.Parameter[0].Part.Where(p => p.Name == SearchParameterStateProperties.Status).First();
             Assert.True(urlPart.Value.ToString() == ResourceId);
             Assert.True(statusPart.Value.ToString() == SearchParameterStatus.PendingDisable.ToString());
-            await _searchParameterOperations.Received(1).UpdateSearchParameterStatusAsync(Arg.Is<IReadOnlyCollection<string>>(x => x.Count == 1 && x.First() == ResourceId), SearchParameterStatus.PendingDisable, Arg.Any<CancellationToken>(), false);
+            await _searchParameterOperations.Received(1).UpdateSearchParameterStatusAsync(Arg.Is<IReadOnlyCollection<string>>(x => x.Count == 1 && x.First() == ResourceId), SearchParameterStatus.PendingDisable, Arg.Any<CancellationToken>());
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Delete/DeletionServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Delete/DeletionServiceTests.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.Delete
 
             var attemptCount = 0;
             _searchParameterOperations
-                .DeleteSearchParameterAsync(Arg.Any<RawResource>(), Arg.Any<CancellationToken>(), Arg.Any<bool>(), Arg.Any<bool>())
+                .DeleteSearchParameterAsync(Arg.Any<RawResource>(), Arg.Any<CancellationToken>(), Arg.Any<bool>())
                 .Returns(callInfo =>
                 {
                     attemptCount++;
@@ -263,7 +263,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.Delete
             _dataStoreFactory.GetScopedDataStore().Returns(scopedDataStore);
 
             _searchParameterOperations
-                .DeleteSearchParameterAsync(Arg.Any<RawResource>(), Arg.Any<CancellationToken>(), Arg.Any<bool>(), Arg.Any<bool>())
+                .DeleteSearchParameterAsync(Arg.Any<RawResource>(), Arg.Any<CancellationToken>(), Arg.Any<bool>())
                 .Returns(_ => throw new BadRequestException(Core.Resources.SearchParameterConcurrencyConflict));
 
             var exception = await Assert.ThrowsAsync<IncompleteOperationException<IDictionary<string, long>>>(async () =>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterBehaviorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterBehaviorTests.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private readonly IResourceWrapperFactory _resourceWrapperFactory;
         private readonly IFhirDataStore _fhirDataStore;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
-        private readonly ISearchParameterStatusManager _searchParameterStatusManager = Substitute.For<ISearchParameterStatusManager>();
         private readonly RequestContextAccessor<IFhirRequestContext> _requestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
         private readonly IModelInfoProvider _modelInfoProvider = ModelInfoProvider.Instance;
 
@@ -125,15 +124,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var response = new DeleteResourceResponse(key);
 
-            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore, _searchParameterDefinitionManager, _searchParameterStatusManager, _requestContextAccessor, _modelInfoProvider);
+            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_fhirDataStore, _searchParameterDefinitionManager);
             await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None);
 
             await _searchParameterOperations.DidNotReceive().ValidateSearchParameterAsync(Arg.Any<ITypedElement>(), Arg.Any<CancellationToken>());
-            await _searchParameterStatusManager.DidNotReceive().GetAllSearchParameterStatus(Arg.Any<CancellationToken>());
         }
 
         [Fact]
-        public async Task GivenADeleteResourceRequest_WhenDeletingASearchParameterResource_ThenPendingDeleteStatusIsQueued()
+        public async Task GivenADeleteResourceRequest_WhenDeletingASearchParameterResource_ThenPendingDeleteStatusIsNotQueued()
         {
             var searchParameter = new SearchParameter() { Id = "Id", Url = "http://example.com/Id" };
             var resource = searchParameter.ToTypedElement().ToResourceElement();
@@ -151,14 +149,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var response = new DeleteResourceResponse(key);
 
-            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore, _searchParameterDefinitionManager, _searchParameterStatusManager, _requestContextAccessor, _modelInfoProvider);
-            await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None);
+            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_fhirDataStore, _searchParameterDefinitionManager);
+            var actualResponse = await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None);
 
-            Assert.True(contextProperties.ContainsKey(SearchParameterRequestContextPropertyNames.PendingStatus));
-            var pendingStatus = contextProperties[SearchParameterRequestContextPropertyNames.PendingStatus] as ResourceSearchParameterStatus;
-            Assert.NotNull(pendingStatus);
-            Assert.Equal(SearchParameterStatus.PendingDelete, pendingStatus.Status);
-            Assert.Equal("http://example.com/Id", pendingStatus.Uri.OriginalString);
+            Assert.Same(response, actualResponse);
+            Assert.False(contextProperties.ContainsKey(SearchParameterRequestContextPropertyNames.PendingStatus));
         }
 
         [Fact]
@@ -175,10 +170,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var response = new DeleteResourceResponse(key);
 
-            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore, _searchParameterDefinitionManager, _searchParameterStatusManager, _requestContextAccessor, _modelInfoProvider);
+            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_fhirDataStore, _searchParameterDefinitionManager);
             await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None);
-
-            await _searchParameterStatusManager.DidNotReceive().GetAllSearchParameterStatus(Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -191,7 +184,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var response = new DeleteResourceResponse(key);
 
-            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore, _searchParameterDefinitionManager, _searchParameterStatusManager, _requestContextAccessor, _modelInfoProvider);
+            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_fhirDataStore, _searchParameterDefinitionManager);
 
             await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
                 await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None));
@@ -215,7 +208,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var response = new DeleteResourceResponse(key);
 
-            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore, _searchParameterDefinitionManager, _searchParameterStatusManager, _requestContextAccessor, _modelInfoProvider);
+            var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_fhirDataStore, _searchParameterDefinitionManager);
 
             await Assert.ThrowsAsync<MethodNotAllowedException>(async () =>
                 await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None));
@@ -280,9 +273,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var newWrapper = CreateResourceWrapper(newResource, false);
 
             _fhirDataStore.GetAsync(key, Arg.Any<CancellationToken>()).Returns(oldWrapper);
-            _searchParameterStatusManager.GetAllSearchParameterStatus(Arg.Any<CancellationToken>())
-                .Returns(new List<ResourceSearchParameterStatus>());
-
             var contextProperties = new Dictionary<string, object>();
             var fhirContext = Substitute.For<IFhirRequestContext>();
             fhirContext.Properties.Returns(contextProperties);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -719,7 +719,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     async () =>
                     {
                         // Only mark with pending status. The actual deletion is performed by the reindex job.
-                        await _searchParameterOperations.DeleteSearchParameterAsync(rawResource, cancellationToken, ignoreSearchParameterNotSupportedException: true, isHardDelete: isHardDelete);
+                        await _searchParameterOperations.DeleteSearchParameterAsync(rawResource, cancellationToken, isHardDelete);
                     },
                     "Deletion");
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -109,6 +109,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             switch (request.DeleteOperation)
             {
                 case DeleteOperation.SoftDelete:
+                    if (key.ResourceType == KnownResourceTypes.SearchParameter)
+                    {
+                        await DeleteSearchParameter(key, fhirDataStore, isHardDelete: false, cancellationToken);
+                        break;
+                    }
+
                     ResourceWrapper deletedWrapper = CreateSoftDeletedWrapper(key.ResourceType, request.ResourceKey.Id);
 
                     bool keepHistory = await _conformanceProvider.Value.CanKeepHistory(key.ResourceType, cancellationToken);
@@ -120,12 +126,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 case DeleteOperation.HardDelete:
                     if (key.ResourceType == KnownResourceTypes.SearchParameter)
                     {
-                        var resourceWrapper = await fhirDataStore.GetAsync(key, cancellationToken);
-                        if (resourceWrapper != null && !resourceWrapper.IsDeleted)
-                        {
-                            await _retryPolicy.ExecuteAsync(async () => await _searchParameterOperations.DeleteSearchParameterAsync(resourceWrapper.RawResource, cancellationToken, ignoreSearchParameterNotSupportedException: true, isHardDelete: true));
-                        }
-
+                        await DeleteSearchParameter(key, fhirDataStore, isHardDelete: true, cancellationToken);
                         break;
                     }
 
@@ -518,8 +519,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     }
                     else
                     {
-                        // For HardDelete, only mark with PendingHardDelete status. The actual deletion is performed by the reindex job.
-                        await DeleteSearchParameterWithLockAsync(item, true, cancellationToken);
+                        await DeleteSearchParameterWithLockAsync(item.Resource.RawResource, true, cancellationToken);
                     }
 
                     parallelBag.Add((item.Resource.ResourceTypeName, item.Resource.ResourceId, item.SearchEntryMode == ValueSets.SearchEntryMode.Include));
@@ -697,11 +697,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         {
             foreach (var entry in entries.Where(_ => _.Resource.ResourceTypeName == KnownResourceTypes.SearchParameter))
             {
-                await DeleteSearchParameterWithLockAsync(entry, false, cancellationToken);
+                await DeleteSearchParameterWithLockAsync(entry.Resource.RawResource, false, cancellationToken);
             }
         }
 
-        private async Task DeleteSearchParameterWithLockAsync(SearchResultEntry item, bool isHardDelete, CancellationToken cancellationToken)
+        private async Task DeleteSearchParameter(ResourceKey key, IFhirDataStore fhirDataStore, bool isHardDelete, CancellationToken cancellationToken)
+        {
+            var resourceWrapper = await fhirDataStore.GetAsync(key, cancellationToken);
+            if (resourceWrapper != null && !resourceWrapper.IsDeleted)
+            {
+                await DeleteSearchParameterWithLockAsync(resourceWrapper.RawResource, isHardDelete, cancellationToken);
+            }
+        }
+
+        private async Task DeleteSearchParameterWithLockAsync(RawResource rawResource, bool isHardDelete, CancellationToken cancellationToken)
         {
             await _searchParamDeleteSemaphore.WaitAsync(cancellationToken);
             try
@@ -709,7 +718,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 await SearchParameterRetry.ExecuteAsync(
                     async () =>
                     {
-                        await _searchParameterOperations.DeleteSearchParameterAsync(item.Resource.RawResource, cancellationToken, ignoreSearchParameterNotSupportedException: true, isHardDelete: isHardDelete);
+                        // Only mark with pending status. The actual deletion is performed by the reindex job.
+                        await _searchParameterOperations.DeleteSearchParameterAsync(rawResource, cancellationToken, ignoreSearchParameterNotSupportedException: true, isHardDelete: isHardDelete);
                     },
                     "Deletion");
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     }
                     else
                     {
-                        await DeleteSearchParameterWithLockAsync(item.Resource.RawResource, true, cancellationToken);
+                        await DeleteSearchParameterAsync(item.Resource.RawResource, true, cancellationToken);
                     }
 
                     parallelBag.Add((item.Resource.ResourceTypeName, item.Resource.ResourceId, item.SearchEntryMode == ValueSets.SearchEntryMode.Include));
@@ -697,7 +697,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         {
             foreach (var entry in entries.Where(_ => _.Resource.ResourceTypeName == KnownResourceTypes.SearchParameter))
             {
-                await DeleteSearchParameterWithLockAsync(entry.Resource.RawResource, false, cancellationToken);
+                await DeleteSearchParameterAsync(entry.Resource.RawResource, false, cancellationToken);
             }
         }
 
@@ -706,11 +706,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             var resourceWrapper = await fhirDataStore.GetAsync(key, cancellationToken);
             if (resourceWrapper != null && !resourceWrapper.IsDeleted)
             {
-                await DeleteSearchParameterWithLockAsync(resourceWrapper.RawResource, isHardDelete, cancellationToken);
+                await DeleteSearchParameterAsync(resourceWrapper.RawResource, isHardDelete, cancellationToken);
             }
         }
 
-        private async Task DeleteSearchParameterWithLockAsync(RawResource rawResource, bool isHardDelete, CancellationToken cancellationToken)
+        private async Task DeleteSearchParameterAsync(RawResource rawResource, bool isHardDelete, CancellationToken cancellationToken)
         {
             await _searchParamDeleteSemaphore.WaitAsync(cancellationToken);
             try
@@ -725,6 +725,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             }
             finally
             {
+                // Search param status is persisted directly above. Clear any queued context status
+                // to prevent it from leaking into unrelated subsequent writes in the same request context.
+                _contextAccessor?.RequestContext?.Properties?.Remove(SearchParameterRequestContextPropertyNames.PendingStatus);
                 _searchParamDeleteSemaphore.Release();
             }
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -725,9 +725,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             }
             finally
             {
-                // Search param status is persisted directly above. Clear any queued context status
-                // to prevent it from leaking into unrelated subsequent writes in the same request context.
-                _contextAccessor?.RequestContext?.Properties?.Remove(SearchParameterRequestContextPropertyNames.PendingStatus);
                 _searchParamDeleteSemaphore.Release();
             }
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -412,13 +412,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     singleTransaction = true;
                 }
 
-                // exclude resources for search param deletes, as they are handled by reindex
-                if (resourceExt.PendingSearchParameterStatus == null
-                    || (resourceExt.PendingSearchParameterStatus.Status != SearchParameterStatus.PendingDelete
-                        && resourceExt.PendingSearchParameterStatus.Status != SearchParameterStatus.PendingHardDelete))
-                {
-                    mergeWrappersWithVersions.Add((new MergeResourceWrapper(resource, resourceExt.KeepHistory && metaHistory, hasVersionToCompare), resourceExt.KeepVersion, int.Parse(resource.Version), existingVersion));
-                }
+                mergeWrappersWithVersions.Add((new MergeResourceWrapper(resource, resourceExt.KeepHistory && metaHistory, hasVersionToCompare), resourceExt.KeepVersion, int.Parse(resource.Version), existingVersion));
 
                 index++;
                 results.Add(resourceExt.GetIdentifier(), new DataStoreOperationOutcome(new UpsertOutcome(resource, resource.Version == InitialVersion ? SaveOutcomeType.Created : SaveOutcomeType.Updated)));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1100,6 +1100,66 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             Assert.Equal(hardDelete ? HttpStatusCode.NotFound : HttpStatusCode.Gone, notFoundEx.StatusCode);
         }
 
+        [Fact]
+        public async Task GivenSearchParamConditionalDeleteByUrl_ThenSuccessAndDeletedAfterReindex()
+        {
+            const string code = "conditional-delete-by-url";
+            var searchParam = CreatePersonSearchParam(code, $"http://reindex/{code}");
+            var create = await _fixture.TestFhirClient.UpdateAsync(searchParam);
+            Assert.True(create.StatusCode == HttpStatusCode.OK || create.StatusCode == HttpStatusCode.Created);
+            Assert.Equal(code, create.Resource.Id);
+
+            var delete = await _fixture.TestFhirClient.DeleteAsync($"SearchParameter?url={searchParam.Url}");
+            Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+
+            var resource = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}");
+            Assert.NotNull(resource?.Resource);
+
+            var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
+            Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
+            var reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
+            Assert.Equal(OperationStatus.Completed, reindexStatus.Status);
+
+            var gone = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code}"));
+            Assert.Equal(HttpStatusCode.Gone, gone.StatusCode);
+        }
+
+        [Fact]
+        public async Task GivenSearchParamConditionalDeleteByMultipleUrlsWithCount_ThenSuccessAndDeletedAfterReindex()
+        {
+            const string code1 = "conditional-delete-by-url-1";
+            var searchParam1 = CreatePersonSearchParam(code1, $"http://reindex/{code1}");
+            var create1 = await _fixture.TestFhirClient.UpdateAsync(searchParam1);
+            Assert.True(create1.StatusCode == HttpStatusCode.OK || create1.StatusCode == HttpStatusCode.Created);
+            Assert.Equal(code1, create1.Resource.Id);
+
+            const string code2 = "conditional-delete-by-url-2";
+            var searchParam2 = CreatePersonSearchParam(code2, $"http://reindex/{code2}");
+            var create2 = await _fixture.TestFhirClient.UpdateAsync(searchParam2);
+            Assert.True(create2.StatusCode == HttpStatusCode.OK || create2.StatusCode == HttpStatusCode.Created);
+            Assert.Equal(code2, create2.Resource.Id);
+
+            var delete = await _fixture.TestFhirClient.DeleteAsync($"SearchParameter?url={searchParam1.Url},{searchParam2.Url}&_count=2");
+            Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+
+            var resource1 = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code1}");
+            Assert.NotNull(resource1?.Resource);
+
+            var resource2 = await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code2}");
+            Assert.NotNull(resource2?.Resource);
+
+            var reindex = await _fixture.TestFhirClient.PostReindexJobAsync(new Parameters { Parameter = [] });
+            Assert.Equal(HttpStatusCode.Created, reindex.reponse.Response.StatusCode);
+            var reindexStatus = await WaitForJobCompletionAsync(reindex.uri, TimeSpan.FromSeconds(300));
+            Assert.Equal(OperationStatus.Completed, reindexStatus.Status);
+
+            var gone1 = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code1}"));
+            Assert.Equal(HttpStatusCode.Gone, gone1.StatusCode);
+
+            var gone2 = await Assert.ThrowsAsync<FhirClientException>(async () => await _fixture.TestFhirClient.ReadAsync<SearchParameter>($"SearchParameter/{code2}"));
+            Assert.Equal(HttpStatusCode.Gone, gone2.StatusCode);
+        }
+
         [Theory]
         [InlineData(true, false)]
         [InlineData(true, true)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/FailingSearchParameterStatusManager.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/FailingSearchParameterStatusManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatus(CancellationToken cancellationToken)
             => Task.FromResult<IReadOnlyCollection<ResourceSearchParameterStatus>>(Array.Empty<ResourceSearchParameterStatus>());
 
-        public Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, long? reindexId = null, DateTimeOffset? lastUpdated = null) => Task.CompletedTask;
+        public Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, long? reindexId = null, DateTimeOffset? lastUpdated = null) => Task.CompletedTask;
 
         public Task<CacheConsistencyResult> CheckCacheConsistencyAsync(DateTime updateEventsSince, DateTime activeHostsSince, CancellationToken cancellationToken) => Task.FromResult(new CacheConsistencyResult());
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -391,12 +391,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             collection.AddTransient<IPipelineBehavior<DeleteResourceRequest, DeleteResourceResponse>>(
                 sp => new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(
-                    _searchParameterOperations,
                     DataStore,
-                    SearchParameterDefinitionManager,
-                    SearchParameterStatusManager,
-                    FhirRequestContextAccessor,
-                    ModelInfoProvider.Instance));
+                    SearchParameterDefinitionManager));
 
             ServiceProvider services = collection.BuildServiceProvider();
 


### PR DESCRIPTION
Fixes https://microsofthealth.visualstudio.com/Health/_workitems/edit/204583

This PR:
1. Removed logic that was passing pending delete statuses in the request context,
2. Added status updates in the deletion service. 
3. Removed special pending delete status handling from Cosmos and SQL stores., 
4. Cleaned interfaces from not used "ignore not supported exception" logic.