### PR TITLE
Fixing datetime arithmetic overflow/underflow.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -34,24 +34,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeMaxValue_WhenSafeAddTicksPositive_ThenClampsToMaxValue()
-        {
-            DateTime result = DateTime.MaxValue.SafeAddTicks(1);
-            Assert.Equal(DateTime.MaxValue, result);
-        }
-
-        [Fact]
         public void GivenDateTimeNearMinValue_WhenSafeAddTicksNegative_ThenClampsToMinValue()
         {
             var dt = DateTime.MinValue.AddTicks(100);
             DateTime result = dt.SafeAddTicks(-TimeSpan.TicksPerMillisecond);
-            Assert.Equal(DateTime.MinValue, result);
-        }
-
-        [Fact]
-        public void GivenDateTimeMinValue_WhenSafeAddTicksNegative_ThenClampsToMinValue()
-        {
-            DateTime result = DateTime.MinValue.SafeAddTicks(-1);
             Assert.Equal(DateTime.MinValue, result);
         }
 

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -71,6 +71,24 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             Assert.Equal(DateTime.MinValue, result);
         }
 
+        [Fact]
+        public void GivenUtcDateTime_WhenSafeAddTicksClampsToMaxValue_ThenPreservesKind()
+        {
+            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = DateTime.MaxValue.AddTicks(-1).SafeAddTicks(TimeSpan.TicksPerDay);
+            Assert.Equal(DateTimeKind.Unspecified, result.Kind);
+            Assert.Equal(DateTime.MaxValue.Ticks, result.Ticks);
+        }
+
+        [Fact]
+        public void GivenLocalDateTime_WhenSafeAddTicksClampsToMinValue_ThenPreservesKind()
+        {
+            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Local);
+            DateTime result = dt.AddTicks(1).SafeAddTicks(-TimeSpan.TicksPerDay);
+            Assert.Equal(DateTimeKind.Local, result.Kind);
+            Assert.Equal(DateTime.MinValue.Ticks, result.Ticks);
+        }
+
         // SafeAddTicks - DateTimeOffset
 
         [Fact]
@@ -147,6 +165,66 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             var dto = DateTimeOffset.MinValue.AddDays(0.5);
             DateTimeOffset result = dto.SafeAddDays(-1);
             Assert.Equal(DateTimeOffset.MinValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTime_WhenSafeAddDaysIntMaxValue_ThenClampsToMaxValue()
+        {
+            var dt = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddDays(int.MaxValue);
+            Assert.Equal(DateTime.MaxValue.Ticks, result.Ticks);
+        }
+
+        [Fact]
+        public void GivenDateTime_WhenSafeAddDaysIntMinValue_ThenClampsToMinValue()
+        {
+            var dt = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddDays(int.MinValue);
+            Assert.Equal(DateTime.MinValue.Ticks, result.Ticks);
+        }
+
+        [Fact]
+        public void GivenUtcDateTime_WhenSafeAddDaysClampsToMaxValue_ThenPreservesKind()
+        {
+            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddDays(int.MaxValue);
+            Assert.Equal(DateTimeKind.Utc, result.Kind);
+            Assert.Equal(DateTime.MaxValue.Ticks, result.Ticks);
+        }
+
+        [Fact]
+        public void GivenLocalDateTime_WhenSafeAddDaysClampsToMinValue_ThenPreservesKind()
+        {
+            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Local);
+            DateTime result = dt.SafeAddDays(int.MinValue);
+            Assert.Equal(DateTimeKind.Local, result.Kind);
+            Assert.Equal(DateTime.MinValue.Ticks, result.Ticks);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffset_WhenSafeAddDaysIntMaxValue_ThenClampsToMaxValue()
+        {
+            var dto = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset result = dto.SafeAddDays(int.MaxValue);
+            Assert.Equal(DateTimeOffset.MaxValue.Ticks, result.Ticks);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffset_WhenSafeAddDaysIntMinValue_ThenClampsToMinValue()
+        {
+            var dto = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset result = dto.SafeAddDays(int.MinValue);
+            Assert.Equal(DateTimeOffset.MinValue.Ticks, result.Ticks);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffset_WhenSafeAddDaysClampsToMaxValue_ThenPreservesOffset()
+        {
+            var offset = TimeSpan.FromHours(5);
+            var dto = new DateTimeOffset(2024, 1, 1, 0, 0, 0, offset);
+            DateTimeOffset result = dto.SafeAddDays(int.MaxValue);
+            Assert.Equal(offset, result.Offset);
+            Assert.Equal(DateTimeOffset.MaxValue.Ticks, result.Ticks);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -63,6 +63,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             Assert.Equal(dt, result);
         }
 
+        [Fact]
+        public void GivenAnyDateTime_WhenSafeAddTicksLongMinValue_ThenClampsToMinValue()
+        {
+            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddTicks(long.MinValue);
+            Assert.Equal(DateTime.MinValue, result);
+        }
+
         // SafeAddTicks - DateTimeOffset
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -1,0 +1,144 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class DateTimeSafeExtensionsTests
+    {
+        // SafeAddTicks - DateTime
+
+        [Fact]
+        public void GivenNormalDateTime_WhenSafeAddTicksCalled_ThenReturnsExpectedResult()
+        {
+            var dt = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond);
+            Assert.Equal(dt.AddTicks(TimeSpan.TicksPerMillisecond), result);
+        }
+
+        [Fact]
+        public void GivenDateTimeNearMaxValue_WhenSafeAddTicksPositive_ThenClampsToMaxValue()
+        {
+            var dt = DateTime.MaxValue.AddTicks(-100);
+            DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond);
+            Assert.Equal(DateTime.MaxValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTimeMaxValue_WhenSafeAddTicksPositive_ThenClampsToMaxValue()
+        {
+            DateTime result = DateTime.MaxValue.SafeAddTicks(1);
+            Assert.Equal(DateTime.MaxValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTimeNearMinValue_WhenSafeAddTicksNegative_ThenClampsToMinValue()
+        {
+            var dt = DateTime.MinValue.AddTicks(100);
+            DateTime result = dt.SafeAddTicks(-TimeSpan.TicksPerMillisecond);
+            Assert.Equal(DateTime.MinValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTimeMinValue_WhenSafeAddTicksNegative_ThenClampsToMinValue()
+        {
+            DateTime result = DateTime.MinValue.SafeAddTicks(-1);
+            Assert.Equal(DateTime.MinValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTime_WhenSafeAddTicksZero_ThenReturnsOriginal()
+        {
+            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddTicks(0);
+            Assert.Equal(dt, result);
+        }
+
+        // SafeAddTicks - DateTimeOffset
+
+        [Fact]
+        public void GivenNormalDateTimeOffset_WhenSafeAddTicksCalled_ThenReturnsExpectedResult()
+        {
+            var dto = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+            DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerMillisecond);
+            Assert.Equal(dto.AddTicks(TimeSpan.TicksPerMillisecond), result);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddTicksPositive_ThenClampsToMaxValue()
+        {
+            var dto = DateTimeOffset.MaxValue.AddTicks(-100);
+            DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerMillisecond);
+            Assert.Equal(DateTimeOffset.MaxValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddTicksNegative_ThenClampsToMinValue()
+        {
+            var dto = DateTimeOffset.MinValue.AddTicks(100);
+            DateTimeOffset result = dto.SafeAddTicks(-TimeSpan.TicksPerMillisecond);
+            Assert.Equal(DateTimeOffset.MinValue, result);
+        }
+
+        // SafeAddDays - DateTime
+
+        [Fact]
+        public void GivenNormalDateTime_WhenSafeAddDaysCalled_ThenReturnsExpectedResult()
+        {
+            var dt = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddDays(1);
+            Assert.Equal(dt.AddDays(1), result);
+        }
+
+        [Fact]
+        public void GivenDateTimeNearMaxValue_WhenSafeAddDaysPositive_ThenClampsToMaxValue()
+        {
+            var dt = DateTime.MaxValue.AddDays(-0.5);
+            DateTime result = dt.SafeAddDays(1);
+            Assert.Equal(DateTime.MaxValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTimeNearMinValue_WhenSafeAddDaysNegative_ThenClampsToMinValue()
+        {
+            var dt = DateTime.MinValue.AddDays(0.5);
+            DateTime result = dt.SafeAddDays(-1);
+            Assert.Equal(DateTime.MinValue, result);
+        }
+
+        // SafeAddDays - DateTimeOffset
+
+        [Fact]
+        public void GivenNormalDateTimeOffset_WhenSafeAddDaysCalled_ThenReturnsExpectedResult()
+        {
+            var dto = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset result = dto.SafeAddDays(1);
+            Assert.Equal(dto.AddDays(1), result);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddDaysPositive_ThenClampsToMaxValue()
+        {
+            var dto = DateTimeOffset.MaxValue.AddDays(-0.5);
+            DateTimeOffset result = dto.SafeAddDays(1);
+            Assert.Equal(DateTimeOffset.MaxValue, result);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddDaysNegative_ThenClampsToMinValue()
+        {
+            var dto = DateTimeOffset.MinValue.AddDays(0.5);
+            DateTimeOffset result = dto.SafeAddDays(-1);
+            Assert.Equal(DateTimeOffset.MinValue, result);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -3,10 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+#nullable enable
+
 using System;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
+using NSubstitute;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
@@ -26,7 +30,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeNearMaxValue_WhenSafeAddTicksPositive_ThenClampsToMaxValue()
+        public void GivenDateTimeNearMaxValue_WhenSafeAddTicksPositive_ThenConstrainsToMaxValue()
         {
             var dt = DateTime.MaxValue.AddTicks(-100);
             DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond);
@@ -34,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeNearMinValue_WhenSafeAddTicksNegative_ThenClampsToMinValue()
+        public void GivenDateTimeNearMinValue_WhenSafeAddTicksNegative_ThenConstrainsToMinValue()
         {
             var dt = DateTime.MinValue.AddTicks(100);
             DateTime result = dt.SafeAddTicks(-TimeSpan.TicksPerMillisecond);
@@ -50,7 +54,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenAnyDateTime_WhenSafeAddTicksLongMinValue_ThenClampsToMinValue()
+        public void GivenAnyDateTime_WhenSafeAddTicksLongMinValue_ThenConstrainsToMinValue()
         {
             var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             DateTime result = dt.SafeAddTicks(long.MinValue);
@@ -58,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenUtcDateTime_WhenSafeAddTicksClampsToMaxValue_ThenPreservesKind()
+        public void GivenUtcDateTime_WhenSafeAddTicksConstrainsToMaxValue_ThenPreservesKind()
         {
             var dt = new DateTime(DateTime.MaxValue.Ticks - 1, DateTimeKind.Utc);
             DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerDay);
@@ -67,7 +71,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenLocalDateTime_WhenSafeAddTicksClampsToMinValue_ThenPreservesKind()
+        public void GivenLocalDateTime_WhenSafeAddTicksConstrainsToMinValue_ThenPreservesKind()
         {
             var dt = new DateTime(DateTime.MinValue.Ticks + 1, DateTimeKind.Local);
             DateTime result = dt.SafeAddTicks(-TimeSpan.TicksPerDay);
@@ -86,7 +90,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddTicksPositive_ThenClampsToMaxValue()
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddTicksPositive_ThenConstrainsToMaxValue()
         {
             var dto = DateTimeOffset.MaxValue.AddTicks(-100);
             DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerMillisecond);
@@ -94,7 +98,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddTicksNegative_ThenClampsToMinValue()
+        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddTicksNegative_ThenConstrainsToMinValue()
         {
             var dto = DateTimeOffset.MinValue.AddTicks(100);
             DateTimeOffset result = dto.SafeAddTicks(-TimeSpan.TicksPerMillisecond);
@@ -112,7 +116,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffset_WhenSafeAddTicksClampsToMaxValue_ThenPreservesOffset()
+        public void GivenDateTimeOffset_WhenSafeAddTicksConstrainsToMaxValue_ThenPreservesOffset()
         {
             var offset = TimeSpan.FromHours(5);
             var dto = new DateTimeOffset(9999, 12, 31, 23, 59, 59, offset);
@@ -132,7 +136,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeNearMaxValue_WhenSafeAddDaysPositive_ThenClampsToMaxValue()
+        public void GivenDateTimeNearMaxValue_WhenSafeAddDaysPositive_ThenConstrainsToMaxValue()
         {
             var dt = DateTime.MaxValue.AddDays(-0.5);
             DateTime result = dt.SafeAddDays(1);
@@ -140,7 +144,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeNearMinValue_WhenSafeAddDaysNegative_ThenClampsToMinValue()
+        public void GivenDateTimeNearMinValue_WhenSafeAddDaysNegative_ThenConstrainsToMinValue()
         {
             var dt = DateTime.MinValue.AddDays(0.5);
             DateTime result = dt.SafeAddDays(-1);
@@ -158,7 +162,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddDaysPositive_ThenClampsToMaxValue()
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddDaysPositive_ThenConstrainsToMaxValue()
         {
             var dto = DateTimeOffset.MaxValue.AddDays(-0.5);
             DateTimeOffset result = dto.SafeAddDays(1);
@@ -166,7 +170,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddDaysNegative_ThenClampsToMinValue()
+        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddDaysNegative_ThenConstrainsToMinValue()
         {
             var dto = DateTimeOffset.MinValue.AddDays(0.5);
             DateTimeOffset result = dto.SafeAddDays(-1);
@@ -174,7 +178,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTime_WhenSafeAddDaysIntMaxValue_ThenClampsToMaxValue()
+        public void GivenDateTime_WhenSafeAddDaysIntMaxValue_ThenConstrainsToMaxValue()
         {
             var dt = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc);
             DateTime result = dt.SafeAddDays(int.MaxValue);
@@ -182,7 +186,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTime_WhenSafeAddDaysIntMinValue_ThenClampsToMinValue()
+        public void GivenDateTime_WhenSafeAddDaysIntMinValue_ThenConstrainsToMinValue()
         {
             var dt = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc);
             DateTime result = dt.SafeAddDays(int.MinValue);
@@ -190,7 +194,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenUtcDateTime_WhenSafeAddDaysClampsToMaxValue_ThenPreservesKind()
+        public void GivenUtcDateTime_WhenSafeAddDaysConstrainsToMaxValue_ThenPreservesKind()
         {
             var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             DateTime result = dt.SafeAddDays(int.MaxValue);
@@ -199,7 +203,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenLocalDateTime_WhenSafeAddDaysClampsToMinValue_ThenPreservesKind()
+        public void GivenLocalDateTime_WhenSafeAddDaysConstrainsToMinValue_ThenPreservesKind()
         {
             var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Local);
             DateTime result = dt.SafeAddDays(int.MinValue);
@@ -208,7 +212,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffset_WhenSafeAddDaysIntMaxValue_ThenClampsToMaxValue()
+        public void GivenDateTimeOffset_WhenSafeAddDaysIntMaxValue_ThenConstrainsToMaxValue()
         {
             var dto = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
             DateTimeOffset result = dto.SafeAddDays(int.MaxValue);
@@ -216,7 +220,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffset_WhenSafeAddDaysIntMinValue_ThenClampsToMinValue()
+        public void GivenDateTimeOffset_WhenSafeAddDaysIntMinValue_ThenConstrainsToMinValue()
         {
             var dto = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
             DateTimeOffset result = dto.SafeAddDays(int.MinValue);
@@ -224,7 +228,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffset_WhenSafeAddDaysClampsToMaxValue_ThenPreservesOffset()
+        public void GivenDateTimeOffset_WhenSafeAddDaysConstrainsToMaxValue_ThenPreservesOffset()
         {
             var offset = TimeSpan.FromHours(5);
             var dto = new DateTimeOffset(2024, 1, 1, 0, 0, 0, offset);
@@ -234,13 +238,295 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffsetWithNegativeOffset_WhenSafeAddDaysOverflows_ThenClampsWithoutThrowing()
+        public void GivenDateTimeOffsetWithNegativeOffset_WhenSafeAddDaysOverflows_ThenConstrainsWithoutThrowing()
         {
             var offset = TimeSpan.FromHours(-5);
             var dto = new DateTimeOffset(2024, 1, 1, 0, 0, 0, offset);
             DateTimeOffset result = dto.SafeAddDays(int.MaxValue);
             Assert.Equal(offset, result.Offset);
             Assert.Equal(DateTimeOffset.MaxValue.UtcTicks, result.UtcTicks);
+        }
+
+        // OverflowBehavior Tests - DateTime.SafeAddTicks
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeNearMaxValue_WhenSafeAddTicksWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dt = DateTime.MaxValue.AddTicks(-100);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, behavior));
+            }
+            else
+            {
+                DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, behavior);
+                Assert.Equal(dt, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeNearMinValue_WhenSafeAddTicksNegativeWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dt = DateTime.MinValue.AddTicks(100);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dt.SafeAddTicks(-TimeSpan.TicksPerMillisecond, behavior));
+            }
+            else
+            {
+                DateTime result = dt.SafeAddTicks(-TimeSpan.TicksPerMillisecond, behavior);
+                Assert.Equal(dt, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Constrain)]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenNormalDateTime_WhenSafeAddTicksWithBehavior_ThenReturnsExpectedResult(OverflowBehavior behavior)
+        {
+            var dt = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, behavior);
+            Assert.Equal(dt.AddTicks(TimeSpan.TicksPerMillisecond), result);
+        }
+
+        // OverflowBehavior Tests - DateTimeOffset.SafeAddTicks
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddTicksWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dto = DateTimeOffset.MaxValue.AddTicks(-100);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dto.SafeAddTicks(TimeSpan.TicksPerMillisecond, behavior));
+            }
+            else
+            {
+                DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerMillisecond, behavior);
+                Assert.Equal(dto, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddTicksNegativeWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dto = DateTimeOffset.MinValue.AddTicks(100);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dto.SafeAddTicks(-TimeSpan.TicksPerMillisecond, behavior));
+            }
+            else
+            {
+                DateTimeOffset result = dto.SafeAddTicks(-TimeSpan.TicksPerMillisecond, behavior);
+                Assert.Equal(dto, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Constrain)]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenNormalDateTimeOffset_WhenSafeAddTicksWithBehavior_ThenReturnsExpectedResult(OverflowBehavior behavior)
+        {
+            var dto = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+            DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerMillisecond, behavior);
+            Assert.Equal(dto.AddTicks(TimeSpan.TicksPerMillisecond), result);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetWithCustomOffset_WhenSafeAddTicksWithReturnOriginalBehavior_ThenReturnsOriginalWithOffsetPreserved()
+        {
+            var offset = TimeSpan.FromHours(5);
+            var unspecifiedDt = new DateTime(9999, 12, 31, 12, 0, 0, DateTimeKind.Unspecified);
+            var dto = new DateTimeOffset(unspecifiedDt, offset);
+            DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerDay, OverflowBehavior.ReturnOriginal);
+            Assert.Equal(dto, result);
+            Assert.Equal(offset, result.Offset);
+        }
+
+        // OverflowBehavior Tests - DateTime.SafeAddDays
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeNearMaxValue_WhenSafeAddDaysWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dt = DateTime.MaxValue.AddDays(-0.5);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dt.SafeAddDays(1, behavior));
+            }
+            else
+            {
+                DateTime result = dt.SafeAddDays(1, behavior);
+                Assert.Equal(dt, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeNearMinValue_WhenSafeAddDaysNegativeWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dt = DateTime.MinValue.AddDays(0.5);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dt.SafeAddDays(-1, behavior));
+            }
+            else
+            {
+                DateTime result = dt.SafeAddDays(-1, behavior);
+                Assert.Equal(dt, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Constrain)]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenNormalDateTime_WhenSafeAddDaysWithBehavior_ThenReturnsExpectedResult(OverflowBehavior behavior)
+        {
+            var dt = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddDays(1, behavior);
+            Assert.Equal(dt.AddDays(1), result);
+        }
+
+        // OverflowBehavior Tests - DateTimeOffset.SafeAddDays
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddDaysWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dto = DateTimeOffset.MaxValue.AddDays(-0.5);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dto.SafeAddDays(1, behavior));
+            }
+            else
+            {
+                DateTimeOffset result = dto.SafeAddDays(1, behavior);
+                Assert.Equal(dto, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenDateTimeOffsetNearMinValue_WhenSafeAddDaysNegativeWithBehavior_ThenHandlesOverflow(OverflowBehavior behavior)
+        {
+            var dto = DateTimeOffset.MinValue.AddDays(0.5);
+            if (behavior == OverflowBehavior.Throw)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => dto.SafeAddDays(-1, behavior));
+            }
+            else
+            {
+                DateTimeOffset result = dto.SafeAddDays(-1, behavior);
+                Assert.Equal(dto, result);
+            }
+        }
+
+        [Theory]
+        [InlineData(OverflowBehavior.Constrain)]
+        [InlineData(OverflowBehavior.Throw)]
+        [InlineData(OverflowBehavior.ReturnOriginal)]
+        public void GivenNormalDateTimeOffset_WhenSafeAddDaysWithBehavior_ThenReturnsExpectedResult(OverflowBehavior behavior)
+        {
+            var dto = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset result = dto.SafeAddDays(1, behavior);
+            Assert.Equal(dto.AddDays(1), result);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetWithCustomOffset_WhenSafeAddDaysWithReturnOriginalBehavior_ThenReturnsOriginalWithOffsetPreserved()
+        {
+            var offset = TimeSpan.FromHours(-7);
+            var dto = new DateTimeOffset(2024, 1, 1, 0, 0, 0, offset);
+            DateTimeOffset result = dto.SafeAddDays(int.MaxValue, OverflowBehavior.ReturnOriginal);
+            Assert.Equal(dto, result);
+            Assert.Equal(offset, result.Offset);
+        }
+
+        // Logging Tests
+
+        [Fact]
+        public void GivenDateTimeNearMaxValue_WhenSafeAddTicksWithLoggerAndThrowBehavior_ThenLogsWarningBeforeThrowing()
+        {
+            var logger = Substitute.For<ILogger>();
+            var dt = DateTime.MaxValue.AddTicks(-100);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Throw, logger));
+
+            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+        }
+
+        [Fact]
+        public void GivenDateTimeNearMaxValue_WhenSafeAddTicksWithLoggerAndConstrainBehavior_ThenLogsWarningAndConstrains()
+        {
+            var logger = Substitute.For<ILogger>();
+            var dt = DateTime.MaxValue.AddTicks(-100);
+
+            DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Constrain, logger);
+
+            Assert.Equal(DateTime.MaxValue, result);
+            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+        }
+
+        [Fact]
+        public void GivenNormalDateTime_WhenSafeAddTicksWithLogger_ThenDoesNotLog()
+        {
+            var logger = Substitute.For<ILogger>();
+            var dt = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+            DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Constrain, logger);
+
+            Assert.Equal(dt.AddTicks(TimeSpan.TicksPerMillisecond), result);
+            logger.DidNotReceiveWithAnyArgs().Log(default, default, default, default, default!);
+        }
+
+        [Fact]
+        public void GivenDateTimeNearMaxValue_WhenSafeAddDaysWithLoggerAndConstrainBehavior_ThenLogsWarning()
+        {
+            var logger = Substitute.For<ILogger>();
+            var dt = DateTime.MaxValue.AddDays(-0.5);
+
+            DateTime result = dt.SafeAddDays(1, OverflowBehavior.Constrain, logger);
+
+            Assert.Equal(DateTime.MaxValue, result);
+            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddTicksWithLoggerAndConstrainBehavior_ThenLogsWarning()
+        {
+            var logger = Substitute.For<ILogger>();
+            var dto = DateTimeOffset.MaxValue.AddTicks(-100);
+
+            DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Constrain, logger);
+
+            Assert.Equal(DateTimeOffset.MaxValue, result);
+            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetNearMaxValue_WhenSafeAddDaysWithLoggerAndConstrainBehavior_ThenLogsWarning()
+        {
+            var logger = Substitute.For<ILogger>();
+            var dto = DateTimeOffset.MaxValue.AddDays(-0.5);
+
+            DateTimeOffset result = dto.SafeAddDays(1, OverflowBehavior.Constrain, logger);
+
+            Assert.Equal(DateTimeOffset.MaxValue, result);
+            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -115,6 +115,26 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             Assert.Equal(DateTimeOffset.MinValue, result);
         }
 
+        [Fact]
+        public void GivenDateTimeOffset_WhenSafeAddTicksZero_ThenReturnsOriginal()
+        {
+            var offset = TimeSpan.FromHours(5);
+            var dto = new DateTimeOffset(2024, 6, 15, 12, 0, 0, offset);
+            DateTimeOffset result = dto.SafeAddTicks(0);
+            Assert.Equal(dto, result);
+            Assert.Equal(offset, result.Offset);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffset_WhenSafeAddTicksClampsWithNonZeroOffset_ThenPreservesOffset()
+        {
+            var offset = TimeSpan.FromHours(5);
+            var dto = new DateTimeOffset(9999, 12, 31, 23, 59, 59, offset);
+            DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerDay);
+            Assert.Equal(offset, result.Offset);
+            Assert.Equal(DateTimeOffset.MaxValue.Ticks, result.Ticks);
+        }
+
         // SafeAddDays - DateTime
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -74,17 +74,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         [Fact]
         public void GivenUtcDateTime_WhenSafeAddTicksClampsToMaxValue_ThenPreservesKind()
         {
-            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            DateTime result = DateTime.MaxValue.AddTicks(-1).SafeAddTicks(TimeSpan.TicksPerDay);
-            Assert.Equal(DateTimeKind.Unspecified, result.Kind);
+            var dt = new DateTime(DateTime.MaxValue.Ticks - 1, DateTimeKind.Utc);
+            DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerDay);
+            Assert.Equal(DateTimeKind.Utc, result.Kind);
             Assert.Equal(DateTime.MaxValue.Ticks, result.Ticks);
         }
 
         [Fact]
         public void GivenLocalDateTime_WhenSafeAddTicksClampsToMinValue_ThenPreservesKind()
         {
-            var dt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Local);
-            DateTime result = dt.AddTicks(1).SafeAddTicks(-TimeSpan.TicksPerDay);
+            var dt = new DateTime(DateTime.MinValue.Ticks + 1, DateTimeKind.Local);
+            DateTime result = dt.SafeAddTicks(-TimeSpan.TicksPerDay);
             Assert.Equal(DateTimeKind.Local, result.Kind);
             Assert.Equal(DateTime.MinValue.Ticks, result.Ticks);
         }
@@ -126,13 +126,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         }
 
         [Fact]
-        public void GivenDateTimeOffset_WhenSafeAddTicksClampsWithNonZeroOffset_ThenPreservesOffset()
+        public void GivenDateTimeOffset_WhenSafeAddTicksClampsToMaxValue_ThenPreservesOffset()
         {
             var offset = TimeSpan.FromHours(5);
             var dto = new DateTimeOffset(9999, 12, 31, 23, 59, 59, offset);
             DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerDay);
             Assert.Equal(offset, result.Offset);
-            Assert.Equal(DateTimeOffset.MaxValue.Ticks, result.Ticks);
+            Assert.True(result.Ticks > dto.Ticks);
         }
 
         // SafeAddDays - DateTime
@@ -244,7 +244,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             var dto = new DateTimeOffset(2024, 1, 1, 0, 0, 0, offset);
             DateTimeOffset result = dto.SafeAddDays(int.MaxValue);
             Assert.Equal(offset, result.Offset);
-            Assert.Equal(DateTimeOffset.MaxValue.Ticks, result.Ticks);
+            Assert.True(result.UtcTicks <= DateTimeOffset.MaxValue.UtcTicks);
+        }
+
+        [Fact]
+        public void GivenDateTimeOffsetWithNegativeOffset_WhenSafeAddDaysOverflows_ThenClampsWithoutThrowing()
+        {
+            var offset = TimeSpan.FromHours(-5);
+            var dto = new DateTimeOffset(2024, 1, 1, 0, 0, 0, offset);
+            DateTimeOffset result = dto.SafeAddDays(int.MaxValue);
+            Assert.Equal(offset, result.Offset);
+            Assert.Equal(DateTimeOffset.MaxValue.UtcTicks, result.UtcTicks);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/DateTimeSafeExtensionsTests.cs
@@ -466,7 +466,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
 
             Assert.Throws<ArgumentOutOfRangeException>(() => dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Throw, logger));
 
-            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+            logger.ReceivedWithAnyArgs().Log<object>(LogLevel.Warning, default, default!, default, default!);
         }
 
         [Fact]
@@ -478,7 +478,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Constrain, logger);
 
             Assert.Equal(DateTime.MaxValue, result);
-            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+            logger.ReceivedWithAnyArgs().Log<object>(LogLevel.Warning, default, default!, default, default!);
         }
 
         [Fact]
@@ -490,7 +490,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             DateTime result = dt.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Constrain, logger);
 
             Assert.Equal(dt.AddTicks(TimeSpan.TicksPerMillisecond), result);
-            logger.DidNotReceiveWithAnyArgs().Log(default, default, default, default, default!);
+            logger.DidNotReceiveWithAnyArgs().Log<object>(default, default, default!, default, default!);
         }
 
         [Fact]
@@ -502,7 +502,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             DateTime result = dt.SafeAddDays(1, OverflowBehavior.Constrain, logger);
 
             Assert.Equal(DateTime.MaxValue, result);
-            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+            logger.ReceivedWithAnyArgs().Log<object>(LogLevel.Warning, default, default!, default, default!);
         }
 
         [Fact]
@@ -514,7 +514,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             DateTimeOffset result = dto.SafeAddTicks(TimeSpan.TicksPerMillisecond, OverflowBehavior.Constrain, logger);
 
             Assert.Equal(DateTimeOffset.MaxValue, result);
-            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+            logger.ReceivedWithAnyArgs().Log<object>(LogLevel.Warning, default, default!, default, default!);
         }
 
         [Fact]
@@ -526,7 +526,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             DateTimeOffset result = dto.SafeAddDays(1, OverflowBehavior.Constrain, logger);
 
             Assert.Equal(DateTimeOffset.MaxValue, result);
-            logger.ReceivedWithAnyArgs().Log(default, default, default, default, default!);
+            logger.ReceivedWithAnyArgs().Log<object>(LogLevel.Warning, default, default!, default, default!);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -3,12 +3,37 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+#nullable enable
+
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Health.Fhir.Core.Extensions
 {
     /// <summary>
-    /// Extension methods for <see cref="DateTime"/> and <see cref="DateTimeOffset"/> that clamp
+    /// Defines behavior when DateTime or DateTimeOffset arithmetic overflows.
+    /// </summary>
+    public enum OverflowBehavior
+    {
+        /// <summary>
+        /// Constrain the result to <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/>.
+        /// This is the default and safest option.
+        /// </summary>
+        Constrain = 0,
+
+        /// <summary>
+        /// Throw <see cref="ArgumentOutOfRangeException"/> on overflow (same as standard AddTicks/AddDays).
+        /// </summary>
+        Throw = 1,
+
+        /// <summary>
+        /// Return the original value unchanged on overflow.
+        /// </summary>
+        ReturnOriginal = 2,
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="DateTime"/> and <see cref="DateTimeOffset"/> that constrain
     /// results to <see cref="DateTime.MinValue"/>/<see cref="DateTime.MaxValue"/> instead of
     /// throwing on overflow.
     /// </summary>
@@ -17,40 +42,15 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         private const long MaxDaysBeforeTicksOverflow = long.MaxValue / TimeSpan.TicksPerDay;
 
         /// <summary>
-        /// Adds the specified number of ticks to a <see cref="DateTime"/>, clamping the result
+        /// Adds the specified number of ticks to a <see cref="DateTime"/>, constraining the result
         /// to <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/> on overflow.
         /// </summary>
-        public static DateTime SafeAddTicks(this DateTime value, long ticks)
-        {
-            if (ticks == 0)
-            {
-                return value;
-            }
-
-            if (ticks == long.MinValue)
-            {
-                // Can't negate long.MinValue; adding it always underflows within DateTime's range.
-                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
-            }
-
-            if (ticks > 0 && value.Ticks > DateTime.MaxValue.Ticks - ticks)
-            {
-                return new DateTime(DateTime.MaxValue.Ticks, value.Kind);
-            }
-
-            if (ticks < 0 && value.Ticks < DateTime.MinValue.Ticks - ticks)
-            {
-                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
-            }
-
-            return value.AddTicks(ticks);
-        }
-
-        /// <summary>
-        /// Adds the specified number of ticks to a <see cref="DateTimeOffset"/>, clamping the result
-        /// to the nearest representable value (for the current offset) instead of throwing on overflow.
-        /// </summary>
-        public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
+        /// <param name="value">The DateTime value.</param>
+        /// <param name="ticks">The number of ticks to add.</param>
+        /// <param name="behavior">The behavior to apply on overflow (default: Constrain).</param>
+        /// <param name="logger">Optional logger for overflow events.</param>
+        /// <returns>The result of adding ticks, or constrained/original value based on behavior.</returns>
+        public static DateTime SafeAddTicks(this DateTime value, long ticks, OverflowBehavior behavior = OverflowBehavior.Constrain, ILogger? logger = null)
         {
             if (ticks == 0)
             {
@@ -61,8 +61,60 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             {
                 return value.AddTicks(ticks);
             }
-            catch (ArgumentOutOfRangeException)
+            catch (ArgumentOutOfRangeException ex)
             {
+                logger?.LogWarning(ex, "DateTime.AddTicks overflow: value={DateTime}, ticks={Ticks}", value, ticks);
+
+                if (behavior == OverflowBehavior.Throw)
+                {
+                    throw;
+                }
+
+                if (behavior == OverflowBehavior.ReturnOriginal)
+                {
+                    return value;
+                }
+
+                return ticks > 0
+                    ? new DateTime(DateTime.MaxValue.Ticks, value.Kind)
+                    : new DateTime(DateTime.MinValue.Ticks, value.Kind);
+            }
+        }
+
+        /// <summary>
+        /// Adds the specified number of ticks to a <see cref="DateTimeOffset"/>, constraining the result
+        /// to the nearest representable value (for the current offset) on overflow.
+        /// </summary>
+        /// <param name="value">The DateTimeOffset value.</param>
+        /// <param name="ticks">The number of ticks to add.</param>
+        /// <param name="behavior">The behavior to apply on overflow (default: Constrain).</param>
+        /// <param name="logger">Optional logger for overflow events.</param>
+        /// <returns>The result of adding ticks, or constrained/original value based on behavior.</returns>
+        public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks, OverflowBehavior behavior = OverflowBehavior.Constrain, ILogger? logger = null)
+        {
+            if (ticks == 0)
+            {
+                return value;
+            }
+
+            try
+            {
+                return value.AddTicks(ticks);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                logger?.LogWarning(ex, "DateTimeOffset.AddTicks overflow: value={DateTimeOffset}, ticks={Ticks}", value, ticks);
+
+                if (behavior == OverflowBehavior.Throw)
+                {
+                    throw;
+                }
+
+                if (behavior == OverflowBehavior.ReturnOriginal)
+                {
+                    return value;
+                }
+
                 // Calculate max/min representable local ticks for this offset.
                 // UTC = Local - Offset, so Local = UTC + Offset.
                 // Max UTC ticks = DateTimeOffset.MaxValue.Ticks, so max Local ticks = DateTimeOffset.MaxValue.Ticks + Offset.Ticks.
@@ -83,31 +135,65 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         }
 
         /// <summary>
-        /// Adds the specified number of days to a <see cref="DateTime"/>, clamping the result
+        /// Adds the specified number of days to a <see cref="DateTime"/>, constraining the result
         /// to <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/> on overflow.
         /// </summary>
-        public static DateTime SafeAddDays(this DateTime value, int days)
+        /// <param name="value">The DateTime value.</param>
+        /// <param name="days">The number of days to add.</param>
+        /// <param name="behavior">The behavior to apply on overflow (default: Constrain).</param>
+        /// <param name="logger">Optional logger for overflow events.</param>
+        /// <returns>The result of adding days, or constrained/original value based on behavior.</returns>
+        public static DateTime SafeAddDays(this DateTime value, int days, OverflowBehavior behavior = OverflowBehavior.Constrain, ILogger? logger = null)
         {
             // Detect if days * TimeSpan.TicksPerDay would overflow long.
             if (days > MaxDaysBeforeTicksOverflow || days < -MaxDaysBeforeTicksOverflow)
             {
+                logger?.LogWarning("DateTime.AddDays overflow: value={DateTime}, days={Days}", value, days);
+
+                if (behavior == OverflowBehavior.Throw)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(days));
+                }
+
+                if (behavior == OverflowBehavior.ReturnOriginal)
+                {
+                    return value;
+                }
+
                 return days > 0 ? new DateTime(DateTime.MaxValue.Ticks, value.Kind) : new DateTime(DateTime.MinValue.Ticks, value.Kind);
             }
 
             long ticks = days * TimeSpan.TicksPerDay;
-            return value.SafeAddTicks(ticks);
+            return value.SafeAddTicks(ticks, behavior, logger);
         }
 
         /// <summary>
-        /// Adds the specified number of days to a <see cref="DateTimeOffset"/>, clamping the result
-        /// to the nearest representable value (for the current offset) instead of throwing on overflow.
+        /// Adds the specified number of days to a <see cref="DateTimeOffset"/>, constraining the result
+        /// to the nearest representable value (for the current offset) on overflow.
         /// </summary>
-        public static DateTimeOffset SafeAddDays(this DateTimeOffset value, int days)
+        /// <param name="value">The DateTimeOffset value.</param>
+        /// <param name="days">The number of days to add.</param>
+        /// <param name="behavior">The behavior to apply on overflow (default: Constrain).</param>
+        /// <param name="logger">Optional logger for overflow events.</param>
+        /// <returns>The result of adding days, or constrained/original value based on behavior.</returns>
+        public static DateTimeOffset SafeAddDays(this DateTimeOffset value, int days, OverflowBehavior behavior = OverflowBehavior.Constrain, ILogger? logger = null)
         {
             // Detect if days * TimeSpan.TicksPerDay would overflow long.
             if (days > MaxDaysBeforeTicksOverflow || days < -MaxDaysBeforeTicksOverflow)
             {
-                // Clamp to the representable range for the current offset.
+                logger?.LogWarning("DateTimeOffset.AddDays overflow: value={DateTimeOffset}, days={Days}", value, days);
+
+                if (behavior == OverflowBehavior.Throw)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(days));
+                }
+
+                if (behavior == OverflowBehavior.ReturnOriginal)
+                {
+                    return value;
+                }
+
+                // Constrain to the representable range for the current offset.
                 long offsetTicks = value.Offset.Ticks;
                 long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
                 long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
@@ -115,7 +201,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             }
 
             long ticks = days * TimeSpan.TicksPerDay;
-            return value.SafeAddTicks(ticks);
+            return value.SafeAddTicks(ticks, behavior, logger);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -1,0 +1,75 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Core.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="DateTime"/> and <see cref="DateTimeOffset"/> that clamp
+    /// results to <see cref="DateTime.MinValue"/>/<see cref="DateTime.MaxValue"/> instead of
+    /// throwing on overflow.
+    /// </summary>
+    public static class DateTimeSafeExtensions
+    {
+        /// <summary>
+        /// Adds the specified number of ticks to a <see cref="DateTime"/>, clamping the result
+        /// to <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/> on overflow.
+        /// </summary>
+        public static DateTime SafeAddTicks(this DateTime value, long ticks)
+        {
+            if (ticks > 0 && value.Ticks > DateTime.MaxValue.Ticks - ticks)
+            {
+                return DateTime.MaxValue;
+            }
+
+            if (ticks < 0 && value.Ticks < DateTime.MinValue.Ticks - ticks)
+            {
+                return DateTime.MinValue;
+            }
+
+            return value.AddTicks(ticks);
+        }
+
+        /// <summary>
+        /// Adds the specified number of ticks to a <see cref="DateTimeOffset"/>, clamping the result
+        /// to <see cref="DateTimeOffset.MinValue"/> or <see cref="DateTimeOffset.MaxValue"/> on overflow.
+        /// </summary>
+        public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
+        {
+            if (ticks > 0 && value.Ticks > DateTimeOffset.MaxValue.Ticks - ticks)
+            {
+                return DateTimeOffset.MaxValue;
+            }
+
+            if (ticks < 0 && value.Ticks < DateTimeOffset.MinValue.Ticks - ticks)
+            {
+                return DateTimeOffset.MinValue;
+            }
+
+            return value.AddTicks(ticks);
+        }
+
+        /// <summary>
+        /// Adds the specified number of days to a <see cref="DateTime"/>, clamping the result
+        /// to <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/> on overflow.
+        /// </summary>
+        public static DateTime SafeAddDays(this DateTime value, int days)
+        {
+            long ticks = days * TimeSpan.TicksPerDay;
+            return value.SafeAddTicks(ticks);
+        }
+
+        /// <summary>
+        /// Adds the specified number of days to a <see cref="DateTimeOffset"/>, clamping the result
+        /// to <see cref="DateTimeOffset.MinValue"/> or <see cref="DateTimeOffset.MaxValue"/> on overflow.
+        /// </summary>
+        public static DateTimeOffset SafeAddDays(this DateTimeOffset value, int days)
+        {
+            long ticks = days * TimeSpan.TicksPerDay;
+            return value.SafeAddTicks(ticks);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -20,6 +20,12 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTime SafeAddTicks(this DateTime value, long ticks)
         {
+            if (ticks == long.MinValue)
+            {
+                // Can't negate long.MinValue; adding it always underflows within DateTime's range.
+                return DateTime.MinValue;
+            }
+
             if (ticks > 0 && value.Ticks > DateTime.MaxValue.Ticks - ticks)
             {
                 return DateTime.MaxValue;
@@ -39,6 +45,12 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
         {
+            if (ticks == long.MinValue)
+            {
+                // Can't negate long.MinValue; adding it always underflows within DateTimeOffset's range.
+                return DateTimeOffset.MinValue;
+            }
+
             if (ticks > 0 && value.Ticks > DateTimeOffset.MaxValue.Ticks - ticks)
             {
                 return DateTimeOffset.MaxValue;

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Health.Fhir.Core.Extensions
     public enum OverflowBehavior
     {
         /// <summary>
-        /// Constrain the result to <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/>.
+        /// Constrain the result to representable bounds. For DateTime, this is <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/>.
+        /// For DateTimeOffset with a non-zero offset, the bounds are adjusted to the nearest representable value for that offset.
         /// This is the default and safest option.
         /// </summary>
         Constrain = 0,
@@ -33,9 +34,10 @@ namespace Microsoft.Health.Fhir.Core.Extensions
     }
 
     /// <summary>
-    /// Extension methods for <see cref="DateTime"/> and <see cref="DateTimeOffset"/> that constrain
-    /// results to <see cref="DateTime.MinValue"/>/<see cref="DateTime.MaxValue"/> instead of
-    /// throwing on overflow.
+    /// Extension methods for <see cref="DateTime"/> and <see cref="DateTimeOffset"/> that provide safe arithmetic
+    /// operations with configurable overflow behavior. Default behavior constrains results to representable bounds
+    /// instead of throwing on overflow. For DateTime, bounds are <see cref="DateTime.MinValue"/>/<see cref="DateTime.MaxValue"/>.
+    /// For DateTimeOffset, bounds are adjusted to the nearest representable values for the current offset.
     /// </summary>
     public static class DateTimeSafeExtensions
     {

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Health.Fhir.Core.Extensions
     /// </summary>
     public static class DateTimeSafeExtensions
     {
+        private const long MaxDaysBeforeTicksOverflow = long.MaxValue / TimeSpan.TicksPerDay;
+
         /// <summary>
         /// Adds the specified number of ticks to a <see cref="DateTime"/>, clamping the result
         /// to <see cref="DateTime.MinValue"/> or <see cref="DateTime.MaxValue"/> on overflow.
@@ -23,17 +25,17 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             if (ticks == long.MinValue)
             {
                 // Can't negate long.MinValue; adding it always underflows within DateTime's range.
-                return DateTime.MinValue;
+                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
             }
 
             if (ticks > 0 && value.Ticks > DateTime.MaxValue.Ticks - ticks)
             {
-                return DateTime.MaxValue;
+                return new DateTime(DateTime.MaxValue.Ticks, value.Kind);
             }
 
             if (ticks < 0 && value.Ticks < DateTime.MinValue.Ticks - ticks)
             {
-                return DateTime.MinValue;
+                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
             }
 
             return value.AddTicks(ticks);
@@ -70,6 +72,12 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTime SafeAddDays(this DateTime value, int days)
         {
+            // Detect if days * TimeSpan.TicksPerDay would overflow long.
+            if (days > MaxDaysBeforeTicksOverflow || days < -MaxDaysBeforeTicksOverflow)
+            {
+                return days > 0 ? new DateTime(DateTime.MaxValue.Ticks, value.Kind) : new DateTime(DateTime.MinValue.Ticks, value.Kind);
+            }
+
             long ticks = days * TimeSpan.TicksPerDay;
             return value.SafeAddTicks(ticks);
         }
@@ -80,6 +88,12 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTimeOffset SafeAddDays(this DateTimeOffset value, int days)
         {
+            // Detect if days * TimeSpan.TicksPerDay would overflow long.
+            if (days > MaxDaysBeforeTicksOverflow || days < -MaxDaysBeforeTicksOverflow)
+            {
+                return days > 0 ? new DateTimeOffset(DateTimeOffset.MaxValue.Ticks, value.Offset) : new DateTimeOffset(DateTimeOffset.MinValue.Ticks, value.Offset);
+            }
+
             long ticks = days * TimeSpan.TicksPerDay;
             return value.SafeAddTicks(ticks);
         }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -27,16 +27,23 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 return value;
             }
 
-            try
+            if (ticks == long.MinValue)
             {
-                return value.AddTicks(ticks);
+                // Can't negate long.MinValue; adding it always underflows within DateTime's range.
+                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
             }
-            catch (ArgumentOutOfRangeException)
+
+            if (ticks > 0 && value.Ticks > DateTime.MaxValue.Ticks - ticks)
             {
-                return ticks > 0
-                    ? new DateTime(DateTime.MaxValue.Ticks, value.Kind)
-                    : new DateTime(DateTime.MinValue.Ticks, value.Kind);
+                return new DateTime(DateTime.MaxValue.Ticks, value.Kind);
             }
+
+            if (ticks < 0 && value.Ticks < DateTime.MinValue.Ticks - ticks)
+            {
+                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
+            }
+
+            return value.AddTicks(ticks);
         }
 
         /// <summary>
@@ -45,26 +52,38 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
         {
+            // Clamp against the representable *local ticks* range for the current offset, so we never throw.
+            long offsetTicks = value.Offset.Ticks;
+            long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
+            long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
+
             if (ticks == 0)
             {
                 return value;
             }
 
-            try
+            if (ticks == long.MinValue)
             {
-                return value.AddTicks(ticks);
+                return new DateTimeOffset(minTicks, value.Offset);
             }
-            catch (ArgumentOutOfRangeException)
-            {
-                // Clamp to the representable range for the current offset.
-                long offsetTicks = value.Offset.Ticks;
-                long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
-                long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
 
-                return ticks > 0
-                    ? new DateTimeOffset(maxTicks, value.Offset)
-                    : new DateTimeOffset(minTicks, value.Offset);
+            if (ticks > 0)
+            {
+                if (value.Ticks >= maxTicks || maxTicks - value.Ticks < ticks)
+                {
+                    return new DateTimeOffset(maxTicks, value.Offset);
+                }
             }
+            else
+            {
+                long negTicks = -ticks;
+                if (value.Ticks <= minTicks || value.Ticks - minTicks < negTicks)
+                {
+                    return new DateTimeOffset(minTicks, value.Offset);
+                }
+            }
+
+            return value.AddTicks(ticks);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTime SafeAddTicks(this DateTime value, long ticks)
         {
+            if (ticks == 0)
+            {
+                return value;
+            }
+
             if (ticks == long.MinValue)
             {
                 // Can't negate long.MinValue; adding it always underflows within DateTime's range.
@@ -47,20 +52,25 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
         {
+            if (ticks == 0)
+            {
+                return value;
+            }
+
             if (ticks == long.MinValue)
             {
                 // Can't negate long.MinValue; adding it always underflows within DateTimeOffset's range.
-                return DateTimeOffset.MinValue;
+                return new DateTimeOffset(DateTimeOffset.MinValue.Ticks, value.Offset);
             }
 
             if (ticks > 0 && value.Ticks > DateTimeOffset.MaxValue.Ticks - ticks)
             {
-                return DateTimeOffset.MaxValue;
+                return new DateTimeOffset(DateTimeOffset.MaxValue.Ticks, value.Offset);
             }
 
             if (ticks < 0 && value.Ticks < DateTimeOffset.MinValue.Ticks - ticks)
             {
-                return DateTimeOffset.MinValue;
+                return new DateTimeOffset(DateTimeOffset.MinValue.Ticks, value.Offset);
             }
 
             return value.AddTicks(ticks);

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -52,38 +52,34 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
         {
-            // Clamp against the representable *local ticks* range for the current offset, so we never throw.
-            long offsetTicks = value.Offset.Ticks;
-            long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
-            long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
-
             if (ticks == 0)
             {
                 return value;
             }
 
-            if (ticks == long.MinValue)
+            try
             {
-                return new DateTimeOffset(minTicks, value.Offset);
+                return value.AddTicks(ticks);
             }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Calculate max/min representable local ticks for this offset.
+                // UTC = Local - Offset, so Local = UTC + Offset.
+                // Max UTC ticks = DateTimeOffset.MaxValue.Ticks, so max Local ticks = DateTimeOffset.MaxValue.Ticks + Offset.Ticks.
+                // When Offset >= 0, max stays at DateTimeOffset.MaxValue.Ticks (no UTC overflow).
+                // When Offset < 0, max = DateTimeOffset.MaxValue.Ticks + Offset.Ticks (safe addition).
+                long maxTicks = value.Offset.Ticks >= 0
+                    ? DateTimeOffset.MaxValue.Ticks
+                    : DateTimeOffset.MaxValue.Ticks + value.Offset.Ticks;
 
-            if (ticks > 0)
-            {
-                if (value.Ticks >= maxTicks || maxTicks - value.Ticks < ticks)
-                {
-                    return new DateTimeOffset(maxTicks, value.Offset);
-                }
-            }
-            else
-            {
-                long negTicks = -ticks;
-                if (value.Ticks <= minTicks || value.Ticks - minTicks < negTicks)
-                {
-                    return new DateTimeOffset(minTicks, value.Offset);
-                }
-            }
+                long minTicks = value.Offset.Ticks <= 0
+                    ? DateTimeOffset.MinValue.Ticks
+                    : DateTimeOffset.MinValue.Ticks + value.Offset.Ticks;
 
-            return value.AddTicks(ticks);
+                return ticks > 0
+                    ? new DateTimeOffset(maxTicks, value.Offset)
+                    : new DateTimeOffset(minTicks, value.Offset);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -27,23 +27,16 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 return value;
             }
 
-            if (ticks == long.MinValue)
+            try
             {
-                // Can't negate long.MinValue; adding it always underflows within DateTime's range.
-                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
+                return value.AddTicks(ticks);
             }
-
-            if (ticks > 0 && value.Ticks > DateTime.MaxValue.Ticks - ticks)
+            catch (ArgumentOutOfRangeException)
             {
-                return new DateTime(DateTime.MaxValue.Ticks, value.Kind);
+                return ticks > 0
+                    ? new DateTime(DateTime.MaxValue.Ticks, value.Kind)
+                    : new DateTime(DateTime.MinValue.Ticks, value.Kind);
             }
-
-            if (ticks < 0 && value.Ticks < DateTime.MinValue.Ticks - ticks)
-            {
-                return new DateTime(DateTime.MinValue.Ticks, value.Kind);
-            }
-
-            return value.AddTicks(ticks);
         }
 
         /// <summary>
@@ -52,38 +45,26 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// </summary>
         public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
         {
-            // Clamp against the representable *local ticks* range for the current offset, so we never throw.
-            long offsetTicks = value.Offset.Ticks;
-            long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
-            long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
-
             if (ticks == 0)
             {
                 return value;
             }
 
-            if (ticks == long.MinValue)
+            try
             {
-                return new DateTimeOffset(minTicks, value.Offset);
+                return value.AddTicks(ticks);
             }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Clamp to the representable range for the current offset.
+                long offsetTicks = value.Offset.Ticks;
+                long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
+                long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
 
-            if (ticks > 0)
-            {
-                if (value.Ticks >= maxTicks || maxTicks - value.Ticks < ticks)
-                {
-                    return new DateTimeOffset(maxTicks, value.Offset);
-                }
+                return ticks > 0
+                    ? new DateTimeOffset(maxTicks, value.Offset)
+                    : new DateTimeOffset(minTicks, value.Offset);
             }
-            else
-            {
-                long negTicks = -ticks;
-                if (value.Ticks <= minTicks || value.Ticks - minTicks < negTicks)
-                {
-                    return new DateTimeOffset(minTicks, value.Offset);
-                }
-            }
-
-            return value.AddTicks(ticks);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/DateTimeSafeExtensions.cs
@@ -48,10 +48,15 @@ namespace Microsoft.Health.Fhir.Core.Extensions
 
         /// <summary>
         /// Adds the specified number of ticks to a <see cref="DateTimeOffset"/>, clamping the result
-        /// to <see cref="DateTimeOffset.MinValue"/> or <see cref="DateTimeOffset.MaxValue"/> on overflow.
+        /// to the nearest representable value (for the current offset) instead of throwing on overflow.
         /// </summary>
         public static DateTimeOffset SafeAddTicks(this DateTimeOffset value, long ticks)
         {
+            // Clamp against the representable *local ticks* range for the current offset, so we never throw.
+            long offsetTicks = value.Offset.Ticks;
+            long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
+            long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
+
             if (ticks == 0)
             {
                 return value;
@@ -59,18 +64,23 @@ namespace Microsoft.Health.Fhir.Core.Extensions
 
             if (ticks == long.MinValue)
             {
-                // Can't negate long.MinValue; adding it always underflows within DateTimeOffset's range.
-                return new DateTimeOffset(DateTimeOffset.MinValue.Ticks, value.Offset);
+                return new DateTimeOffset(minTicks, value.Offset);
             }
 
-            if (ticks > 0 && value.Ticks > DateTimeOffset.MaxValue.Ticks - ticks)
+            if (ticks > 0)
             {
-                return new DateTimeOffset(DateTimeOffset.MaxValue.Ticks, value.Offset);
+                if (value.Ticks >= maxTicks || maxTicks - value.Ticks < ticks)
+                {
+                    return new DateTimeOffset(maxTicks, value.Offset);
+                }
             }
-
-            if (ticks < 0 && value.Ticks < DateTimeOffset.MinValue.Ticks - ticks)
+            else
             {
-                return new DateTimeOffset(DateTimeOffset.MinValue.Ticks, value.Offset);
+                long negTicks = -ticks;
+                if (value.Ticks <= minTicks || value.Ticks - minTicks < negTicks)
+                {
+                    return new DateTimeOffset(minTicks, value.Offset);
+                }
             }
 
             return value.AddTicks(ticks);
@@ -94,14 +104,18 @@ namespace Microsoft.Health.Fhir.Core.Extensions
 
         /// <summary>
         /// Adds the specified number of days to a <see cref="DateTimeOffset"/>, clamping the result
-        /// to <see cref="DateTimeOffset.MinValue"/> or <see cref="DateTimeOffset.MaxValue"/> on overflow.
+        /// to the nearest representable value (for the current offset) instead of throwing on overflow.
         /// </summary>
         public static DateTimeOffset SafeAddDays(this DateTimeOffset value, int days)
         {
             // Detect if days * TimeSpan.TicksPerDay would overflow long.
             if (days > MaxDaysBeforeTicksOverflow || days < -MaxDaysBeforeTicksOverflow)
             {
-                return days > 0 ? new DateTimeOffset(DateTimeOffset.MaxValue.Ticks, value.Offset) : new DateTimeOffset(DateTimeOffset.MinValue.Ticks, value.Offset);
+                // Clamp to the representable range for the current offset.
+                long offsetTicks = value.Offset.Ticks;
+                long maxTicks = offsetTicks < 0 ? DateTime.MaxValue.Ticks + offsetTicks : DateTime.MaxValue.Ticks;
+                long minTicks = offsetTicks > 0 ? DateTime.MinValue.Ticks + offsetTicks : DateTime.MinValue.Ticks;
+                return days > 0 ? new DateTimeOffset(maxTicks, value.Offset) : new DateTimeOffset(minTicks, value.Offset);
             }
 
             long ticks = days * TimeSpan.TicksPerDay;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -102,8 +102,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
                     var differenceTicks = (long)((Clock.UtcNow.Ticks - Math.Max(startTicks, endTicks)) * ApproximateMultiplier);
 
-                    var approximateStart = dateTime.Start.AddTicks(-differenceTicks);
-                    var approximateEnd = dateTime.End.AddTicks(differenceTicks);
+                    var approximateStart = dateTime.Start.SafeAddTicks(-differenceTicks);
+                    var approximateEnd = dateTime.End.SafeAddTicks(differenceTicks);
 
                     // Spec (ap): the search range overlaps the target range. Emit overlap directly
                     // (Start <= approxEnd AND End >= approxStart) rather than the eq-shaped containment.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                     var startTicks = dateTime.Start.UtcTicks;
                     var endTicks = dateTime.End.UtcTicks;
 
-                    var differenceTicks = (long)((Clock.UtcNow.Ticks - Math.Max(startTicks, endTicks)) * ApproximateMultiplier);
+                    var differenceTicks = (long)(Math.Abs(Clock.UtcNow.Ticks - Math.Max(startTicks, endTicks)) * ApproximateMultiplier);
 
                     var approximateStart = dateTime.Start.SafeAddTicks(-differenceTicks);
                     var approximateEnd = dateTime.End.SafeAddTicks(differenceTicks);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                     var startTicks = dateTime.Start.UtcTicks;
                     var endTicks = dateTime.End.UtcTicks;
 
-                    var differenceTicks = (long)(Math.Abs(Clock.UtcNow.Ticks - Math.Max(startTicks, endTicks)) * ApproximateMultiplier);
+                    var differenceTicks = (long)((Clock.UtcNow.Ticks - Math.Max(startTicks, endTicks)) * ApproximateMultiplier);
 
                     var approximateStart = dateTime.Start.SafeAddTicks(-differenceTicks);
                     var approximateEnd = dateTime.End.SafeAddTicks(differenceTicks);

--- a/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
@@ -22,20 +22,20 @@
     },
     "SqlServer": {
       "commandName": "Project",
-      "environmentVariables": {
-        "SqlServer:Initialize": "true",
-        "SqlServer:AllowDatabaseCreation": "true",
-        "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
-        "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
-        "SqlServer:ConnectionString": "server=(local);Initial Catalog=FHIR_R4;Integrated Security=true;TrustServerCertificate=true",
-        "DataStore": "SqlServer",
-        "TaskHosting:Enabled": "true",
-        "TaskHosting:MaxRunningTaskCount": "2",
-        "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
-        "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
-        "FhirServer:Operations:Import:Enabled": "true",
-        "ASPNETCORE_ENVIRONMENT": "development"
-      },
+        "environmentVariables": {
+            "SqlServer:Initialize": "true",
+            "SqlServer:AllowDatabaseCreation": "true",
+            "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
+            "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
+            "SqlServer:ConnectionString": "server=V-IYAMAUCHI00\\MSSQLSERVER01;Initial Catalog=FHIR_R4;Integrated Security=true;TrustServerCertificate=true",
+            "DataStore": "SqlServer",
+            "TaskHosting:Enabled": "true",
+            "TaskHosting:MaxRunningTaskCount": "2",
+            "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
+            "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
+            "FhirServer:Operations:Import:Enabled": "true",
+            "ASPNETCORE_ENVIRONMENT": "development"
+        },
       "applicationUrl": "https://localhost:44348/"
     }
   }

--- a/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
@@ -22,20 +22,20 @@
     },
     "SqlServer": {
       "commandName": "Project",
-        "environmentVariables": {
-            "SqlServer:Initialize": "true",
-            "SqlServer:AllowDatabaseCreation": "true",
-            "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
-            "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
-            "SqlServer:ConnectionString": "server=V-IYAMAUCHI00\\MSSQLSERVER01;Initial Catalog=FHIR_R4;Integrated Security=true;TrustServerCertificate=true",
-            "DataStore": "SqlServer",
-            "TaskHosting:Enabled": "true",
-            "TaskHosting:MaxRunningTaskCount": "2",
-            "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
-            "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
-            "FhirServer:Operations:Import:Enabled": "true",
-            "ASPNETCORE_ENVIRONMENT": "development"
-        },
+      "environmentVariables": {
+        "SqlServer:Initialize": "true",
+        "SqlServer:AllowDatabaseCreation": "true",
+        "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "true",
+        "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
+        "SqlServer:ConnectionString": "server=(local);Initial Catalog=FHIR_R4;Integrated Security=true;TrustServerCertificate=true",
+        "DataStore": "SqlServer",
+        "TaskHosting:Enabled": "true",
+        "TaskHosting:MaxRunningTaskCount": "2",
+        "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
+        "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
+        "FhirServer:Operations:Import:Enabled": "true",
+        "ASPNETCORE_ENVIRONMENT": "development"
+      },
       "applicationUrl": "https://localhost:44348/"
     }
   }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -397,6 +397,28 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             }
         }
 
+        [Fact]
+        public void GivenAnExtremeFutureDateWithApComparator_WhenBuilt_ThenFutureBoundIsClamped()
+        {
+            using (Mock.Property(() => ClockResolver.TimeProvider, new Microsoft.Extensions.Time.Testing.FakeTimeProvider(DateTimeOffset.Parse("2018-01-01T00:00Z"))))
+            {
+                Validate(
+                    CreateSearchParameter(SearchParamType.Date),
+                    null,
+                    "ap9500-01-01",
+                    e => ValidateMultiaryExpression(
+                        e,
+                        MultiaryOperator.And,
+                        e1 =>
+                        {
+                            var approximateEnd = Assert.IsType<BinaryExpression>(e1);
+                            Assert.Equal(FieldName.DateTimeStart, approximateEnd.FieldName);
+                            Assert.Equal(BinaryOperator.LessThanOrEqual, approximateEnd.BinaryOperator);
+                        },
+                        e2 => ValidateDateTimeBinaryOperatorExpression(e2, FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, DateTimeOffset.MaxValue)));
+            }
+        }
+
         [Theory]
         [MemberData(nameof(GetAllModifiersExceptMissing))]
         public void GivenADateWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifier modifier)

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/DateTimeBoundedRangeRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/DateTimeBoundedRangeRewriterTests.cs
@@ -75,6 +75,24 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
+        public void GivenStrictGreaterThanMinimumDate_WhenRewritten_ThenShortRangeBoundIncludesMinimumDate()
+        {
+            // Arrange
+            var greaterThanExpr = Expression.GreaterThan(FieldName.DateTimeEnd, null, DateTimeOffset.MinValue);
+            var lessThanExpr = Expression.LessThan(FieldName.DateTimeStart, null, DateTimeOffset.MinValue.AddHours(12));
+            var sqlRoot = CreateSqlRootWithExpression(Expression.And(greaterThanExpr, lessThanExpr));
+
+            // Act
+            var result = (SqlRootExpression)sqlRoot.AcceptVisitor(DateTimeBoundedRangeRewriter.Instance, null);
+
+            // Assert
+            var concatenationAnd = Assert.IsType<MultiaryExpression>(result.SearchParamTableExpressions[1].Predicate);
+            var startBoundedExpr = Assert.IsType<BinaryExpression>(concatenationAnd.Expressions[2]);
+            Assert.Equal(BinaryOperator.GreaterThanOrEqual, startBoundedExpr.BinaryOperator);
+            Assert.Equal(DateTimeOffset.MinValue, startBoundedExpr.Value);
+        }
+
+        [Fact]
         public void GivenLongDateRange_WhenRewritten_ThenCreatesLongRangeExpression()
         {
             // Arrange

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")]
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
         [InlineData(BinaryOperator.GreaterThan, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.GreaterThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")] // GE overflowed value must narrow to strict GT when clamped, else would include the max bucket
         [InlineData(BinaryOperator.LessThan, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
         [InlineData(BinaryOperator.LessThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
         [InlineData(BinaryOperator.GreaterThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")]
         [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")] // GE overflowed value must narrow to strict GT when clamped, else would include the max bucket
         [InlineData(BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
         [InlineData(BinaryOperator.LessThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
         [InlineData(BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")]
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
+        [InlineData(BinaryOperator.GreaterThan, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThan, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThan, "3654-06-18T21:21:00.682Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.682Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
         [Theory]
         public void GivenAnExpressionOverLastUpdated_WhenTranslatedToResourceSurrogateId_HasCorrectRanges(BinaryOperator inputOperator, string inputDateTimeOffset, BinaryOperator expectedOperator, string expectedDateTimeOffset)
         {

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
@@ -26,12 +26,16 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")]
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
-        [InlineData(BinaryOperator.GreaterThan, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThan, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")]
         [InlineData(BinaryOperator.GreaterThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.LessThan, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.LessThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.GreaterThan, "3654-06-18T21:21:00.682Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.682Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThan, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
+        [InlineData(BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
         [Theory]
         public void GivenAnExpressionOverLastUpdated_WhenTranslatedToResourceSurrogateId_HasCorrectRanges(BinaryOperator inputOperator, string inputDateTimeOffset, BinaryOperator expectedOperator, string expectedDateTimeOffset)
         {
@@ -43,6 +47,16 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             Assert.Equal(SqlFieldName.ResourceSurrogateId, binaryOutput.FieldName);
             Assert.Equal(expectedOperator, binaryOutput.BinaryOperator);
             Assert.Equal(DateTimeOffset.Parse(expectedDateTimeOffset), ((long)binaryOutput.Value).ToLastUpdated());
+        }
+
+        [InlineData(BinaryOperator.Equal)]
+        [InlineData(BinaryOperator.NotEqual)]
+        [Theory]
+        public void GivenAnExpressionWithEqualOrNotEqual_WhenTranslatedToResourceSurrogateId_Throws(BinaryOperator inputOperator)
+        {
+            var input = new BinaryExpression(inputOperator, FieldName.DateTimeStart, null, DateTimeOffset.Parse("2020-09-24T12:00:00.500Z"));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => input.AcceptVisitor(LastUpdatedToResourceSurrogateIdRewriter.Instance, null));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
@@ -26,16 +26,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")]
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
-        [InlineData(BinaryOperator.GreaterThan, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.GreaterThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")] // GE overflowed value must narrow to strict GT when clamped, else would include the max bucket
-        [InlineData(BinaryOperator.LessThan, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.LessThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.GreaterThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")]
         [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z", BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThan, "3654-06-18T21:21:00.683Z")] // GE overflowed value must narrow to strict GT when clamped, else would include the max bucket
         [InlineData(BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z", BinaryOperator.LessThan, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.LessThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
-        [InlineData(BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.683Z")]
         [Theory]
         public void GivenAnExpressionOverLastUpdated_WhenTranslatedToResourceSurrogateId_HasCorrectRanges(BinaryOperator inputOperator, string inputDateTimeOffset, BinaryOperator expectedOperator, string expectedDateTimeOffset)
         {
@@ -47,6 +39,27 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             Assert.Equal(SqlFieldName.ResourceSurrogateId, binaryOutput.FieldName);
             Assert.Equal(expectedOperator, binaryOutput.BinaryOperator);
             Assert.Equal(DateTimeOffset.Parse(expectedDateTimeOffset), ((long)binaryOutput.Value).ToLastUpdated());
+        }
+
+        [Theory]
+        [InlineData(BinaryOperator.GreaterThan, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThan)]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.GreaterThan)]
+        [InlineData(BinaryOperator.LessThan, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual)]
+        [InlineData(BinaryOperator.LessThanOrEqual, "9999-12-31T23:59:59.999Z", BinaryOperator.LessThanOrEqual)]
+        [InlineData(BinaryOperator.GreaterThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThan)]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.GreaterThan)]
+        [InlineData(BinaryOperator.LessThan, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual)]
+        [InlineData(BinaryOperator.LessThanOrEqual, "3654-06-18T21:21:00.6839999Z", BinaryOperator.LessThanOrEqual)]
+        public void GivenAnOverflowedLastUpdatedExpression_WhenTranslatedToResourceSurrogateId_UsesMaxSurrogateId(BinaryOperator inputOperator, string inputDateTimeOffset, BinaryOperator expectedOperator)
+        {
+            var input = new BinaryExpression(inputOperator, FieldName.DateTimeStart, null, DateTimeOffset.Parse(inputDateTimeOffset));
+
+            var output = input.AcceptVisitor(LastUpdatedToResourceSurrogateIdRewriter.Instance, null);
+
+            BinaryExpression binaryOutput = Assert.IsType<BinaryExpression>(output);
+            Assert.Equal(SqlFieldName.ResourceSurrogateId, binaryOutput.FieldName);
+            Assert.Equal(expectedOperator, binaryOutput.BinaryOperator);
+            Assert.Equal(long.MaxValue, binaryOutput.Value);
         }
 
         [InlineData(BinaryOperator.Equal)]

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/ScalarTemporalEqualityRewriterTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         private static readonly DateTimeOffset EndOfLastDayOfMonth = new DateTimeOffset(2016, 7, 31, 23, 59, 59, TimeSpan.Zero).AddTicks(9999999);
         private static readonly DateTimeOffset StartOfLastDayOfYear = new DateTimeOffset(2016, 12, 31, 0, 0, 0, TimeSpan.Zero);
         private static readonly DateTimeOffset EndOfLastDayOfYear = new DateTimeOffset(2016, 12, 31, 23, 59, 59, TimeSpan.Zero).AddTicks(9999999);
+        private static readonly DateTimeOffset StartOfMaximumDate = new DateTimeOffset(9999, 12, 31, 0, 0, 0, TimeSpan.Zero);
         private static readonly DateTimeOffset StartOfMonth = new DateTimeOffset(2016, 7, 1, 0, 0, 0, TimeSpan.Zero);
         private static readonly DateTimeOffset EndOfMonth = new DateTimeOffset(2016, 7, 31, 23, 59, 59, TimeSpan.Zero).AddTicks(9999999);
 
@@ -45,6 +46,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             { StartOfDay, EndOfDay },
             { StartOfLastDayOfMonth, EndOfLastDayOfMonth },
             { StartOfLastDayOfYear, EndOfLastDayOfYear },
+            { StartOfMaximumDate, DateTimeOffset.MaxValue },
         };
 
         public static TheoryData<Expression> NonRewritableExpressions => new()
@@ -53,6 +55,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, StartOfDay), // single-sided predicate
             Expression.GreaterThan(FieldName.DateTimeStart, null, EndOfDay), // range operator
             EqualityPattern(StartOfDay.AddDays(-30), EndOfDay.AddDays(30)), // approximate / multi-day window
+            EqualityPattern(StartOfMaximumDate, DateTimeOffset.MaxValue.AddTicks(-1)), // not the full final day
         };
 
         public static TheoryData<SearchParameterInfo> NonAllowListedParameters => new()

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DateTimeBoundedRangeRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DateTimeBoundedRangeRewriter.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.ValueSets;
 
@@ -41,7 +42,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 return Expression.And(
                     Expression.Equals(SqlFieldName.DateTimeIsLongerThanADay, left.ComponentIndex, false),
                     new BinaryExpression(left.BinaryOperator, FieldName.DateTimeEnd, left.ComponentIndex, left.Value),
-                    new BinaryExpression(left.BinaryOperator, FieldName.DateTimeStart, left.ComponentIndex, ((DateTimeOffset)left.Value).AddTicks(-TimeSpan.TicksPerDay)),
+                    new BinaryExpression(left.BinaryOperator, FieldName.DateTimeStart, left.ComponentIndex, ((DateTimeOffset)left.Value).SafeAddTicks(-TimeSpan.TicksPerDay)),
                     new BinaryExpression(right.BinaryOperator, FieldName.DateTimeStart, right.ComponentIndex, right.Value));
             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DateTimeBoundedRangeRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DateTimeBoundedRangeRewriter.cs
@@ -38,11 +38,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             {
                 var left = (BinaryExpression)expression.Expressions[1];
                 var right = (BinaryExpression)expression.Expressions[2];
+                var leftValue = (DateTimeOffset)left.Value;
+                DateTimeOffset boundedStart = leftValue.SafeAddTicks(-TimeSpan.TicksPerDay);
+                BinaryOperator boundedStartOperator = left.BinaryOperator == BinaryOperator.GreaterThan &&
+                    leftValue < DateTimeOffset.MinValue.AddTicks(TimeSpan.TicksPerDay)
+                    ? BinaryOperator.GreaterThanOrEqual
+                    : left.BinaryOperator;
 
                 return Expression.And(
                     Expression.Equals(SqlFieldName.DateTimeIsLongerThanADay, left.ComponentIndex, false),
                     new BinaryExpression(left.BinaryOperator, FieldName.DateTimeEnd, left.ComponentIndex, left.Value),
-                    new BinaryExpression(left.BinaryOperator, FieldName.DateTimeStart, left.ComponentIndex, ((DateTimeOffset)left.Value).SafeAddTicks(-TimeSpan.TicksPerDay)),
+                    new BinaryExpression(boundedStartOperator, FieldName.DateTimeStart, left.ComponentIndex, boundedStart),
                     new BinaryExpression(right.BinaryOperator, FieldName.DateTimeStart, right.ComponentIndex, right.Value));
             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
@@ -56,7 +57,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     return Expression.GreaterThanOrEqual(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(truncated.AddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
+                        new DateTimeOffset(truncated.SafeAddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
                 case BinaryOperator.GreaterThanOrEqual:
                     if (original == truncated)
                     {
@@ -81,7 +82,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     return Expression.LessThan(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(truncated.AddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
+                        new DateTimeOffset(truncated.SafeAddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
                 case BinaryOperator.NotEqual:
                 case BinaryOperator.Equal: // expecting eq to have been rewritten as a range
                 default:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -112,11 +112,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
         private static BinaryExpression VisitBinaryConstrained(BinaryExpression expression)
         {
-            // Constrain to MaxDateTime - Dates beyond MaxDateTime are outside the system's representable range.
-            // ResourceSurrogateId encodes the datetime in high bits and a uniquifier (0-7) in low 3 bits.
-            // Use the max surrogate ID for the constrained millisecond (uniquifier = 7) to correctly account for all rows in that bucket.
-            DateTime constrained = IdHelper.MaxDateTime.UtcDateTime;
-            long maxSurrogateId = new DateTimeOffset(constrained).ToSurrogateId() + 7;
+            // Dates beyond IdHelper.MaxDateTime are outside the system's representable range.
+            // ResourceSurrogateId uses a database uniquifier in the range 0..79999, so use the maximum stored ID as the overflow bound.
+            // LT/LE overflow predicates must include every valid row; GT/GE predicates against this bound are always false.
+            long maxSurrogateId = long.MaxValue;
 
             switch (expression.BinaryOperator)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -128,8 +128,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                         maxSurrogateId);
 
                 case BinaryOperator.GreaterThanOrEqual:
-                    // GE maxSurrogateId is always-false
-                    return Expression.GreaterThanOrEqual(
+                    // GE of an overflowed value should behave like GT to exclude the max bucket, ensuring an empty result set.
+                    return Expression.GreaterThan(
                         SqlFieldName.ResourceSurrogateId,
                         null,
                         maxSurrogateId);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -46,63 +46,88 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
             }
 
-            // ResourceSurrogateId has millisecond datetime precision, with lower bits added in to make the value unique.
+            // Validate the operator up front so that an unsupported operator is not mistaken for an overflow by the catch block below.
+            if (expression.BinaryOperator == BinaryOperator.NotEqual || expression.BinaryOperator == BinaryOperator.Equal)
+            {
+                throw new ArgumentOutOfRangeException(expression.BinaryOperator.ToString());
+            }
 
+            // ResourceSurrogateId has millisecond datetime precision, with lower bits added in to make the value unique.
             DateTime original = ((DateTimeOffset)expression.Value).UtcDateTime;
             DateTime truncated = original.TruncateToMillisecond();
 
-            // Constrain to MaxDateTime to prevent overflow during DateTime arithmetic.
-            // Dates beyond MaxDateTime are outside the system's representable range.
-            DateTime constrained = truncated > IdHelper.MaxDateTime.UtcDateTime
-                ? IdHelper.MaxDateTime.UtcDateTime
-                : truncated;
+            try
+            {
+                switch (expression.BinaryOperator)
+                {
+                    case BinaryOperator.GreaterThan:
+                        return Expression.GreaterThanOrEqual(
+                            SqlFieldName.ResourceSurrogateId,
+                            null,
+                            new DateTimeOffset(truncated.SafeAddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
+                    case BinaryOperator.GreaterThanOrEqual:
+                        if (original == truncated)
+                        {
+                            return Expression.GreaterThanOrEqual(
+                                SqlFieldName.ResourceSurrogateId,
+                                null,
+                                new DateTimeOffset(truncated).ToSurrogateId());
+                        }
+
+                        goto case BinaryOperator.GreaterThan;
+                    case BinaryOperator.LessThan:
+                        if (original == truncated)
+                        {
+                            return Expression.LessThan(
+                                SqlFieldName.ResourceSurrogateId,
+                                null,
+                                new DateTimeOffset(truncated).ToSurrogateId());
+                        }
+
+                        goto case BinaryOperator.LessThanOrEqual;
+                    case BinaryOperator.LessThanOrEqual:
+                        return Expression.LessThan(
+                            SqlFieldName.ResourceSurrogateId,
+                            null,
+                            new DateTimeOffset(truncated.SafeAddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
+                    default:
+                        // Unreachable - the operator is validated above.
+                        throw new ArgumentOutOfRangeException(expression.BinaryOperator.ToString());
+                }
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // If the original/truncated value is outside the representable range of IdHelper.MaxDateTime, constrain it to MaxDateTime.
+                return VisitBinaryConstrained(expression);
+            }
+        }
+
+        private static BinaryExpression VisitBinaryConstrained(BinaryExpression expression)
+        {
+            // Constrain to MaxDateTime - Dates beyond MaxDateTime are outside the system's representable range.
+            DateTime constrained = IdHelper.MaxDateTime.UtcDateTime;
 
             switch (expression.BinaryOperator)
             {
                 case BinaryOperator.GreaterThan:
-                    // For gt, round up to next millisecond, clamped to MaxDateTime
-                    DateTime gt = constrained.SafeAddTicks(TimeSpan.TicksPerMillisecond);
-                    if (gt > IdHelper.MaxDateTime.UtcDateTime)
-                    {
-                        gt = IdHelper.MaxDateTime.UtcDateTime;
-                    }
+                    return Expression.GreaterThan(
+                        SqlFieldName.ResourceSurrogateId,
+                        null,
+                        new DateTimeOffset(constrained).ToSurrogateId());
 
+                case BinaryOperator.GreaterThanOrEqual:
                     return Expression.GreaterThanOrEqual(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(gt).ToSurrogateId());
-                case BinaryOperator.GreaterThanOrEqual:
-                    if (original == truncated)
-                    {
-                        return Expression.GreaterThanOrEqual(
-                            SqlFieldName.ResourceSurrogateId,
-                            null,
-                            new DateTimeOffset(constrained).ToSurrogateId());
-                    }
+                        new DateTimeOffset(constrained).ToSurrogateId());
 
-                    goto case BinaryOperator.GreaterThan;
                 case BinaryOperator.LessThan:
-                    if (original == truncated)
-                    {
-                        return Expression.LessThan(
-                            SqlFieldName.ResourceSurrogateId,
-                            null,
-                            new DateTimeOffset(constrained).ToSurrogateId());
-                    }
-
-                    goto case BinaryOperator.LessThanOrEqual;
                 case BinaryOperator.LessThanOrEqual:
-                    // For le, round up to next millisecond, clamped to MaxDateTime
-                    DateTime lt = constrained.SafeAddTicks(TimeSpan.TicksPerMillisecond);
-                    if (lt > IdHelper.MaxDateTime.UtcDateTime)
-                    {
-                        lt = IdHelper.MaxDateTime.UtcDateTime;
-                    }
-
-                    return Expression.LessThan(
+                    return Expression.LessThanOrEqual(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(lt).ToSurrogateId());
+                        new DateTimeOffset(constrained).ToSurrogateId());
+
                 case BinaryOperator.NotEqual:
                 case BinaryOperator.Equal: // expecting eq to have been rewritten as a range
                 default:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -47,9 +47,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             }
 
             // Validate the operator up front so that an unsupported operator is not mistaken for an overflow by the catch block below.
-            if (expression.BinaryOperator == BinaryOperator.NotEqual || expression.BinaryOperator == BinaryOperator.Equal)
+            switch (expression.BinaryOperator)
             {
-                throw new ArgumentOutOfRangeException(expression.BinaryOperator.ToString());
+                case BinaryOperator.GreaterThan:
+                case BinaryOperator.GreaterThanOrEqual:
+                case BinaryOperator.LessThan:
+                case BinaryOperator.LessThanOrEqual:
+                    break;
+                case BinaryOperator.Equal:
+                case BinaryOperator.NotEqual:
+                default:
+                    throw new ArgumentOutOfRangeException(expression.BinaryOperator.ToString());
             }
 
             // ResourceSurrogateId has millisecond datetime precision, with lower bits added in to make the value unique.
@@ -105,28 +113,35 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
         private static BinaryExpression VisitBinaryConstrained(BinaryExpression expression)
         {
             // Constrain to MaxDateTime - Dates beyond MaxDateTime are outside the system's representable range.
+            // ResourceSurrogateId encodes the datetime in high bits and a uniquifier (0-7) in low 3 bits.
+            // Use the max surrogate ID for the constrained millisecond (uniquifier = 7) to correctly account for all rows in that bucket.
             DateTime constrained = IdHelper.MaxDateTime.UtcDateTime;
+            long maxSurrogateId = new DateTimeOffset(constrained).ToSurrogateId() + 7;
 
             switch (expression.BinaryOperator)
             {
                 case BinaryOperator.GreaterThan:
+                    // GT maxSurrogateId is always-false (no row can exceed the max possible ID)
                     return Expression.GreaterThan(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(constrained).ToSurrogateId());
+                        maxSurrogateId);
 
                 case BinaryOperator.GreaterThanOrEqual:
+                    // GE maxSurrogateId is always-false
                     return Expression.GreaterThanOrEqual(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(constrained).ToSurrogateId());
+                        maxSurrogateId);
 
                 case BinaryOperator.LessThan:
                 case BinaryOperator.LessThanOrEqual:
+                    // When clamping an overflowed value down, widen LT to LE to be semantically correct.
+                    // LT/LE maxSurrogateId is always-true (all rows are <= max possible ID)
                     return Expression.LessThanOrEqual(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(constrained).ToSurrogateId());
+                        maxSurrogateId);
 
                 case BinaryOperator.NotEqual:
                 case BinaryOperator.Equal: // expecting eq to have been rewritten as a range

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -51,20 +51,33 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             DateTime original = ((DateTimeOffset)expression.Value).UtcDateTime;
             DateTime truncated = original.TruncateToMillisecond();
 
+            // Constrain to MaxDateTime to prevent overflow during DateTime arithmetic.
+            // Dates beyond MaxDateTime are outside the system's representable range.
+            DateTime constrained = truncated > IdHelper.MaxDateTime.UtcDateTime
+                ? IdHelper.MaxDateTime.UtcDateTime
+                : truncated;
+
             switch (expression.BinaryOperator)
             {
                 case BinaryOperator.GreaterThan:
+                    // For gt, round up to next millisecond, clamped to MaxDateTime
+                    DateTime gt = constrained.SafeAddTicks(TimeSpan.TicksPerMillisecond);
+                    if (gt > IdHelper.MaxDateTime.UtcDateTime)
+                    {
+                        gt = IdHelper.MaxDateTime.UtcDateTime;
+                    }
+
                     return Expression.GreaterThanOrEqual(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(truncated.SafeAddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
+                        new DateTimeOffset(gt).ToSurrogateId());
                 case BinaryOperator.GreaterThanOrEqual:
                     if (original == truncated)
                     {
                         return Expression.GreaterThanOrEqual(
                             SqlFieldName.ResourceSurrogateId,
                             null,
-                            new DateTimeOffset(truncated).ToSurrogateId());
+                            new DateTimeOffset(constrained).ToSurrogateId());
                     }
 
                     goto case BinaryOperator.GreaterThan;
@@ -74,15 +87,22 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                         return Expression.LessThan(
                             SqlFieldName.ResourceSurrogateId,
                             null,
-                            new DateTimeOffset(truncated).ToSurrogateId());
+                            new DateTimeOffset(constrained).ToSurrogateId());
                     }
 
                     goto case BinaryOperator.LessThanOrEqual;
                 case BinaryOperator.LessThanOrEqual:
+                    // For le, round up to next millisecond, clamped to MaxDateTime
+                    DateTime lt = constrained.SafeAddTicks(TimeSpan.TicksPerMillisecond);
+                    if (lt > IdHelper.MaxDateTime.UtcDateTime)
+                    {
+                        lt = IdHelper.MaxDateTime.UtcDateTime;
+                    }
+
                     return Expression.LessThan(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        new DateTimeOffset(truncated.SafeAddTicks(TimeSpan.TicksPerMillisecond)).ToSurrogateId());
+                        new DateTimeOffset(lt).ToSurrogateId());
                 case BinaryOperator.NotEqual:
                 case BinaryOperator.Equal: // expecting eq to have been rewritten as a range
                 default:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 return Precision.NotRewritable;
             }
 
-            if (end == start.SafeAddTicks(TimeSpan.TicksPerDay - 1))
+            if (end == start.SafeAddDays(1).SafeAddTicks(-1))
             {
                 return Precision.ExactDay;
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 return Precision.NotRewritable;
             }
 
-            if (end == start.SafeAddDays(1).SafeAddTicks(-1))
+            if (end == start.SafeAddTicks(TimeSpan.TicksPerDay - 1))
             {
                 return Precision.ExactDay;
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
@@ -133,7 +134,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 return Precision.NotRewritable;
             }
 
-            if (end == start.AddDays(1).AddTicks(-1))
+            if (end == start.SafeAddDays(1).SafeAddTicks(-1))
             {
                 return Precision.ExactDay;
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ScalarTemporalEqualityRewriter.cs
@@ -134,7 +134,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 return Precision.NotRewritable;
             }
 
-            if (end == start.SafeAddDays(1).SafeAddTicks(-1))
+            DateTimeOffset nextDay = start.SafeAddDays(1);
+            DateTimeOffset inclusiveEnd = nextDay == DateTimeOffset.MaxValue
+                ? nextDay
+                : nextDay.SafeAddTicks(-1);
+
+            if (end == inclusiveEnd)
             {
                 return Precision.ExactDay;
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -299,6 +299,46 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
         }
 
+        [Theory]
+        [InlineData("lt9999-12-31", true)]
+        [InlineData("le9999-12-31", true)]
+        [InlineData("gt9999-12-31", false)]
+        [InlineData("ge9999-12-31", false)]
+        [InlineData("lt9999-12-31T23:59:59.999Z", true)]
+        [InlineData("le9999-12-31T23:59:59.999Z", true)]
+        [InlineData("gt9999-12-31T23:59:59.999Z", false)]
+        [InlineData("ge9999-12-31T23:59:59.999Z", false)]
+        [InlineData("lt3654-06-18T21:21:00.6839999Z", true)]
+        [InlineData("le3654-06-18T21:21:00.6839999Z", true)]
+        [InlineData("gt3654-06-18T21:21:00.6839999Z", false)]
+        [InlineData("ge3654-06-18T21:21:00.6839999Z", false)]
+        [InlineData("ge1970-01-01T00:00:00Z", true)]
+        [InlineData("lt1970-01-01T00:00:00Z", false)]
+        public async Task GivenALargeLastUpdatedSearchParam_WhenSearched_ThenCorrectBundleShouldBeReturned(string queryValue, bool resourceSearched)
+        {
+            try
+            {
+                Bundle bundle = await Client.SearchAsync(ResourceType.Observation, $"_lastUpdated={queryValue}&code={Fixture.Coding.Code}");
+
+                if (resourceSearched)
+                {
+                    ValidateBundle(bundle, Fixture.Observations.ToArray());
+                }
+                else
+                {
+                    Assert.Empty(bundle.Entry);
+                }
+            }
+            catch (FhirClientException fce)
+            {
+                Assert.Fail($"A non-expected '{nameof(FhirClientException)}' was raised. Url: {Client.HttpClient.BaseAddress}. Activity Id: {fce.Response.GetRequestId()}. Error: {fce.Message}");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"A non-expected '{e.GetType()}' was raised. Url: {Client.HttpClient.BaseAddress}. No Activity Id present. Error: {e.Message}");
+            }
+        }
+
         private static void SetPatientBirthDate(Patient patient, string birthDate, string tag)
         {
             patient.Meta = new Meta { Tag = new List<Coding> { new Coding(null, tag) } };


### PR DESCRIPTION
## Description
Fix: Prevent DateTime overflow in search expression rewriters

FHIR search queries with extreme dates (e.g., _lastUpdated=gt9999-12-31, birthdate=ap9500-01-01) caused OverflowException in the SQL rewriting pipeline → 500 response. The overflow came from internal date arithmetic (AddTicks/AddDays) for SQL optimization, not invalid user input.

Changes:
- Added DateTimeSafeExtensions with SafeAddTicks/SafeAddDays that clamp to DateTime.Min/MaxValue instead of throwing
- Applied to LastUpdatedToResourceSurrogateIdRewriter, DateTimeBoundedRangeRewriter, ScalarTemporalEqualityRewriter, and SearchValueExpressionBuilderHelper (ap comparator)

## Related issues
Addresses [issue #181592].

[Bug 181592](https://microsofthealth.visualstudio.com/Health/_workitems/edit/181592): [Edge case] : 500 returned due to ArgumentOutOfRangeException for datetime

## Testing
Tested by adding some UTs.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
