### PR TITLE
Advertise SMART permission-v1 capability

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Constants.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Constants.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
             "permission-patient",
             "permission-user",
             "permission-offline",
+            "permission-v1",
             "permission-v2",
         };
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/GetSmartConfigurationHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/GetSmartConfigurationHandlerTests.cs
@@ -92,6 +92,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             Assert.Equal(baseEndpoint + "/oauth2/v2.0/authorize", response.AuthorizationEndpoint.ToString());
             Assert.Equal(baseEndpoint + "/oauth2/v2.0/token", response.TokenEndpoint.ToString());
             Assert.Equal(ExpectedBaseCapabilities, response.Capabilities);
+            Assert.Contains("permission-v1", response.Capabilities);
+            Assert.Contains("permission-v2", response.Capabilities);
             Assert.Equal(baseEndpoint + "/v2.0", response.Issuer);
             Assert.Equal(baseEndpoint + "/discovery/v2.0/keys", response.JwksUri);
 


### PR DESCRIPTION
## Description
Adds `permission-v1` to the capabilities advertised by `/.well-known/smart-configuration` while retaining the existing `permission-v2` capability. Adds explicit regression coverage for both values.

## Related issues
N/A.

## Testing
`dotnet test .\src\Microsoft.Health.Fhir.R4.Core.UnitTests\Microsoft.Health.Fhir.R4.Core.UnitTests.csproj --filter "FullyQualifiedName~GetSmartConfigurationHandlerTests" --verbosity quiet` (11 passed)

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch — adds a missing advertised capability without changing API compatibility.