### PR TITLE
Fix client ID returned by token introspection

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Security/DefaultTokenIntrospectionService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Security/DefaultTokenIntrospectionService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
         /// </summary>
         public const string OidcConfigurationHttpClientName = "OidcConfiguration";
 
+        private static readonly List<string> ClientIdClaimNames = new List<string> { "client_id", "appid", "azp", "sub" };
         private static readonly List<string> DefaultScopeClaimNames = new List<string> { "scp" };
 
         private readonly SecurityConfiguration _securityConfiguration;
@@ -202,8 +203,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
                 response["iat"] = new DateTimeOffset(token.ValidFrom).ToUnixTimeSeconds();
             }
 
-            // Extract client_id (use sub if client_id not present)
-            var clientId = principal.FindFirst("client_id")?.Value ?? principal.FindFirst("sub")?.Value;
+            // Entra v1 tokens use appid and v2 tokens use azp; sub remains the fallback for development OpenIddict tokens.
+            var clientId = ClientIdClaimNames
+                .Select(claimName => principal.FindFirst(claimName)?.Value)
+                .FirstOrDefault(value => !string.IsNullOrEmpty(value));
             if (!string.IsNullOrEmpty(clientId))
             {
                 response["client_id"] = clientId;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/DefaultTokenIntrospectionServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/DefaultTokenIntrospectionServiceTests.cs
@@ -1,0 +1,126 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Api.Features.Security;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Security
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Security)]
+    public class DefaultTokenIntrospectionServiceTests
+    {
+        private const string ExpectedClientId = "ef0c25fd-8da1-47d5-9c85-7ece2c7c1779";
+        private const string UserSubject = "9di8U8daZj2Gfq8XmjWGYC3qBanXsnRG8eS7tvH3lcM";
+
+        [Theory]
+        [InlineData("appid")]
+        [InlineData("azp")]
+        public async Task GivenEntraClientIdClaim_WhenIntrospecting_ThenReturnsApplicationIdAsClientId(string clientIdClaimName)
+        {
+            // Arrange
+            var service = CreateService(
+                new Claim("sub", UserSubject),
+                new Claim(clientIdClaimName, ExpectedClientId));
+
+            // Act
+            var response = await service.IntrospectTokenAsync("test-token");
+
+            // Assert
+            Assert.Equal(ExpectedClientId, response["client_id"]);
+            Assert.Equal(UserSubject, response["sub"]);
+        }
+
+        [Fact]
+        public async Task GivenExplicitClientIdAndEntraClaims_WhenIntrospecting_ThenPrefersExplicitClientId()
+        {
+            // Arrange
+            const string explicitClientId = "explicit-client-id";
+            var service = CreateService(
+                new Claim("sub", UserSubject),
+                new Claim("appid", ExpectedClientId),
+                new Claim("azp", ExpectedClientId),
+                new Claim("client_id", explicitClientId));
+
+            // Act
+            var response = await service.IntrospectTokenAsync("test-token");
+
+            // Assert
+            Assert.Equal(explicitClientId, response["client_id"]);
+        }
+
+        [Fact]
+        public async Task GivenOnlySubjectClaim_WhenIntrospecting_ThenUsesSubjectAsClientId()
+        {
+            // Arrange
+            var service = CreateService(new Claim("sub", ExpectedClientId));
+
+            // Act
+            var response = await service.IntrospectTokenAsync("test-token");
+
+            // Assert
+            Assert.Equal(ExpectedClientId, response["client_id"]);
+        }
+
+        private static StubTokenIntrospectionService CreateService(params Claim[] claims)
+        {
+            var httpClientFactory = Substitute.For<IHttpClientFactory>();
+            httpClientFactory
+                .CreateClient(DefaultTokenIntrospectionService.OidcConfigurationHttpClientName)
+                .Returns(new HttpClient());
+
+            var securityConfiguration = new SecurityConfiguration
+            {
+                Authentication = new AuthenticationConfiguration
+                {
+                    Authority = "https://issuer.example.com",
+                    Audience = "https://fhir.example.com",
+                },
+            };
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+            return new StubTokenIntrospectionService(
+                Options.Create(securityConfiguration),
+                httpClientFactory,
+                principal);
+        }
+
+        private sealed class StubTokenIntrospectionService : DefaultTokenIntrospectionService
+        {
+            private readonly ClaimsPrincipal _principal;
+
+            public StubTokenIntrospectionService(
+                IOptions<SecurityConfiguration> securityConfiguration,
+                IHttpClientFactory httpClientFactory,
+                ClaimsPrincipal principal)
+                : base(
+                    securityConfiguration,
+                    NullLogger<DefaultTokenIntrospectionService>.Instance,
+                    httpClientFactory)
+            {
+                _principal = principal;
+            }
+
+            protected override Task<TokenValidationResult> ValidateTokenAsync(
+                string token,
+                CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(TokenValidationResult.Valid(new JwtSecurityToken(), _principal));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/DefaultTokenIntrospectionServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/DefaultTokenIntrospectionServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
@@ -22,10 +23,16 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Security
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Security)]
-    public class DefaultTokenIntrospectionServiceTests
+    public class DefaultTokenIntrospectionServiceTests : IDisposable
     {
         private const string ExpectedClientId = "ef0c25fd-8da1-47d5-9c85-7ece2c7c1779";
         private const string UserSubject = "9di8U8daZj2Gfq8XmjWGYC3qBanXsnRG8eS7tvH3lcM";
+        private readonly HttpClient _httpClient = new HttpClient();
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+        }
 
         [Theory]
         [InlineData("appid")]
@@ -76,12 +83,12 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Security
             Assert.Equal(ExpectedClientId, response["client_id"]);
         }
 
-        private static StubTokenIntrospectionService CreateService(params Claim[] claims)
+        private StubTokenIntrospectionService CreateService(params Claim[] claims)
         {
             var httpClientFactory = Substitute.For<IHttpClientFactory>();
             httpClientFactory
                 .CreateClient(DefaultTokenIntrospectionService.OidcConfigurationHttpClientName)
-                .Returns(new HttpClient());
+                .Returns(_httpClient);
 
             var securityConfiguration = new SecurityConfiguration
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -97,6 +97,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Routing\RouteTestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Routing\UrlResolverTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\RuntimeState\RuntimeStateMiddlewareTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Security\DefaultTokenIntrospectionServiceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\RequestHandlerCheckAccessTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\SecurityProviderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\SMART\SmartClinicalScopesMiddlewareTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TokenIntrospectionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TokenIntrospectionTests.cs
@@ -68,7 +68,8 @@ namespace Microsoft.Health.Fhir.Smart.Tests.E2E
             Assert.True(response.TryGetValue("iss", out _), $"Response missing 'iss' claim. Response: {responseJson}");
             Assert.True(response.TryGetValue("aud", out _), $"Response missing 'aud' claim. Response: {responseJson}");
             Assert.True(response.TryGetValue("exp", out JsonElement expirationElement), $"Response missing 'exp' claim. Response: {responseJson}");
-            Assert.True(response.TryGetValue("client_id", out _), $"Response missing 'client_id' claim. Response: {responseJson}");
+            Assert.True(response.TryGetValue("client_id", out JsonElement clientIdElement), $"Response missing 'client_id' claim. Response: {responseJson}");
+            Assert.Equal(TestApplications.GlobalAdminServicePrincipal.ClientId, clientIdElement.GetString());
 
             // Verify timestamps are Unix timestamps (positive numbers)
             Assert.True(expirationElement.GetInt64() > 0);
@@ -261,6 +262,8 @@ namespace Microsoft.Health.Fhir.Smart.Tests.E2E
             Assert.True(readerResponse.TryGetValue("client_id", out JsonElement readerClientIdElement), $"Reader response missing 'client_id'. Response: {readerResponseJson}");
             var adminClientId = adminClientIdElement.GetString();
             var readerClientId = readerClientIdElement.GetString();
+            Assert.Equal(TestApplications.GlobalAdminServicePrincipal.ClientId, adminClientId);
+            Assert.Equal(TestApplications.ReadOnlyUser.ClientId, readerClientId);
             Assert.NotEqual(adminClientId, readerClientId);
         }
 


### PR DESCRIPTION
## Description
- Return the Entra v1 `appid` or Entra v2 `azp` claim as the RFC 7662 `client_id` instead of the user subject.
- Preserve explicit `client_id` precedence and the `sub` fallback used by development OpenIddict tokens.
- Add direct service regression tests and exact client ID assertions to the E2E coverage.

## Related issues
Addresses [issue [AB#206560](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/206560)].


## Testing
Additional integration tests were added

## FHIR Team Checklist
- [ ] CI is green before merge

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch - corrects the client identifier returned by token introspection without changing the endpoint contract.