### PR TITLE
Fix SMART system search scope filtering

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Context/ScopeRestriction.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/ScopeRestriction.cs
@@ -35,6 +35,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
         // Finer-grained resource constraints using search parameters for SMART V2 compliance
         public SearchParams SearchParameters { get; }
 
+        /// <summary>
+        /// Determines whether this restriction permits any of the requested data actions.
+        /// </summary>
+        /// <param name="dataActions">The data actions to check.</param>
+        /// <returns><see langword="true"/> when at least one requested action is permitted.</returns>
+        public bool AllowsAny(DataActions dataActions)
+        {
+            return (AllowedDataAction & dataActions) != DataActions.None;
+        }
+
         public bool Equals(ScopeRestriction other)
         {
             if (other == null)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Access/ExpressionAccessControl.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Access/ExpressionAccessControl.cs
@@ -25,6 +25,15 @@ public class ExpressionAccessControl
 
     public void CheckAndRaiseAccessExceptions(Expression expression)
     {
+        CheckAndRaiseAccessExceptions(
+            expression,
+            _requestContextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions?.ToList());
+    }
+
+    public void CheckAndRaiseAccessExceptions(
+        Expression expression,
+        IReadOnlyCollection<ScopeRestriction> applicableScopeRestrictions)
+    {
         if (expression == null)
         {
             return;
@@ -39,7 +48,7 @@ public class ExpressionAccessControl
                     out IReadOnlyList<ChainedExpression> chainedExpressions,
                     out _))
             {
-                var validResourceTypes = _requestContextAccessor.RequestContext?.AccessControlContext.AllowedResourceActions.Select(r => r.Resource).ToHashSet();
+                var validResourceTypes = applicableScopeRestrictions?.Select(r => r.Resource).ToHashSet();
 
                 // check resource type restrictions from SMART clinical scopes
                 foreach (var type in chainedExpressions

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Security;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
@@ -17,6 +18,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
             bool onlyIds = false,
             bool isIncludesOperation = false);
+
+        SearchOptions Create(
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            DataActions scopeDataActions,
+            bool isAsyncOperation = false,
+            ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
+            bool onlyIds = false,
+            bool isIncludesOperation = false)
+        {
+            return Create(resourceType, queryParameters, isAsyncOperation, resourceVersionTypes, onlyIds, isIncludesOperation);
+        }
 
         SearchOptions Create(
             string compartmentType,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bool onlyIds = false,
             bool isIncludesOperation = false);
 
+        /// <summary>
+        /// Creates <see cref="SearchOptions"/> using only SMART scope restrictions that permit one of the supplied actions.
+        /// </summary>
+        /// <remarks>
+        /// The default interface implementation delegates to the overload that does not take <paramref name="scopeDataActions"/>,
+        /// so implementations should override this method to enforce action-specific scope filtering.
+        /// </remarks>
         SearchOptions Create(
             string resourceType,
             IReadOnlyList<Tuple<string, string>> queryParameters,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
@@ -37,6 +38,31 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
             bool onlyIds = false,
             bool isIncludesOperation = false);
+
+        /// <summary>
+        /// Searches resources using only SMART scope restrictions that permit one of the supplied actions.
+        /// </summary>
+        /// <param name="resourceType">The resource type that should be searched.</param>
+        /// <param name="queryParameters">The search queries.</param>
+        /// <param name="scopeDataActions">The data actions that may authorize the search.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="isAsyncOperation">Whether the search is part of an async operation.</param>
+        /// <param name="resourceVersionTypes">Which version types to include in search.</param>
+        /// <param name="onlyIds">Whether to return only resource IDs.</param>
+        /// <param name="isIncludesOperation">Whether the search is querying remaining include resources.</param>
+        /// <returns>A <see cref="SearchResult"/> representing the result.</returns>
+        Task<SearchResult> SearchAsync(
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            DataActions scopeDataActions,
+            CancellationToken cancellationToken,
+            bool isAsyncOperation = false,
+            ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
+            bool onlyIds = false,
+            bool isIncludesOperation = false)
+        {
+            return SearchAsync(resourceType, queryParameters, cancellationToken, isAsyncOperation, resourceVersionTypes, onlyIds, isIncludesOperation);
+        }
 
         /// <summary>
         /// Searches the resources using the <paramref name="searchOptions"/>.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
@@ -42,6 +42,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// <summary>
         /// Searches resources using only SMART scope restrictions that permit one of the supplied actions.
         /// </summary>
+        /// <remarks>
+        /// The default interface implementation delegates to the overload that does not take <paramref name="scopeDataActions"/>,
+        /// so implementations should override this method to enforce action-specific scope filtering.
+        /// </remarks>
         /// <param name="resourceType">The resource type that should be searched.</param>
         /// <param name="queryParameters">The search queries.</param>
         /// <param name="scopeDataActions">The data actions that may authorize the search.</param>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
@@ -57,6 +58,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             IsAsyncOperation = other.IsAsyncOperation;
             SkipAppendIntersectionWithPredecessor = other.SkipAppendIntersectionWithPredecessor;
             ContainsIterativeInclude = other.ContainsIterativeInclude;
+            ScopeDataActions = other.ScopeDataActions;
         }
 
         /// <summary>
@@ -160,6 +162,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public IReadOnlyList<(string Param, string Value)> QueryHints { get; set; }
 
         public bool OnlyIds { get; set; }
+
+        /// <summary>
+        /// Gets the data actions that may contribute SMART scope restrictions to this search.
+        /// </summary>
+        public DataActions ScopeDataActions { get; internal set; } = DataActions.Read | DataActions.Search;
 
         /// <summary>
         /// Flag for async operations.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
@@ -64,6 +65,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation, resourceVersionTypes, onlyIds, isIncludesOperation);
 
             // Execute the actual search.
+            return await SearchAsync(searchOptions, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual async Task<SearchResult> SearchAsync(
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            DataActions scopeDataActions,
+            CancellationToken cancellationToken,
+            bool isAsyncOperation = false,
+            ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
+            bool onlyIds = false,
+            bool isIncludesOperation = false)
+        {
+            SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters, scopeDataActions, isAsyncOperation, resourceVersionTypes, onlyIds, isIncludesOperation);
+
             return await SearchAsync(searchOptions, cancellationToken);
         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -22,6 +22,7 @@ using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
@@ -177,7 +178,14 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                 null,
                 cancellationToken);
 
-            (IList<FhirCosmosResourceWrapper> includes, bool includesTruncated) = await PerformIncludeQueries(results, includeExpressions, revIncludeExpressions, searchOptions.IncludeCount, smartV2ScopeExpressions, cancellationToken);
+            (IList<FhirCosmosResourceWrapper> includes, bool includesTruncated) = await PerformIncludeQueries(
+                results,
+                includeExpressions,
+                revIncludeExpressions,
+                searchOptions.IncludeCount,
+                smartV2ScopeExpressions,
+                searchOptions.ScopeDataActions,
+                cancellationToken);
 
             SearchResult searchResult = CreateSearchResult(
                 searchOptions,
@@ -618,6 +626,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             IReadOnlyCollection<IncludeExpression> revIncludeExpressions,
             int maxIncludeCount,
             IReadOnlyList<UnionExpression> smartV2ScopeExpressions,
+            DataActions scopeDataActions,
             CancellationToken cancellationToken)
         {
             if (matches.Count == 0 || (includeExpressions.Count == 0 && revIncludeExpressions.Count == 0))
@@ -650,7 +659,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     foreach (var resourceTypeGroup in referencesToInclude.GroupBy(r => r.ResourceType))
                     {
                         string resourceType = resourceTypeGroup.Key;
-                        Expression smartScopeFilter = GetSmartScopeFilterForResourceType(smartV2ScopeExpressions, resourceType, out bool hasNoAccess);
+                        Expression smartScopeFilter = GetSmartScopeFilterForResourceType(smartV2ScopeExpressions, resourceType, scopeDataActions, out bool hasNoAccess);
 
                         // Skip this resource type if no scope allows access
                         if (hasNoAccess)
@@ -778,7 +787,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         // Specific resource type(s) - check scope for each type
                         foreach (string targetResourceType in targetResourceTypes)
                         {
-                            Expression smartScopeFilter = GetSmartScopeFilterForResourceType(smartV2ScopeExpressions, targetResourceType, out bool hasNoAccess);
+                            Expression smartScopeFilter = GetSmartScopeFilterForResourceType(smartV2ScopeExpressions, targetResourceType, scopeDataActions, out bool hasNoAccess);
 
                             // Skip this revinclude if no scope allows access to this resource type
                             if (hasNoAccess)
@@ -971,7 +980,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         /// Returns a special "no access" expression if no scope allows access to this resource type (caller should skip the query).
         /// Returns the filter expression if granular scopes exist for this resource type.
         /// </summary>
-        private Expression GetSmartScopeFilterForResourceType(IReadOnlyList<UnionExpression> smartV2ScopeExpressions, string resourceType, out bool hasNoAccess)
+        private Expression GetSmartScopeFilterForResourceType(
+            IReadOnlyList<UnionExpression> smartV2ScopeExpressions,
+            string resourceType,
+            DataActions scopeDataActions,
+            out bool hasNoAccess)
         {
             hasNoAccess = false;
 
@@ -986,7 +999,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                 return null;
             }
 
-            var scopeRestrictions = _requestContextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions;
+            var scopeRestrictions = _requestContextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions
+                ?.Where(scope => scope.AllowsAny(scopeDataActions))
+                .ToList();
             if (scopeRestrictions == null || !scopeRestrictions.Any())
             {
                 return null;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -175,6 +175,47 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                     null,
                     "(Union (All) [(And (And (Param ResourceType (StringEquals TokenCode 'Observation')) code1=doo)) OR (And (And (Param ResourceType (StringEquals TokenCode 'Encounter')) code2=goo))])",
                 };
+                yield return new object[]
+                {
+                    null,
+                    new List<ScopeRestriction>
+                    {
+                        new ScopeRestriction("Patient", DataActions.Search, "system"),
+                        new ScopeRestriction("Observation", DataActions.ReadById, "system"),
+                    },
+                    new List<Tuple<string, string>>
+                    {
+                        Tuple.Create("_type", "Observation"),
+                    },
+                    "(Param ResourceType (StringEquals TokenCode 'none'))",
+                };
+                yield return new object[]
+                {
+                    null,
+                    new List<ScopeRestriction>
+                    {
+                        new ScopeRestriction(KnownResourceTypes.All, DataActions.ReadById, "system"),
+                        new ScopeRestriction("Patient", DataActions.Search, "system"),
+                    },
+                    new List<Tuple<string, string>>
+                    {
+                        Tuple.Create("_type", "Patient,Observation"),
+                    },
+                    "(Param ResourceType (StringEquals TokenCode 'Patient'))",
+                };
+                yield return new object[]
+                {
+                    null,
+                    new List<ScopeRestriction>
+                    {
+                        new ScopeRestriction("Observation", DataActions.Read, "system"),
+                    },
+                    new List<Tuple<string, string>>
+                    {
+                        Tuple.Create("_type", "Observation"),
+                    },
+                    "(Param ResourceType (StringEquals TokenCode 'Observation'))",
+                };
             }
         }
 
@@ -798,6 +839,88 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public void GivenAnIncludesOperationRequest_WhenIncludesContinuationTokenIsMissing_ThenExceptionShouldBeThrown()
         {
             Assert.Throws<BadRequestException>(() => CreateSearchOptions(isIncludesOperation: true));
+        }
+
+        [Fact]
+        public void GivenReadByIdScopeActions_WhenCreatingConcreteResourceSearch_ThenReadByIdRestrictionIsApplied()
+        {
+            _defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+            _defaultFhirRequestContext.AccessControlContext.AllowedResourceActions.Add(
+                new ScopeRestriction(KnownResourceTypes.All, DataActions.ReadById, "system"));
+
+            SearchOptions options = _factory.Create(
+                KnownResourceTypes.Observation,
+                queryParameters: null,
+                scopeDataActions: DataActions.Read | DataActions.ReadById);
+
+            ValidateResourceTypeSearchParameterExpression(options.Expression, KnownResourceTypes.Observation);
+            Assert.Equal(DataActions.Read | DataActions.ReadById, options.ScopeDataActions);
+        }
+
+        [Fact]
+        public void GivenReadByIdAndSearchScopes_WhenCreatingIncludeSearch_ThenOnlySearchScopedTypesArePassedToIncludeParser()
+        {
+            _defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+            _defaultFhirRequestContext.AccessControlContext.AllowedResourceActions.Add(
+                new ScopeRestriction(KnownResourceTypes.All, DataActions.ReadById, "system"));
+            _defaultFhirRequestContext.AccessControlContext.AllowedResourceActions.Add(
+                new ScopeRestriction(KnownResourceTypes.Patient, DataActions.Search, "system"));
+
+            const string include = "Patient:general-practitioner";
+            _expressionParser.ParseInclude(
+                    Arg.Any<string[]>(),
+                    include,
+                    false,
+                    false,
+                    Arg.Any<IReadOnlyCollection<string>>())
+                .Throws(new InvalidSearchOperationException("Expected test exception."));
+
+            Assert.Throws<InvalidSearchOperationException>(() =>
+                _factory.Create(
+                    resourceType: null,
+                    queryParameters: new[]
+                    {
+                        Tuple.Create(KnownQueryParameterNames.Type, KnownResourceTypes.Patient),
+                        Tuple.Create(SearchParameterNames.Include, include),
+                    }));
+
+            _expressionParser.Received(1).ParseInclude(
+                Arg.Any<string[]>(),
+                include,
+                false,
+                false,
+                Arg.Is<IReadOnlyCollection<string>>(resourceTypes =>
+                    resourceTypes.Count == 1 &&
+                    resourceTypes.Contains(KnownResourceTypes.Patient)));
+        }
+
+        [Fact]
+        public void GivenReadByIdScopeForRequestedIncludeType_WhenCreatingSystemSearch_ThenIncludeIsSkipped()
+        {
+            _defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+            _defaultFhirRequestContext.AccessControlContext.AllowedResourceActions.Add(
+                new ScopeRestriction(KnownResourceTypes.All, DataActions.ReadById, "system"));
+            _defaultFhirRequestContext.AccessControlContext.AllowedResourceActions.Add(
+                new ScopeRestriction(KnownResourceTypes.Patient, DataActions.Search, "system"));
+            _expressionParser.Parse(Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new StubExpression("query"));
+
+            const string include = "Observation:subject";
+            SearchOptions options = _factory.Create(
+                resourceType: null,
+                queryParameters: new[]
+                {
+                    Tuple.Create(KnownQueryParameterNames.Type, KnownResourceTypes.Observation),
+                    Tuple.Create(SearchParameterNames.Include, include),
+                });
+
+            _expressionParser.DidNotReceive().ParseInclude(
+                Arg.Any<string[]>(),
+                include,
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IReadOnlyCollection<string>>());
+            Assert.Contains("'none'", options.Expression.ToString(), StringComparison.Ordinal);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Get/GetResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Get/GetResourceHandler.cs
@@ -63,7 +63,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Get
                 var query = new List<Tuple<string, string>>();
                 query.Add(new Tuple<string, string>(KnownQueryParameterNames.Id, key.Id));
 
-                var results = await _searchService.SearchAsync(key.ResourceType, query, cancellationToken);
+                var results = await _searchService.SearchAsync(
+                    key.ResourceType,
+                    query,
+                    DataActions.Read | DataActions.ReadById,
+                    cancellationToken);
 
                 if (results.Results.Any())
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -24,6 +24,7 @@ using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search.Access;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers;
+using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Models;
 using Expression = Microsoft.Health.Fhir.Core.Features.Search.Expressions.Expression;
 
@@ -32,6 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
     public class SearchOptionsFactory : ISearchOptionsFactory
     {
         private static readonly string SupportedTotalTypes = $"'{TotalType.Accurate}', '{TotalType.None}'".ToLower(CultureInfo.CurrentCulture);
+        private const DataActions SearchScopeDataActions = DataActions.Read | DataActions.Search;
 
         private readonly IExpressionParser _expressionParser;
         private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor;
@@ -88,7 +90,37 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
         public SearchOptions Create(string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false, ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest, bool onlyIds = false, bool isIncludesOperation = false)
         {
-            return Create(null, null, resourceType, queryParameters, isAsyncOperation, resourceVersionTypes: resourceVersionTypes, onlyIds: onlyIds, isIncludesOperation: isIncludesOperation);
+            return Create(
+                null,
+                null,
+                resourceType,
+                queryParameters,
+                SearchScopeDataActions,
+                isAsyncOperation,
+                resourceVersionTypes: resourceVersionTypes,
+                onlyIds: onlyIds,
+                isIncludesOperation: isIncludesOperation);
+        }
+
+        public SearchOptions Create(
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            DataActions scopeDataActions,
+            bool isAsyncOperation = false,
+            ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
+            bool onlyIds = false,
+            bool isIncludesOperation = false)
+        {
+            return Create(
+                null,
+                null,
+                resourceType,
+                queryParameters,
+                scopeDataActions,
+                isAsyncOperation,
+                resourceVersionTypes: resourceVersionTypes,
+                onlyIds: onlyIds,
+                isIncludesOperation: isIncludesOperation);
         }
 
         public SearchOptions Create(
@@ -102,7 +134,35 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bool onlyIds = false,
             bool isIncludesOperation = false)
         {
-            var searchOptions = new SearchOptions();
+            return Create(
+                compartmentType,
+                compartmentId,
+                resourceType,
+                queryParameters,
+                SearchScopeDataActions,
+                isAsyncOperation,
+                useSmartCompartmentDefinition,
+                resourceVersionTypes,
+                onlyIds,
+                isIncludesOperation);
+        }
+
+        private SearchOptions Create(
+            string compartmentType,
+            string compartmentId,
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            DataActions scopeDataActions,
+            bool isAsyncOperation = false,
+            bool useSmartCompartmentDefinition = false,
+            ResourceVersionType resourceVersionTypes = ResourceVersionType.Latest,
+            bool onlyIds = false,
+            bool isIncludesOperation = false)
+        {
+            var searchOptions = new SearchOptions
+            {
+                ScopeDataActions = scopeDataActions,
+            };
 
             if (queryParameters != null && queryParameters.Any(_ => _.Item1 == KnownQueryParameterNames.StartSurrogateId && _.Item2 != null))
             {
@@ -390,12 +450,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             }
 
             var resourceTypesString = parsedResourceTypes.Select(x => x.ToString()).ToArray();
+            IReadOnlyCollection<ScopeRestriction> applicableScopeRestrictions =
+                _contextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions
+                    ?.Where(restriction => restriction.AllowsAny(scopeDataActions))
+                    .ToArray()
+                ?? Array.Empty<ScopeRestriction>();
 
             // Form all the include revinclude expressions before for the Smart queries access control check
             // Collect all the resource types required by the include/revinclude expressions
             var includeRevincludeSearchExpressions = new List<IncludeExpression>();
-            includeRevincludeSearchExpressions.AddRange(ParseIncludeIterateExpressions(searchParams.Include, resourceTypesString, false).Where(e => e != null));
-            includeRevincludeSearchExpressions.AddRange(ParseIncludeIterateExpressions(searchParams.RevInclude, resourceTypesString, true).Where(e => e != null));
+            includeRevincludeSearchExpressions.AddRange(ParseIncludeIterateExpressions(searchParams.Include, resourceTypesString, false, applicableScopeRestrictions).Where(e => e != null));
+            includeRevincludeSearchExpressions.AddRange(ParseIncludeIterateExpressions(searchParams.RevInclude, resourceTypesString, true, applicableScopeRestrictions).Where(e => e != null));
             var requiredResourceTypes = includeRevincludeSearchExpressions.SelectMany(x => x.Produces).ToList();
 
             // Add the parsed resource types to the required resource types for access control check
@@ -403,7 +468,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             // including those from the search path, _type parameter, and resource types returned via include/revinclude expressions
             requiredResourceTypes.AddRange(parsedResourceTypes);
 
-            CheckFineGrainedAccessControl(searchExpressions, searchParams, requiredResourceTypes);
+            CheckFineGrainedAccessControl(
+                searchExpressions,
+                searchParams,
+                requiredResourceTypes,
+                applicableScopeRestrictions);
 
             var validSearchParameters = new List<SearchParameterInfo>();
 
@@ -623,7 +692,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 }
             }
 
-            _expressionAccess.CheckAndRaiseAccessExceptions(searchOptions.Expression);
+            _expressionAccess.CheckAndRaiseAccessExceptions(searchOptions.Expression, applicableScopeRestrictions);
 
             try
             {
@@ -637,7 +706,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             return searchOptions;
         }
 
-        private IEnumerable<IncludeExpression> ParseIncludeIterateExpressions(IList<(string query, IncludeModifier modifier)> includes, string[] typesString, bool isReversed)
+        private IEnumerable<IncludeExpression> ParseIncludeIterateExpressions(
+            IList<(string query, IncludeModifier modifier)> includes,
+            string[] typesString,
+            bool isReversed,
+            IReadOnlyCollection<ScopeRestriction> applicableScopeRestrictions)
         {
             return includes.Select(p =>
             {
@@ -658,7 +731,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 IReadOnlyCollection<string> allowedResourceTypesByScope = null;
                 if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true)
                 {
-                    allowedResourceTypesByScope = _contextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions.Select(s => s.Resource).ToList();
+                    allowedResourceTypesByScope = applicableScopeRestrictions.Select(s => s.Resource).ToList();
+                }
+
+                if (allowedResourceTypesByScope != null &&
+                    !allowedResourceTypesByScope.Contains(KnownResourceTypes.All))
+                {
+                    string includeSourceResourceType = p.query?.Split(':')[0];
+                    if (!string.Equals(includeSourceResourceType, "*", StringComparison.Ordinal) &&
+                        !string.Equals(includeSourceResourceType, KnownResourceTypes.All, StringComparison.Ordinal) &&
+                        !allowedResourceTypesByScope.Contains(includeSourceResourceType))
+                    {
+                        return null;
+                    }
+
+                    includeResourceTypeList = includeResourceTypeList.Intersect(allowedResourceTypesByScope).ToArray();
+                    if (includeResourceTypeList.Length == 0)
+                    {
+                        return null;
+                    }
                 }
 
                 var expression = _expressionParser.ParseInclude(includeResourceTypeList, p.query, isReversed, iterate, allowedResourceTypesByScope);
@@ -791,7 +882,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             _logger.LogInformation(logOutput);
         }
 
-        private void CheckFineGrainedAccessControl(List<Expression> searchExpressions, SearchParams searchParams, List<string> requiredResourceTypes)
+        private void CheckFineGrainedAccessControl(
+            List<Expression> searchExpressions,
+            SearchParams searchParams,
+            List<string> requiredResourceTypes,
+            IReadOnlyCollection<ScopeRestriction> applicableScopeRestrictions)
         {
             // check resource type restrictions from SMART clinical scopes
             if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true)
@@ -801,7 +896,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 var finalSmartSearchExpressions = new List<Expression>();
                 bool isFineGrainedAccessControlWithSearchParameters = false;
 
-                foreach (ScopeRestriction restriction in _contextAccessor.RequestContext?.AccessControlContext.AllowedResourceActions)
+                foreach (ScopeRestriction restriction in applicableScopeRestrictions)
                 {
                     if (restriction.Resource == KnownResourceTypes.All)
                     {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -745,10 +745,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         return null;
                     }
 
-                    includeResourceTypeList = includeResourceTypeList.Intersect(allowedResourceTypesByScope).ToArray();
-                    if (includeResourceTypeList.Length == 0)
+                    if (!(includeResourceTypeList.Length == 1 &&
+                          string.Equals(includeResourceTypeList[0], KnownResourceTypes.DomainResource, StringComparison.OrdinalIgnoreCase)))
                     {
-                        return null;
+                        includeResourceTypeList = includeResourceTypeList.Intersect(allowedResourceTypesByScope).ToArray();
+                        if (includeResourceTypeList.Length == 0)
+                        {
+                            return null;
+                        }
                     }
                 }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -2771,6 +2771,48 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        public async Task GivenSmartV2WildcardReadByIdAndPatientSearchScopes_WhenSearchingAcrossResourceTypes_ThenOnlyPatientsAreReturned()
+        {
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var wildcardReadByIdScope = new ScopeRestriction(KnownResourceTypes.All, Core.Features.Security.DataActions.ReadById, "system");
+            var patientSearchScope = new ScopeRestriction(KnownResourceTypes.Patient, Core.Features.Security.DataActions.Search, "system");
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { wildcardReadByIdScope, patientSearchScope });
+
+            var query = new List<Tuple<string, string>>
+            {
+                new(KnownQueryParameterNames.Type, KnownResourceTypes.Observation),
+            };
+
+            var results = await _searchService.Value.SearchAsync(null, query, CancellationToken.None);
+            Assert.Empty(results.Results);
+
+            query = new List<Tuple<string, string>>
+            {
+                new(KnownQueryParameterNames.Type, $"{KnownResourceTypes.Patient},{KnownResourceTypes.Observation}"),
+            };
+
+            results = await _searchService.Value.SearchAsync(null, query, CancellationToken.None);
+            Assert.NotEmpty(results.Results);
+            Assert.All(results.Results, result => Assert.Equal(KnownResourceTypes.Patient, result.Resource.ResourceTypeName));
+
+            query = new List<Tuple<string, string>>
+            {
+                new(KnownQueryParameterNames.Id, "smart-observation-A1"),
+            };
+
+            results = await _searchService.Value.SearchAsync(
+                KnownResourceTypes.Observation,
+                query,
+                Core.Features.Security.DataActions.Read | Core.Features.Security.DataActions.ReadById,
+                CancellationToken.None);
+            Assert.Collection(results.Results, result => Assert.Equal("smart-observation-A1", result.Resource.ResourceId));
+        }
+
+        [SkippableFact]
         public async Task GivenSmartV2ObservationSearchScopeWithoutAndWithCodeAndStatusFilter_WhenSearching_ThenResultsAreReturnAsExpected()
         {
             Skip.If(


### PR DESCRIPTION
## Description
Preserves the resource/action pairing for SMART clinical scopes when search requests do not carry a concrete route resource type.

- Normal searches use only legacy `.read` or SMART v2 `.s` restrictions.
- Direct reads by known ID continue to use legacy `.read` or SMART v2 `.r` restrictions.
- The filtered restrictions are applied to `_type`, all-resource searches, history and compartment searches, include/revinclude validation, and Cosmos DB include queries.
- SMART write-operation enforcement is unchanged.

## Related issues
[AB#206787](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/206787)

## Testing
- Added SQL/Cosmos integration coverage

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch
