### PR TITLE
Adds logging for search params and normalizes reindex log messages.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/FhirOperationDataStoreBase.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/FhirOperationDataStoreBase.cs
@@ -248,13 +248,13 @@ public abstract class FhirOperationDataStoreBase : IFhirOperationDataStore
         };
 
         // If no Active jobs, we are safe to queue
-        _logger.LogInformation($"Queueing reindex job with definition: {def}");
         var results = await _queueClient.EnqueueAsync(QueueType.Reindex, cancellationToken, definitions: def);
 
         var jobInfo = results[0];
         jobRecord.Id = jobInfo.Id.ToString();
         jobRecord.Status = OperationStatus.Queued;
         PopulateReindexJobRecordTimestampsFromJobInfo(jobInfo, jobRecord);
+        _logger.LogInformation($"CreateReindexJob: id={jobInfo.GroupId} definition={jobInfo.Definition}");
         return new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId(jobInfo.Version.ToString()));
     }
 
@@ -275,6 +275,7 @@ public abstract class FhirOperationDataStoreBase : IFhirOperationDataStore
             jobRecord.Status = OperationStatus.Canceled;
             PopulateReindexJobRecordTimestampsFromJobInfo(jobWithGroupId, jobRecord);
 
+            _logger.LogInformation($"CancelReindexJob: id={jobId}");
             return new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId(jobWithGroupId.Version.ToString()));
         }
         catch (JobNotExistException ex)
@@ -293,6 +294,8 @@ public abstract class FhirOperationDataStoreBase : IFhirOperationDataStore
     public virtual async Task<ReindexJobWrapper> GetReindexJobByIdAsync(string jobId, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNullOrWhiteSpace(jobId, nameof(jobId));
+
+        _logger.LogInformation($"GetReindexJobById: id={jobId} starting.");
 
         if (!long.TryParse(jobId, out var id))
         {
@@ -390,6 +393,8 @@ public abstract class FhirOperationDataStoreBase : IFhirOperationDataStore
                 record.Status = OperationStatus.Unknown;
                 break;
         }
+
+        _logger.LogInformation($"GetReindexJobById: completed. jobRecord={JsonConvert.SerializeObject(record)}");
 
         return new ReindexJobWrapper(record, WeakETag.FromVersionId(jobInfo.Version.ToString()));
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
                 await RefreshSearchParameterCache(true);
 
-                _logger.LogInformation("Reindex job with Id: {Id} has been started. Status: {Status}.", _jobInfo.Id, _jobInfo.Status);
+                _logger.LogJobInformation(_jobInfo, $"The reindex job started. Id={_jobInfo.Id} isSql={_isSql}");
 
                 await CreateReindexProcessingJobsAsync();
 
@@ -184,7 +184,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private async Task RefreshSearchParameterCache(bool isReindexStart)
         {
             var suffix = isReindexStart ? "Start" : "End";
-            _logger.LogJobInformation(_jobInfo, $"Reindex orchestrator job started cache refresh at the {suffix}.");
+            _logger.LogJobInformation(_jobInfo, $"Reindex orchestrator started cache refresh at the {suffix}.");
             await TryLogEvent($"ReindexOrchestratorJob={_jobInfo.Id}.ExecuteAsync.{suffix}", "Warn", "Started", null);
 
             if (_isSql)
@@ -197,7 +197,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 if (!isConsistent)
                 {
                     var msg = "Unable to sync search parameter cache. Please resubmit reindex. If issue persists please contact your administrator.";
-                    _logger.LogJobError(_jobInfo, msg);
+                    _logger.LogJobError(_jobInfo, $"Reindex: {msg}");
                     await TryLogEvent($"ReindexOrchestratorJob={_jobInfo.Id}.ExecuteAsync.{suffix}", "Error", msg, null);
                     AddErrorResult(OperationOutcomeConstants.IssueSeverity.Error, OperationOutcomeConstants.IssueType.Exception, msg);
                     throw new JobExecutionException(msg, _result, false);
@@ -230,11 +230,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
                     if (result.IsConsistent)
                     {
-                        _logger.LogJobInformation(_jobInfo, $"Cache sync check: All {result.ActiveHosts} active host(s) have converged to SearchParamLastUpdated={_searchParameterOperations.SearchParamLastUpdated.ToString("yyyy-MM-dd HH:mm:ss.fff")}.");
+                        _logger.LogJobInformation(_jobInfo, $"Reindex: Cache sync check: All {result.ActiveHosts} active host(s) have converged to SearchParamLastUpdated={_searchParameterOperations.SearchParamLastUpdated.ToString("yyyy-MM-dd HH:mm:ss.fff")}.");
                         break;
                     }
 
-                    _logger.LogJobInformation(_jobInfo, $"Cache sync check: {result.ConvergedHosts}/{result.ActiveHosts} hosts synced. Waiting...");
+                    _logger.LogJobInformation(_jobInfo, $"Reindex: Cache sync check: {result.ConvergedHosts}/{result.ActiveHosts} hosts synced. Waiting...");
                     await Task.Delay(waitInterval, cancellationToken);
                 }
 
@@ -244,19 +244,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
         private async Task DeleteOrphans()
         {
-            _logger.LogJobInformation(_jobInfo, "DeleteOrphans: Starting...");
+            _logger.LogJobInformation(_jobInfo, "Reindex.DeleteOrphans: Starting...");
 
-            var all = (await _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)).Select(_ => _.Uri.OriginalString).ToList();
+            var all = (await _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)).Select(_ => _.Uri.OriginalString).ToList();
             var systemDefined = new HashSet<string>(_searchParameterDefinitionManager.AllSearchParameters.Where(p => p.IsSystemDefined).Select(p => p.Url.OriginalString));
             var custom = all.Where(_ => !systemDefined.Contains(_)).ToList();
-            _logger.LogJobInformation(_jobInfo, $"DeleteOrphans: Custom params total={custom.Count}.");
+            _logger.LogJobInformation(_jobInfo, $"Reindex.DeleteOrphans: Custom params total={custom.Count}.");
 
             var searchParamsWithResources = await _retries.ExecuteAsync(async () => await _searchParameterOperations.GetSearchParametersByUrlsAsync(custom, _cancellationToken));
 
             var toMarkDeleted = new List<string>();
             foreach (var url in custom.Where(_ => !searchParamsWithResources.ContainsKey(_)))
             {
-                _logger.LogJobWarning(_jobInfo, $"DeleteOrphans: {url} - Resource not found.");
+                _logger.LogJobWarning(_jobInfo, $"Reindex.DeleteOrphans: {url} - Resource not found.");
                 toMarkDeleted.Add(url);
             }
 
@@ -264,18 +264,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 await _retries.ExecuteAsync(
                     async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(toMarkDeleted, SearchParameterStatus.Deleted, _cancellationToken, reindexId: _jobInfo.Id));
-                _logger.LogJobInformation(_jobInfo, $"DeleteOrphans: {toMarkDeleted.Count} search parameter(s) marked as Deleted.");
+                _logger.LogJobInformation(_jobInfo, $"Reindex.DeleteOrphans: {toMarkDeleted.Count} search parameter(s) marked as Deleted.");
             }
 
-            _logger.LogJobInformation(_jobInfo, "DeleteOrphans: Completed.");
+            _logger.LogJobInformation(_jobInfo, "Reindex.DeleteOrphans: Completed.");
         }
 
         private async Task<IReadOnlyList<long>> CreateReindexProcessingJobsAsync()
         {
             // Find search parameters not in a final state such as supported, pendingDelete, pendingDisable.
             var targetStatuses = new List<SearchParameterStatus>() { SearchParameterStatus.Supported, SearchParameterStatus.PendingDelete, SearchParameterStatus.PendingHardDelete, SearchParameterStatus.PendingDisable };
-            var searchParams = (await _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)).Where(_ => targetStatuses.Contains(_.Status)).ToList();
-            _logger.LogJobInformation(_jobInfo, $"CreateReindexProcessingJobsAsync: Get search param(s) for processing. Total={searchParams.Count}.");
+            var searchParams = (await _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)).Where(_ => targetStatuses.Contains(_.Status)).ToList();
+            _logger.LogJobInformation(_jobInfo, $"Reindex.CreateReindexProcessingJobsAsync: Get search param(s) for processing. Total={searchParams.Count}.");
 
             // Filter to only those search parameters which have valid definitions
             var targetParams = new List<SearchParameterInfo>();
@@ -284,13 +284,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 if (_searchParameterDefinitionManager.TryGetSearchParameter(validUrl, out var param))
                 {
                     targetParams.Add(param);
-                    var msg = $"GetDefinitionFromCache: {validUrl} status={param.SearchParameterStatus}";
+                    var msg = $"Reindex.GetDefinitionFromCache: url=[{validUrl}] status={param.SearchParameterStatus}";
                     _logger.LogJobInformation(_jobInfo, msg);
                     await TryLogEvent($"ReindexOrchestratorJob={_jobInfo.Id}", "Warn", msg, null);
                 }
                 else
                 {
-                    var msg = $"GetDefinitionFromCache: {validUrl} not found in cache.";
+                    var msg = $"Reindex.GetDefinitionFromCache: url=[{validUrl}] not found in cache.";
                     AddErrorResult(OperationOutcomeConstants.IssueSeverity.Error, OperationOutcomeConstants.IssueType.Exception, msg);
                     throw new JobExecutionException(msg, _result, false);
                 }
@@ -373,7 +373,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     var startId = 0L;
                     var endId = long.MaxValue;
 
-                    _logger.LogJobInformation(_jobInfo, "Fetching and enqueueing surrogate ID ranges for resource type {ResourceType} in batches of {BatchSize}. StartId={StartId}, EndId={EndId}", resourceType, numberOfRangesPerBatch, startId, endId);
+                    _logger.LogJobInformation(_jobInfo, $"Reindex: Fetching and enqueueing surrogate ID ranges for resource type {resourceType} in batches of {numberOfRangesPerBatch}. StartId={startId}, EndId={endId}");
 
                     using var searchService = _searchServiceFactory();
                     IReadOnlyList<(long StartId, long EndId, int Count)> ranges;
@@ -394,20 +394,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                     while (ranges.Any());
 
-                    _logger.LogJobInformation(_jobInfo, "Completed fetching and enqueueing {RangeCount} surrogate ID ranges for resource type {ResourceType}.", totalRangesEnqueued, resourceType);
+                    _logger.LogJobInformation(_jobInfo, $"Reindex: Completed fetching and enqueueing {totalRangesEnqueued} surrogate ID ranges for resource type {resourceType}.");
                 }
                 else
                 {
                     // Cosmos does not support surrogate ID ranges, so a single processing job is created per resource type.
                     // That job drains all continuation tokens internally, fetching and writing one batch at a time.
                     var resourceCount = _resourceCounts[resourceType]; // Resource counts are calculated only for Cosmos
-                    _logger.LogJobInformation(_jobInfo, "Creating single processing job for resource type {ResourceType}. Total resource count: {Count}.", resourceType, resourceCount.Count);
+                    _logger.LogJobInformation(_jobInfo, $"Reindex: Creating single processing job for resource type {resourceType}. Total resource count: {resourceCount.Count}.");
                     var processingRanges = new List<(long StartId, long EndId, int Count)>() { (0L, 0L, (int)resourceCount.Count) };
 
                     IReadOnlyList<long> batchJobIds;
                     if (existingCosmosJobs.TryGetValue(resourceType, out var existingJobIds))
                     {
-                        _logger.LogJobInformation(_jobInfo, "Skipping Cosmos processing job creation for resource type {ResourceType}. Reusing {Count} existing job(s).", resourceType, existingJobIds.Count);
+                        _logger.LogJobInformation(_jobInfo, $"Reindex: Skipping Cosmos processing job creation for resource type {resourceType}. Reusing {existingJobIds.Count} existing job(s).");
                         batchJobIds = existingJobIds;
                     }
                     else
@@ -420,10 +420,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     allEnqueuedJobIds.AddRange(batchJobIds);
                 }
 
-                _logger.LogJobInformation(_jobInfo, "Created jobs for resource type {ResourceType} with {Count} valid search parameters: {SearchParams}", resourceType, urlsToProcess.Count, string.Join(", ", urlsToProcess));
+                _logger.LogJobInformation(_jobInfo, $"Reindex: Created jobs for resource type {resourceType} with {urlsToProcess.Count} search parameters. urls=[{string.Join(", ", urlsToProcess)}]");
             }
 
-            _logger.LogJobInformation(_jobInfo, "Enqueued {Count} total query processing jobs.", allEnqueuedJobIds.Count);
+            _logger.LogJobInformation(_jobInfo, $"Reindex: Enqueued {allEnqueuedJobIds.Count} processing jobs.");
             return allEnqueuedJobIds;
         }
 
@@ -495,12 +495,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 var jobIds = await _timeoutRetries.ExecuteAsync(
                     async () => (await _queueClient.EnqueueAsync((byte)QueueType.Reindex, definitions.ToArray(), _jobInfo.GroupId, false, _cancellationToken)).Select(job => job.Id).ToList());
-                _logger.LogJobInformation(_jobInfo, "Enqueued batch of {Count} jobs for resource type {ResourceType}.", jobIds.Count, resourceType);
+                _logger.LogJobInformation(_jobInfo, $"Reindex: Enqueued batch of {jobIds.Count} jobs for resource type {resourceType}.");
                 return jobIds;
             }
             catch (Exception ex)
             {
-                _logger.LogJobError(ex, _jobInfo, "Failed to enqueue jobs for resource type {ResourceType}.", resourceType);
+                _logger.LogJobError(ex, _jobInfo, $"Reindex: Failed to enqueue jobs for resource type {resourceType}.");
                 throw;
             }
         }
@@ -540,7 +540,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             }
             catch (Exception ex)
             {
-                var msg = $"Error running reindex query for resource type {resourceType}.";
+                var msg = $"Reindex: Error running cosmos query for resource type {resourceType}.";
                 _logger.LogJobError(ex, _jobInfo, msg);
                 AddErrorResult(OperationOutcomeConstants.IssueSeverity.Error, OperationOutcomeConstants.IssueType.Exception, msg);
                 throw new JobExecutionException(msg, _result, false);
@@ -559,7 +559,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                                     : spStatus == SearchParameterStatus.Supported || spStatus == SearchParameterStatus.Enabled
                                         ? SearchParameterStatus.Enabled
                                         : throw new InvalidOperationException("Unexpected input status");
-                _logger.LogJobInformation(_jobInfo, "Reindex job updating the status of the fully indexed search parameter, parameter: '{ParamUri}' to {Status}.", searchParameterUrl, output);
+                _logger.LogJobInformation(_jobInfo, $"Reindex: updating status of fully reindexed search parameter. url=['{searchParameterUrl}'] status={output}.");
 
                 if (output == SearchParameterStatus.Deleted)
                 {
@@ -626,7 +626,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         _result.SucceededResources += succeededResourceCount;
                         _result.FailedResources += def.ResourceCount.Count - succeededResourceCount;
 
-                        var msg = $"Processing job = {job.Id} failed. Resource type = {def.ResourceType}{(result == null ? "." : " Error = " + result.Error)}";
+                        var msg = $"Reindex: processing job = {job.Id} failed. Resource type = {def.ResourceType}{(result == null ? "." : " Error = " + result.Error)}";
                         _logger.LogJobError(_jobInfo, msg);
                         AddErrorResult(OperationOutcomeConstants.IssueSeverity.Error, OperationOutcomeConstants.IssueType.Exception, msg);
 
@@ -659,7 +659,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             var allJobsComplete = _transientResourceTypeJobs.Values.All(_ => _.Count == 0);
             if (allJobsComplete)
             {
-                _logger.LogJobInformation(_jobInfo, $"Finished processing jobs. Completed={_result.CompletedJobs} created={_result.CreatedJobs}");
+                _logger.LogJobInformation(_jobInfo, $"Reindex: Finished processing jobs. Completed={_result.CompletedJobs} created={_result.CreatedJobs}");
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
             _searchParamLastUpdated = _searchParameterOperations.SearchParamLastUpdated;
 
-            _logger.LogJobInformation(_jobInfo, $"Reindex orchestrator job completed cache refresh at the {suffix}: SearchParamLastUpdated {_searchParamLastUpdated}");
+            _logger.LogJobInformation(_jobInfo, $"Reindex orchestrator job completed cache refresh at the {suffix}: SearchParamLastUpdated={_searchParamLastUpdated}");
             await TryLogEvent($"ReindexOrchestratorJob={_jobInfo.Id}.ExecuteAsync.{suffix}", "Warn", $"SearchParamLastUpdated={_searchParamLastUpdated.ToString("yyyy-MM-dd HH:mm:ss.fff")}", null);
 
             async Task<bool> WaitForAllInstancesCacheSyncAsync(DateTime updateEventsSince, CancellationToken cancellationToken)
@@ -256,15 +256,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             var toMarkDeleted = new List<string>();
             foreach (var url in custom.Where(_ => !searchParamsWithResources.ContainsKey(_)))
             {
-                _logger.LogJobWarning(_jobInfo, $"Reindex.DeleteOrphans: {url} - Resource not found.");
+                _logger.LogJobWarning(_jobInfo, $"Reindex.DeleteOrphans: url=[{url}]. Resource not found. Will be marked as Deleted.");
                 toMarkDeleted.Add(url);
             }
 
             if (toMarkDeleted.Any())
             {
-                await _retries.ExecuteAsync(
-                    async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(toMarkDeleted, SearchParameterStatus.Deleted, _cancellationToken, reindexId: _jobInfo.Id));
-                _logger.LogJobInformation(_jobInfo, $"Reindex.DeleteOrphans: {toMarkDeleted.Count} search parameter(s) marked as Deleted.");
+                await _retries.ExecuteAsync(async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(toMarkDeleted, SearchParameterStatus.Deleted, _cancellationToken, reindexId: _jobInfo.Id));
             }
 
             _logger.LogJobInformation(_jobInfo, "Reindex.DeleteOrphans: Completed.");
@@ -423,7 +421,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 _logger.LogJobInformation(_jobInfo, $"Reindex: Created jobs for resource type {resourceType} with {urlsToProcess.Count} search parameters. urls=[{string.Join(", ", urlsToProcess)}]");
             }
 
-            _logger.LogJobInformation(_jobInfo, $"Reindex: Enqueued {allEnqueuedJobIds.Count} processing jobs.");
+            _logger.LogJobInformation(_jobInfo, $"Reindex: Completed enqueuing. Jobs={allEnqueuedJobIds.Count}. Analytics: {{ProcessingJobs}}", allEnqueuedJobIds.Count);
             return allEnqueuedJobIds;
         }
 
@@ -659,7 +657,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             var allJobsComplete = _transientResourceTypeJobs.Values.All(_ => _.Count == 0);
             if (allJobsComplete)
             {
-                _logger.LogJobInformation(_jobInfo, $"Reindex: Finished processing jobs. Completed={_result.CompletedJobs} created={_result.CreatedJobs}");
+                _logger.LogJobInformation(_jobInfo, $"Reindex: Finished processing jobs. Completed={_result.CompletedJobs} created={_result.CreatedJobs}. Analytics: {{CompletedJobs}} {{CreatedJobs}}", _result.CompletedJobs, _result.CreatedJobs);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexProcessingJob.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         /// </summary>
         private async Task ProcessWithContinuationTokensAsync()
         {
-            _logger.LogJobInformation(_jobInfo, "Cosmos reindex starts. BatchSize={BatchSize}", _batchSize);
+            _logger.LogJobInformation(_jobInfo, $"Cosmos reindex starts. BatchSize={_batchSize}");
 
             using var store = _fhirDataStoreFactory();
             string continuationToken = null;
@@ -281,7 +281,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     _result.SucceededResourceCount += resources.Count;
                     _jobInfo.Data = _result.SucceededResourceCount;
 
-                    _logger.LogJobInformation(_jobInfo, "Cosmos reindex batch complete. BatchSize={BatchSize}, TotalProcessed={TotalProcessed}", resources.Count, _result.SucceededResourceCount);
+                    _logger.LogJobInformation(_jobInfo, $"Cosmos reindex batch complete. BatchSize={resources.Count}, TotalProcessed={_result.SucceededResourceCount}");
                 }
 
                 if (string.IsNullOrEmpty(result.ContinuationToken))

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 }
 
                 // Once added to the definition manager we can update their status
-                await _searchParameterStatusManager.ApplySearchParameterStatus(statuses, cancellationToken);
+                await _searchParameterStatusManager.ApplySearchParameterStatuses(statuses, cancellationToken);
 
                 if (results.LastUpdated.HasValue)
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
@@ -13,11 +13,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 {
     public interface ISearchParameterStatusManager
     {
-        Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken);
+        Task ApplySearchParameterStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken);
 
-        Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken);
-
-        Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatus(CancellationToken cancellationToken);
+        Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatuses(CancellationToken cancellationToken);
 
         Task HandleAsync(SearchParameterDefinitionManagerInitialized notification, CancellationToken cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -132,8 +132,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
         public async Task HandleAsync(SearchParameterDefinitionManagerInitialized notification, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("SearchParameterStatusManager: Search parameter definition manager initialized");
+            _logger.LogInformation("SearchParameterStatusManager: initialization starting...");
             await EnsureInitializedAsync(cancellationToken);
+            _logger.LogInformation("SearchParameterStatusManager: initialization completed.");
         }
 
         public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, long? reindexId = null, DateTimeOffset? lastUpdated = null)
@@ -143,7 +144,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             var statuses = new List<ResourceSearchParameterStatus>();
             foreach (string uri in searchParameterUris)
             {
-                _logger.LogInformation("Setting the search parameter status of '{Uri}' to '{NewStatus}'", uri, status.ToString());
+                _logger.LogInformation($"UpdateSearchParameterStatus: url=[{uri}] status={status} starting...");
 
                 // Validate that the search parameter exists in the definition manager.
                 // This makes sense only for status other than Deleted.
@@ -162,12 +163,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             }
 
             await _searchParameterStatusDataStore.UpsertStatuses(statuses, cancellationToken, reindexId);
-        }
-
-        public async Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken)
-        {
-            var searchParamUris = new List<string>() { url };
-            await UpdateSearchParameterStatusAsync(searchParamUris, SearchParameterStatus.Deleted, cancellationToken);
+            _logger.LogInformation($"UpdateSearchParameterStatus: urls=[{string.Join(", ", searchParameterUris)}] completed.");
         }
 
         public async Task<(IReadOnlyCollection<ResourceSearchParameterStatus> Statuses, DateTimeOffset? LastUpdated)> GetSearchParameterStatusUpdates(CancellationToken cancellationToken, DateTimeOffset? startLastUpdated = null)
@@ -178,21 +174,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         }
 
         // This is just a conveniance wrapper method that should not be going to store directly
-        public async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatus(CancellationToken cancellationToken)
+        public async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatuses(CancellationToken cancellationToken)
         {
             return (await GetSearchParameterStatusUpdates(cancellationToken)).Statuses;
         }
 
         /// <summary>
-        /// Used to apply search parameter status updates to the SearchParameterDefinitionManager.Used in reindex operation when checking every 10 minutes or so.
+        /// Used to apply search parameter status updates in the SearchParameterDefinitionManager.
         /// </summary>
         /// <param name="updatedSearchParameterStatus">Collection of updated search parameter statuses</param>
         /// <param name="cancellationToken">Cancellation Token</param>
-        public async Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken)
+        public async Task ApplySearchParameterStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken)
         {
             if (!updatedSearchParameterStatus.Any())
             {
-                _logger.LogDebug("ApplySearchParameterStatus: No search parameter status updates to apply.");
+                _logger.LogDebug("ApplySearchParameterStatuses: No search parameter status updates to apply.");
                 return;
             }
 
@@ -223,7 +219,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
             _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
 
-            _logger.LogDebug("ApplySearchParameterStatus: Synced params. Updated cache timestamp.");
+            _logger.LogDebug($"ApplySearchParameterStatuses: Synced params. urls=[{string.Join(", ", updatedSearchParameterStatus.Select(_ => _.Uri))}]");
             await _mediator.PublishAsync(new SearchParametersUpdatedNotification(updated), cancellationToken);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
@@ -2432,7 +2432,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var orchestrator = CreateReindexOrchestratorJob();
 
             var ex = await Assert.ThrowsAsync<JobExecutionException>(() => orchestrator.ExecuteAsync(jobInfo, _cancellationToken));
-            var expectedMessage = $"GetDefinitionFromCache: {missingUrl} not found in cache.";
+            var expectedMessage = $"Reindex.GetDefinitionFromCache: url=[{missingUrl}] not found in cache.";
 
             Assert.Contains(expectedMessage, ex.Message);
             var result = Assert.IsType<ReindexOrchestratorJobResult>(ex.Error);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             _searchParameterStatusManager = Substitute.For<ISearchParameterStatusManager>();
             _searchParameterOperations = Substitute.For<ISearchParameterOperations>();
             _searchDefinitionManager.AllSearchParameters.Returns(new List<SearchParameterInfo>());
-            _searchParameterStatusManager.GetAllSearchParameterStatus(Arg.Any<CancellationToken>())
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(Arg.Any<CancellationToken>())
                 .Returns(new List<ResourceSearchParameterStatus>());
             _searchParameterStatusManager.CheckCacheConsistencyAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
                 .Returns(new CacheConsistencyResult { IsConsistent = true, ActiveHosts = 1, ConvergedHosts = 1 });
@@ -322,7 +322,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task ExecuteAsync_WithExceptionInProcessing_ThrowsJobExecutionExceptionWithErrorResult()
         {
             // Arrange
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(Task.FromException<IReadOnlyCollection<ResourceSearchParameterStatus>>(
                     new InvalidOperationException("Database error")));
 
@@ -346,7 +346,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var emptyStatus = new ReadOnlyCollection<ResourceSearchParameterStatus>(
                 new List<ResourceSearchParameterStatus>());
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(emptyStatus);
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>()).Returns(false);
@@ -380,7 +380,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
 
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
@@ -498,7 +498,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
 
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
@@ -609,7 +609,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
 
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
@@ -714,7 +714,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
                 .Returns(callInfo =>
@@ -775,7 +775,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
                 .Returns(callInfo =>
@@ -856,7 +856,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
 
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
@@ -952,7 +952,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             _searchDefinitionManager.AllSearchParameters.Returns(new List<SearchParameterInfo> { searchParam });
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
 
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
@@ -1003,7 +1003,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             _searchDefinitionManager.AllSearchParameters.Returns(new List<SearchParameterInfo> { systemParam });
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(
                     new List<ResourceSearchParameterStatus>
                     {
@@ -1053,7 +1053,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             _searchDefinitionManager.AllSearchParameters.Returns(new List<SearchParameterInfo> { systemParam });
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(
                     new List<ResourceSearchParameterStatus>
                     {
@@ -1099,7 +1099,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             _searchDefinitionManager.AllSearchParameters.Returns(new List<SearchParameterInfo> { systemParam });
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(
                     new List<ResourceSearchParameterStatus>
                     {
@@ -1138,7 +1138,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.PendingDelete,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
 
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
@@ -1183,7 +1183,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var emptyStatus = new ReadOnlyCollection<ResourceSearchParameterStatus>(
                 new List<ResourceSearchParameterStatus>());
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(emptyStatus);
 
             _searchDefinitionManager.AllSearchParameters
@@ -1246,7 +1246,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2, searchParamStatus3 });
 
             // ALL three parameters are in the reindex job
@@ -1330,7 +1330,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var emptyStatus = new ReadOnlyCollection<ResourceSearchParameterStatus>(
                 new List<ResourceSearchParameterStatus>());
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(emptyStatus);
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>()).Returns(false);
@@ -1396,7 +1396,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2, searchParamStatus3 });
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>())
@@ -1606,7 +1606,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2, searchParamStatus3 });
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>())
@@ -1711,7 +1711,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2 });
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>())
@@ -1877,7 +1877,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task HandleException_ThrowsJobExecutionExceptionWithError()
         {
             // Arrange
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(Task.FromException<IReadOnlyCollection<ResourceSearchParameterStatus>>(
                     new SystemException("Critical error")));
 
@@ -1918,7 +1918,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2 });
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>())
@@ -2021,7 +2021,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus });
 
             _searchDefinitionManager.TryGetSearchParameter(searchParam.Url.OriginalString, out Arg.Any<SearchParameterInfo>())
@@ -2088,7 +2088,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2 });
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>())
@@ -2171,7 +2171,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.PendingDelete,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2 });
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>())
@@ -2263,7 +2263,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.PendingDisable,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2 });
 
             _searchDefinitionManager.TryGetSearchParameter(Arg.Any<string>(), out Arg.Any<SearchParameterInfo>())
@@ -2340,7 +2340,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Status = SearchParameterStatus.Supported,
             };
 
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus> { searchParamStatus1, searchParamStatus2 });
 
             _searchDefinitionManager.AllSearchParameters
@@ -2397,7 +2397,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task RefreshSearchParameterCache_WaitsForConfiguredNumberOfCacheRefreshCycles()
         {
             var emptyStatus = new List<ResourceSearchParameterStatus>();
-            _searchParameterStatusManager.GetAllSearchParameterStatus(Arg.Any<CancellationToken>())
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(Arg.Any<CancellationToken>())
                 .Returns(emptyStatus);
 
             var jobInfo = await CreateReindexJobRecord();
@@ -2414,7 +2414,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task CreateReindexProcessingJobsAsync_WhenStatusExistsButDefinitionMissing_ThrowsJobExecutionException()
         {
             var missingUrl = "http://example.org/fhir/SearchParameter/missing-sp";
-            _searchParameterStatusManager.GetAllSearchParameterStatus(_cancellationToken)
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(_cancellationToken)
                 .Returns(new List<ResourceSearchParameterStatus>
                 {
                     new ResourceSearchParameterStatus

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterBehaviorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterBehaviorTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None);
 
             await _searchParameterOperations.DidNotReceive().ValidateSearchParameterAsync(Arg.Any<ITypedElement>(), Arg.Any<CancellationToken>());
-            await _searchParameterStatusManager.DidNotReceive().GetAllSearchParameterStatus(Arg.Any<CancellationToken>());
+            await _searchParameterStatusManager.DidNotReceive().GetAllSearchParameterStatuses(Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore, _searchParameterDefinitionManager, _searchParameterStatusManager, _requestContextAccessor, _modelInfoProvider);
             await behavior.HandleAsync(request, async () => await Task.Run(() => response), CancellationToken.None);
 
-            await _searchParameterStatusManager.DidNotReceive().GetAllSearchParameterStatus(Arg.Any<CancellationToken>());
+            await _searchParameterStatusManager.DidNotReceive().GetAllSearchParameterStatuses(Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -280,7 +280,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var newWrapper = CreateResourceWrapper(newResource, false);
 
             _fhirDataStore.GetAsync(key, Arg.Any<CancellationToken>()).Returns(oldWrapper);
-            _searchParameterStatusManager.GetAllSearchParameterStatus(Arg.Any<CancellationToken>())
+            _searchParameterStatusManager.GetAllSearchParameterStatuses(Arg.Any<CancellationToken>())
                 .Returns(new List<ResourceSearchParameterStatus>());
 
             var contextProperties = new Dictionary<string, object>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -905,9 +905,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 Assert.True(resourceTypeParam.IsSupported, $"_type should remain supported after initialization cycle {i + 1}");
             }
 
-            // Also verify that ApplySearchParameterStatus (called during refresh) doesn't
+            // Also verify that ApplySearchParameterStatuses (called during refresh) doesn't
             // affect _type, since it only processes statuses passed to it and _type has none.
-            await statusManager.ApplySearchParameterStatus(
+            await statusManager.ApplySearchParameterStatuses(
                 new[]
                 {
                     new ResourceSearchParameterStatus

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateHandler.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.SearchParameterState
 
             SearchParameterStateResponse response;
             Hl7.Fhir.Model.Parameters parameters = new Hl7.Fhir.Model.Parameters();
-            IReadOnlyCollection<ResourceSearchParameterStatus> states = await _searchParameterStatusManager.GetAllSearchParameterStatus(cancellationToken);
+            IReadOnlyCollection<ResourceSearchParameterStatus> states = await _searchParameterStatusManager.GetAllSearchParameterStatuses(cancellationToken);
             foreach (SearchParameterInfo searchParam in searchParameterResult)
             {
                 try

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.SearchParameterState
 
             await _authorizationService.CheckAccess(DataActions.SearchParameter, true, cancellationToken);
 
-            _resourceSearchParameterStatus = await _searchParameterStatusManager.GetAllSearchParameterStatus(cancellationToken);
+            _resourceSearchParameterStatus = await _searchParameterStatusManager.GetAllSearchParameterStatuses(cancellationToken);
             Dictionary<SearchParameterStatus, List<string>> searchParametersToUpdate = ParseRequestForUpdate(request, out List<OperationOutcomeIssue> invalidSearchParameters);
 
             foreach (var statusGroup in searchParametersToUpdate)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -873,6 +873,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             {
                 resource.PendingSearchParameterStatus = (ResourceSearchParameterStatus)value;
                 _requestContextAccessor.RequestContext.Properties.Remove(SearchParameterRequestContextPropertyNames.PendingStatus);
+                _logger.LogInformation($"SetAndClearPendingSearchParameterStatus: uri={resource.PendingSearchParameterStatus.Uri} status={resource.PendingSearchParameterStatus.Status} previousUri={resource.PendingSearchParameterStatus.PreviousUri}");
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/FailingSearchParameterStatusManager.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/FailingSearchParameterStatusManager.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         public Task AddSearchParameterStatusAsync(IReadOnlyCollection<string> searchParamUris, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task ApplySearchParameterStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatus(CancellationToken cancellationToken)
+        public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatuses(CancellationToken cancellationToken)
             => Task.FromResult<IReadOnlyCollection<ResourceSearchParameterStatus>>(Array.Empty<ResourceSearchParameterStatus>());
 
         public Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, long? reindexId = null, DateTimeOffset? lastUpdated = null) => Task.CompletedTask;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             using var cancellationTokenSource = new CancellationTokenSource();
             await WaitForReindexCompletionAsync(response, cancellationTokenSource);
 
-            var statuses = await _searchParameterStatusManager.GetAllSearchParameterStatus(CancellationToken.None);
+            var statuses = await _searchParameterStatusManager.GetAllSearchParameterStatuses(CancellationToken.None);
             var paramStatus = statuses.FirstOrDefault(s => s.Uri.OriginalString == searchParam.Url);
             Assert.NotNull(paramStatus);
             Assert.Equal(SearchParameterStatus.Deleted, paramStatus.Status);
@@ -520,7 +520,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             customResource = await _fixture.DataStore.GetAsync(customKey, CancellationToken.None);
             Assert.Null(customResource);
 
-            var statusAfterDelete = (await _searchParameterStatusManager.GetAllSearchParameterStatus(CancellationToken.None)).FirstOrDefault(s => s.Uri.OriginalString == customSearchParam.Url);
+            var statusAfterDelete = (await _searchParameterStatusManager.GetAllSearchParameterStatuses(CancellationToken.None)).FirstOrDefault(s => s.Uri.OriginalString == customSearchParam.Url);
             Assert.NotNull(statusAfterDelete);
             Assert.Equal(SearchParameterStatus.Supported, statusAfterDelete.Status);
 
@@ -528,7 +528,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             using var cancellationTokenSource = new CancellationTokenSource();
             await WaitForReindexCompletionAsync(response, cancellationTokenSource);
 
-            var customStatus = (await _searchParameterStatusManager.GetAllSearchParameterStatus(CancellationToken.None)).FirstOrDefault(s => s.Uri.OriginalString == customSearchParam.Url);
+            var customStatus = (await _searchParameterStatusManager.GetAllSearchParameterStatuses(CancellationToken.None)).FirstOrDefault(s => s.Uri.OriginalString == customSearchParam.Url);
             Assert.NotNull(customStatus);
             Assert.Equal(SearchParameterStatus.Deleted, customStatus.Status);
         }
@@ -563,7 +563,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             await WaitForReindexCompletionAsync(response, cancellationTokenSource);
 
-            var updateSearchParamList = await _searchParameterStatusManager.GetAllSearchParameterStatus(default);
+            var updateSearchParamList = await _searchParameterStatusManager.GetAllSearchParameterStatuses(default);
             Assert.Equal(SearchParameterStatus.Enabled, updateSearchParamList.Where(sp => sp.Uri.OriginalString == searchParam.Url.OriginalString).First().Status);
         }
 
@@ -769,7 +769,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             bool hasPrimaryDefinition = false;
             for (int attempt = 0; attempt < 50; attempt++)
             {
-                var statuses = await _searchParameterStatusManager.GetAllSearchParameterStatus(CancellationToken.None);
+                var statuses = await _searchParameterStatusManager.GetAllSearchParameterStatuses(CancellationToken.None);
                 syncedStatus = statuses.FirstOrDefault(s => string.Equals(s.Uri?.OriginalString, searchParam.Url, StringComparison.Ordinal));
                 hasPrimaryDefinition = _searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Url, out _);
 
@@ -847,7 +847,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             // If the SearchParameter resource is missing at sync time, service2 should handle refresh without throwing.
             _searchParameterDefinitionManager2.TryGetSearchParameter(searchParam.Url, out searchParamInfo);
 
-            var statuses = await _searchParameterStatusManager2.GetAllSearchParameterStatus(CancellationToken.None);
+            var statuses = await _searchParameterStatusManager2.GetAllSearchParameterStatuses(CancellationToken.None);
             var status = statuses.Single(sp => sp.Uri.OriginalString.Equals(searchParam.Url, StringComparison.Ordinal)).Status;
             Assert.Contains(status, new[] { SearchParameterStatus.Supported, SearchParameterStatus.PendingDelete });
         }
@@ -860,7 +860,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             Assert.False(_searchParameterDefinitionManager2.TryGetSearchParameter(searchParam.Url, out _));
 
-            var maxLastUpdated = (await _searchParameterStatusManager2.GetAllSearchParameterStatus(CancellationToken.None)).Max(s => s.LastUpdated);
+            var maxLastUpdated = (await _searchParameterStatusManager2.GetAllSearchParameterStatuses(CancellationToken.None)).Max(s => s.LastUpdated);
 
             await _searchParameterStatusManager.UpdateSearchParameterStatusAsync([searchParam.Url], SearchParameterStatus.PendingDelete, CancellationToken.None, lastUpdated: maxLastUpdated);
 


### PR DESCRIPTION
Fixes https://microsofthealth.visualstudio.com/Health/_workitems/edit/204978/
by adding logging in SqlServerFhirDataStore for pending search param statuses

Normalizes reindex messages to facilitate debugging (reindex word is part of every message)

Also corrects (makes plural) method names GetAllSearchParameterStatus**es** and ApplySearchParameterStatus**es**

