### PR TITLE
Fix $validate fatal 5003 on Bundles with resource-less entries

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <Hl7FhirLegacyVersion>5.11.0</Hl7FhirLegacyVersion>
     <DotNetSdkPackageVersion>10.0.10</DotNetSdkPackageVersion>
     <OpenIddictPackageVersion>6.2.0</OpenIddictPackageVersion>
-    <IgnixaPackageVersion>0.0.163</IgnixaPackageVersion>
+    <IgnixaPackageVersion>0.6.74</IgnixaPackageVersion>
   </PropertyGroup>
   <!-- SDK Packages -->
   <Choose>

--- a/src/Microsoft.Health.Fhir.Ignixa/Features/Operations/Import/IgnixaImportResourceParser.cs
+++ b/src/Microsoft.Health.Fhir.Ignixa/Features/Operations/Import/IgnixaImportResourceParser.cs
@@ -63,12 +63,10 @@ namespace Microsoft.Health.Fhir.Ignixa.Features.Operations.Import
             ImportResourceIdValidator.Validate(resource.Id);
             CheckConditionalReferenceInResource(resource, importMode);
 
-            resource.Meta ??= new MetaJsonNode();
-
-            var lastUpdatedIsNull = importMode == ImportMode.InitialLoad || resource.Meta.LastUpdated == null;
-            var lastUpdated = lastUpdatedIsNull ? Clock.UtcNow : resource.Meta.LastUpdated.Value;
-            resource.Meta.LastUpdated = new DateTimeOffset(lastUpdated.DateTime.TruncateToMillisecond(), lastUpdated.Offset);
-            if (!lastUpdatedIsNull && resource.Meta.LastUpdated.Value > Clock.UtcNow.AddSeconds(10)) // 10 sec is the max for the computers in the domain
+            var lastUpdatedIsNull = importMode == ImportMode.InitialLoad || resource.Meta.LastUpdatedOffset == null;
+            var lastUpdated = lastUpdatedIsNull ? Clock.UtcNow : resource.Meta.LastUpdatedOffset.Value;
+            resource.Meta.LastUpdatedOffset = new DateTimeOffset(lastUpdated.DateTime.TruncateToMillisecond(), lastUpdated.Offset);
+            if (!lastUpdatedIsNull && resource.Meta.LastUpdatedOffset.Value > Clock.UtcNow.AddSeconds(10)) // 10 sec is the max for the computers in the domain
             {
                 throw new NotSupportedException("LastUpdated in the resource cannot be in the future.");
             }
@@ -134,7 +132,7 @@ namespace Microsoft.Health.Fhir.Ignixa.Features.Operations.Import
         /// </remarks>
         private void CheckConditionalReferenceInResource(ResourceJsonNode resource, ImportMode importMode)
         {
-            if (importMode == ImportMode.IncrementalLoad || resource.MutableNode is not JsonObject root)
+            if (importMode == ImportMode.IncrementalLoad || resource.ToSourceNavigator().Meta<JsonNode>() is not JsonObject root)
             {
                 return;
             }
@@ -156,7 +154,7 @@ namespace Microsoft.Health.Fhir.Ignixa.Features.Operations.Import
                 {
                     foreach (var item in array)
                     {
-                        ThrowIfConditionalReference(item, resource.FhirVersion);
+                        ThrowIfConditionalReference(item);
                     }
                 }
                 else
@@ -166,23 +164,21 @@ namespace Microsoft.Health.Fhir.Ignixa.Features.Operations.Import
                     // Match that leniency here (field.IsCollection but value isn't a JsonArray) instead of
                     // rejecting it - ThrowIfConditionalReference still throws below if this value isn't even
                     // a JSON object.
-                    ThrowIfConditionalReference(value, resource.FhirVersion);
+                    ThrowIfConditionalReference(value);
                 }
             }
         }
 
         /// <summary>
-        /// Reads the reference field through the typed <see cref="ReferenceJsonNode"/> model instead of casting
-        /// through raw <see cref="JsonValue"/>. A missing "reference" property (e.g. an identifier-only or
-        /// display-only reference, both valid FHIR) yields a null <see cref="ReferenceJsonNode.Reference"/> and
-        /// is skipped, matching the Firely parser. A non-string "reference" scalar (e.g. <c>"reference": 123</c>)
-        /// is deliberately not guarded against - <see cref="ReferenceJsonNode.Reference"/> throws in that case.
+        /// Reads the reference field from the raw JSON object. A missing "reference" property (e.g. an
+        /// identifier-only or display-only reference, both valid FHIR) is skipped, matching the Firely parser.
+        /// A non-string "reference" scalar (e.g. <c>"reference": 123</c>) deliberately throws.
         /// A reference field that is present but isn't a JSON object at all (schema-invalid, e.g. a bare string
         /// or number) also throws here rather than being silently skipped - confirmed empirically that
         /// <c>resource.ToElement(schema)</c> does NOT reject this shape on its own, so this is the only place
         /// that catches it. A null array item (e.g. <c>[null, {...}]</c>) is treated as absent, not malformed.
         /// </summary>
-        private static void ThrowIfConditionalReference(JsonNode referenceNode, FhirVersion? fhirVersion)
+        private static void ThrowIfConditionalReference(JsonNode referenceNode)
         {
             if (referenceNode is null)
             {
@@ -194,7 +190,7 @@ namespace Microsoft.Health.Fhir.Ignixa.Features.Operations.Import
                 throw new FormatException($"Expected a Reference object but found {referenceNode.GetValueKind()}.");
             }
 
-            var reference = new ReferenceJsonNode(referenceObject, fhirVersion).Reference;
+            var reference = referenceObject["reference"]?.GetValue<string>();
             if (!string.IsNullOrWhiteSpace(reference) && reference.Contains('?', StringComparison.Ordinal))
             {
                 throw new NotSupportedException($"Conditional reference is not supported for $import in {ImportMode.InitialLoad}.");

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ProfileValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ProfileValidatorTests.cs
@@ -4,7 +4,10 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.Reflection;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Validation;
 using Microsoft.Extensions.Logging;
@@ -74,5 +77,80 @@ public class ProfileValidatorTests
 
         // Asser
         Assert.DoesNotContain("cid-0", internalValidator.Settings.ConstraintsToIgnore ?? []);
+    }
+
+    [Fact]
+    public void GivenABundleWithAnEntryThatHasNoResource_WhenValidating_ThenNoInternalLogicFailureIsReported()
+    {
+        // Arrange
+        var validator = new ProfileValidator(_profilesResolver, _options, _logger, ModelInfoProvider.Instance);
+        Bundle bundle = CreateTransactionBundleWithAResourcelessEntry();
+
+        // Act
+        OperationOutcomeIssue[] issues = validator.TryValidate(bundle.ToTypedElement());
+
+        // Assert - ordinary validation issues are expected and fine, an internal failure is not.
+        Assert.DoesNotContain(issues, IsCatastrophicFailure);
+    }
+
+    private static bool IsCatastrophicFailure(OperationOutcomeIssue issue)
+    {
+        if (issue.DetailsText?.Contains("Internal logic failure", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return true;
+        }
+
+        return string.Equals(issue.Severity, "Fatal", StringComparison.OrdinalIgnoreCase)
+            && issue.DetailsCodes?.Coding.Any(coding => string.Equals(coding.Code, "5003", StringComparison.Ordinal)) == true;
+    }
+
+    private static Bundle CreateTransactionBundleWithAResourcelessEntry()
+    {
+        const string organizationFullUrl = "urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0001";
+
+        var bundle = new Bundle
+        {
+            Type = Bundle.BundleType.Transaction,
+        };
+
+        bundle.Entry.Add(new Bundle.EntryComponent
+        {
+            FullUrl = "urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0002",
+            Resource = new Patient
+            {
+                ManagingOrganization = new ResourceReference(organizationFullUrl),
+            },
+            Request = new Bundle.RequestComponent
+            {
+                Method = Bundle.HTTPVerb.POST,
+                Url = "Patient",
+            },
+        });
+
+        bundle.Entry.Add(new Bundle.EntryComponent
+        {
+            FullUrl = organizationFullUrl,
+            Resource = new Organization
+            {
+                Name = "Contoso Health",
+            },
+            Request = new Bundle.RequestComponent
+            {
+                Method = Bundle.HTTPVerb.POST,
+                Url = "Organization",
+            },
+        });
+
+        // The trigger: a transaction DELETE entry has a request but no resource.
+        bundle.Entry.Add(new Bundle.EntryComponent
+        {
+            Request = new Bundle.RequestComponent
+            {
+                Method = Bundle.HTTPVerb.DELETE,
+                Url = "Patient/does-not-exist",
+            },
+        });
+
+        return bundle;
     }
 }

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -166,6 +166,7 @@
     <None Remove="TestFiles\Normative\Bundle-BatchWithDuplicatedItems.json" />
     <None Remove="TestFiles\R5\Bundle-TransactionWithMetaHistory.json" />
     <None Remove="TestFiles\Normative\Bundle-TransactionWithMetaHistory.json" />
+    <None Remove="TestFiles\Normative\Bundle-TransactionWithResourcelessEntry.json" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="TestFiles\Normative\Bundle-InvalidBundleType.json" />
@@ -174,6 +175,7 @@
 	  <EmbeddedResource Include="TestFiles\Normative\Bundle-BatchWithDuplicatedItems.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\Bundle-BatchWithConditionalUpdateByIdentifier.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\Bundle-TransactionForRollBackWithDelete.json" />
+	  <EmbeddedResource Include="TestFiles\Normative\Bundle-TransactionWithResourcelessEntry.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\capabilitystatement-example.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\codesystem-abstract-types.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\Flag.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-TransactionWithResourcelessEntry.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-TransactionWithResourcelessEntry.json
@@ -1,0 +1,45 @@
+{
+    "resourceType": "Bundle",
+    "type": "transaction",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0002",
+            "resource": {
+                "resourceType": "Patient",
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Foo",
+                        "given": [ "Bar" ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "2005-02-05",
+                "managingOrganization": {
+                    "reference": "urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0001"
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0001",
+            "resource": {
+                "resourceType": "Organization",
+                "name": "Contoso Health"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Organization"
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient/does-not-exist"
+            }
+        }
+    ]
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
@@ -46,6 +46,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [Fact]
+        public async Task GivenABundleWithAnEntryThatHasNoResource_WhenValidated_ThenNoInternalLogicFailureIsReturned()
+        {
+            // A transaction bundle that mixes entries carrying a resource with a DELETE entry that carries only a
+            // request. Resolving the reference in the first entry forces the Firely bundle cache to build, which
+            // walks every entry looking for a "resource" child - including the resource-less one.
+            var bundleAsString = Samples.GetJson("Bundle-TransactionWithResourcelessEntry");
+
+            OperationOutcome outcome = await _client.ValidateAsync("Bundle/$validate", bundleAsString);
+
+            // Ordinary validation issues are expected and fine. $validate returns HTTP 200 with the outcome in the
+            // body, so a catastrophic internal failure here would otherwise be invisible to status-code telemetry.
+            Assert.DoesNotContain(
+                outcome.Issue,
+                issue => issue.Details?.Text?.Contains("Internal logic failure", StringComparison.OrdinalIgnoreCase) == true
+                    || (issue.Severity == OperationOutcome.IssueSeverity.Fatal
+                        && issue.Details?.Coding?.Any(coding => string.Equals(coding.Code, "5003", StringComparison.Ordinal)) == true));
+        }
+
+        [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenABundleWithConditionalUpdateByReference_WhenExecutedWithMaximizedConditionalQueryParallelism_RunsTheQueryInParallel()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
@@ -46,8 +46,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
         public async Task GivenABundleWithAnEntryThatHasNoResource_WhenValidated_ThenNoInternalLogicFailureIsReturned()
         {
+            // The payload is posted as a raw JSON string, so this test is JSON-only - the Xml argument set would
+            // set an Xml content type and fail to parse it.
             // A transaction bundle that mixes entries carrying a resource with a DELETE entry that carries only a
             // request. Resolving the reference in the first entry forces the Firely bundle cache to build, which
             // walks every entry looking for a "resource" child - including the resource-less one.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
@@ -279,6 +279,49 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
+        [Fact]
+        public async Task GivenABundleWithAnEntryThatHasNoResource_WhenValidateCalled_ThenNoInternalLogicFailureIsReturned()
+        {
+            // A transaction bundle that mixes entries carrying a resource with a DELETE entry that carries only a
+            // request. Resolving the reference in the first entry forces the bundle cache to build, which walks
+            // every entry looking for a "resource" child - including the resource-less one.
+            var payload = @"{
+                ""resourceType"": ""Bundle"",
+                ""type"": ""transaction"",
+                ""entry"": [
+                    {
+                        ""fullUrl"": ""urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0002"",
+                        ""resource"": {
+                            ""resourceType"": ""Patient"",
+                            ""managingOrganization"": { ""reference"": ""urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0001"" }
+                        },
+                        ""request"": { ""method"": ""POST"", ""url"": ""Patient"" }
+                    },
+                    {
+                        ""fullUrl"": ""urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0001"",
+                        ""resource"": {
+                            ""resourceType"": ""Organization"",
+                            ""name"": ""Contoso Health""
+                        },
+                        ""request"": { ""method"": ""POST"", ""url"": ""Organization"" }
+                    },
+                    {
+                        ""request"": { ""method"": ""DELETE"", ""url"": ""Patient/does-not-exist"" }
+                    }
+                ]
+            }";
+
+            OperationOutcome outcome = await _client.ValidateAsync("Bundle/$validate", payload);
+
+            // Ordinary validation issues are expected and fine. $validate returns HTTP 200 with the outcome in the
+            // body, so a catastrophic internal failure here would otherwise be invisible to status-code telemetry.
+            Assert.DoesNotContain(
+                outcome.Issue,
+                issue => issue.Details?.Text?.Contains("Internal logic failure", StringComparison.OrdinalIgnoreCase) == true
+                    || (issue.Severity == OperationOutcome.IssueSeverity.Fatal
+                        && issue.Details?.Coding?.Any(coding => string.Equals(coding.Code, "5003", StringComparison.Ordinal)) == true));
+        }
+
         private void CheckOperationOutcomeIssue(
             OperationOutcome.IssueComponent issue,
             OperationOutcome.IssueSeverity? expectedSeverity,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
@@ -279,49 +279,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact]
-        public async Task GivenABundleWithAnEntryThatHasNoResource_WhenValidateCalled_ThenNoInternalLogicFailureIsReturned()
-        {
-            // A transaction bundle that mixes entries carrying a resource with a DELETE entry that carries only a
-            // request. Resolving the reference in the first entry forces the bundle cache to build, which walks
-            // every entry looking for a "resource" child - including the resource-less one.
-            var payload = @"{
-                ""resourceType"": ""Bundle"",
-                ""type"": ""transaction"",
-                ""entry"": [
-                    {
-                        ""fullUrl"": ""urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0002"",
-                        ""resource"": {
-                            ""resourceType"": ""Patient"",
-                            ""managingOrganization"": { ""reference"": ""urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0001"" }
-                        },
-                        ""request"": { ""method"": ""POST"", ""url"": ""Patient"" }
-                    },
-                    {
-                        ""fullUrl"": ""urn:uuid:6e2b8f22-6f2c-4a5f-9bd2-0f5f8c0a0001"",
-                        ""resource"": {
-                            ""resourceType"": ""Organization"",
-                            ""name"": ""Contoso Health""
-                        },
-                        ""request"": { ""method"": ""POST"", ""url"": ""Organization"" }
-                    },
-                    {
-                        ""request"": { ""method"": ""DELETE"", ""url"": ""Patient/does-not-exist"" }
-                    }
-                ]
-            }";
-
-            OperationOutcome outcome = await _client.ValidateAsync("Bundle/$validate", payload);
-
-            // Ordinary validation issues are expected and fine. $validate returns HTTP 200 with the outcome in the
-            // body, so a catastrophic internal failure here would otherwise be invisible to status-code telemetry.
-            Assert.DoesNotContain(
-                outcome.Issue,
-                issue => issue.Details?.Text?.Contains("Internal logic failure", StringComparison.OrdinalIgnoreCase) == true
-                    || (issue.Severity == OperationOutcome.IssueSeverity.Fatal
-                        && issue.Details?.Coding?.Any(coding => string.Equals(coding.Code, "5003", StringComparison.Ordinal)) == true));
-        }
-
         private void CheckOperationOutcomeIssue(
             OperationOutcome.IssueComponent issue,
             OperationOutcome.IssueSeverity? expectedSeverity,


### PR DESCRIPTION
## Description

`$validate` silently fails for any Bundle containing an entry with no `resource` child — e.g. a transaction `DELETE` entry that carries only a `request` — when the Bundle also contains a `Reference`. It returns **HTTP 200** with a fatal issue in the *body*, so the failure is invisible to status-code and exception telemetry. Observed live: service `5.0.22` → `All OK`; `5.0.53` → fatal `5003`.
 
**Root cause.** `Hl7.Fhir.Base` changed `ScopedNode.BundledResources()` between 5.11.4 and 5.11.5:

```csharp
// 5.11.4 (SAFE)
let resource = e.Children("resource").FirstOrDefault() as ScopedNode

// 5.11.5+ (BUGGY)
entry.Children("resource").First().ToScopedNode()
// ...plus a .Single() in the versioned-entry branch
```

The `.First()` is unguarded, so resolving a reference forces the bundle cache to build and throws `InvalidOperationException: Sequence contains no elements`. The legacy validator (`Hl7.Fhir.Validation.Legacy`) converts that into a fatal `OperationOutcome` issue with details code `5003`, `"Internal logic failure: Sequence contains no elements"`.

**Why the pin didn't protect us.** `Directory.Packages.props` already set `Hl7FhirVersion=5.11.4`, but that was only *partially* effective. `Microsoft.Health.Fhir.Core` and the shared `Microsoft.Health.Fhir.Api` carry a direct `PackageReference` to `Hl7.Fhir.Base`, so CPM pinned them. The version-specific `R4/R4B/R5/Stu3.Api` projects do **not** — they only `ProjectReference` `Microsoft.Health.Fhir.Ignixa`, which pulled `Ignixa.Extensions.FirelySdk5` → `Hl7.Fhir.Base >= 5.13.1`. With no direct reference there is nothing for CPM to pin, so transitive highest-wins applied and a single `Hl7.Fhir.Base.dll` at **5.13.1** landed in the output, `*.Web` shipping artifacts included.

(A direct `PackageReference` pins *per project*, not transitively — adding it only to `*.Api` would still leave each `*.Web` leaf on 5.13.1. Verified empirically.)

**The fix.** `Ignixa.Extensions.FirelySdk5` 0.6.74 lowers its declared floor to 5.11.4, so the existing pin becomes effective again — no `NU1605` suppression, no downgrade conflict. The `0.6.x` line renames three serialization members, so `IgnixaImportResourceParser` is updated to match:

```
Meta.LastUpdated              ->  Meta.LastUpdatedOffset   (Meta auto-materializes, so
                                                            `??= new MetaJsonNode()` drops out)
ResourceJsonNode.MutableNode  ->  ToSourceNavigator().Meta<JsonNode>()
ReferenceJsonNode             ->  read "reference" off the raw JsonObject
```

5 files changed:

| file | change |
|---|---|
| `Directory.Packages.props` | `IgnixaPackageVersion` `0.0.163` → `0.6.74` |
| `IgnixaImportResourceParser.cs` | three API renames, no behavioural change |
| `ProfileValidatorTests.cs` | unit-level regression test |
| `Bundle-TransactionWithResourcelessEntry.json` | the breaking payload, as a reusable sample |
| `BundleEdgeCaseTests.cs` | E2E regression test |

## Related issues

Addresses [AB#206224](https://microsofthealth.visualstudio.com/Health/_workitems/edit/206224).

## Testing

Two regression tests, at both layers.

**Unit** — `ProfileValidatorTests.GivenABundleWithAnEntryThatHasNoResource_WhenValidating_ThenNoInternalLogicFailureIsReported`, driving the existing public seam `ProfileValidator.TryValidate(ITypedElement, string)`.

**E2E** — `BundleEdgeCaseTests.GivenABundleWithAnEntryThatHasNoResource_WhenValidated_ThenNoInternalLogicFailureIsReturned`, POSTing the Bundle to `Bundle/$validate` through the real HTTP pipeline. This layer matters specifically because the defect surfaces *inside a 200 response body* — an E2E assertion is what actually reflects what a caller observes. It lives with the other bundle-shape edge cases and carries the `Bundle` category trait.

The breaking payload is checked in as a reusable sample, `TestFiles/Normative/Bundle-TransactionWithResourcelessEntry.json`, following the existing bundle-sample convention rather than being inlined as an escaped string. `Normative` is the fallback folder for every FHIR version, so one file serves STU3, R4, R4B and R5.

Both tests use the same shape: a `Patient` carrying a `managingOrganization` reference (which forces the bundle cache to build), the referenced `Organization`, and an entry with only a `request` (DELETE) and **no** `resource`.

Both assert the **absence of the crash**, not the absence of all issues — ordinary validation warnings and errors remain allowed, so neither test becomes brittle. Both live in shared test projects and compile for STU3, R4, R4B and R5.

**Proven to fail on the defect and pass on the fix:**

- *Before* the bump (`Hl7.Fhir.Base/5.13.1`): the unit test **fails** on all four FHIR versions — `Assert.DoesNotContain() Failure: Filter matched in collection`. The E2E sample file was verified by loading it through `Samples.GetJson` and running it against the real `ProfileValidator` pinned to 5.13.1, producing exactly:
  ```
  Loaded sample, 1321 chars
  [Fatal/Exception] details='Internal logic failure: Sequence contains no elements'
  ```
- *After* the bump: `Microsoft.Health.Fhir.R4.Web` **and** the R4 test project both resolve `Hl7.Fhir.Base/5.11.4`, output dll `5.11.4+3605c91f`, and:

| suite | result |
|---|---|
| new unit test — STU3 / R4 / R4B / R5 | **passed** |
| E2E project build — STU3 / R4 / R4B / R5 | **0 errors** |
| `ImportResourceParserParityTests` | **35 passed**, 0 failed |
| all Import + Ignixa tests (R4) | **52 passed**, 0 failed |
| `Microsoft.Health.Fhir.R4.Core.UnitTests` (full) | **1748 total, 0 failed**, 1 skipped |
| `Microsoft.Health.Fhir.R4B.Api.UnitTests` (full) | **1441 passed**, 0 failed |

The E2E test itself requires a deployed server (or a data store for the in-proc fixture), so it runs in CI rather than locally — but its sample file and assertion were verified end-to-end against the validator in both the defective and fixed configurations, as shown above.

The parser migration is covered by the existing parity suite, which asserts equivalence with the Firely parser — including the missing-`meta` case (`GivenMissingMetaAndInvalidVersion_WhenParsedOnIncrementalLoad_ThenBothProvidersResetVersion`), which is what makes dropping the `MetaJsonNode` initialisation safe.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch

## Notes

- The unguarded `.First()`/`.Single()` is **still present upstream** in `FirelyTeam/firely-net-sdk` `develop`, so upgrading forward does not help — the test guards against drifting back onto an affected version.
- Only `Hl7.Fhir.Base` **≤ 5.11.4** is safe. `v5.11.5`, `v5.11.7`, `v5.12.0` and `v5.13.x` all contain the unguarded call.
- This overlaps with the larger Ignixa `0.6.x` adoption in #5776; this PR is the minimal subset needed to ship the fix to `main` now, and makes the same functional edits to `IgnixaImportResourceParser` as that branch.


