### PR TITLE
Reject non-orchestrator job ids from $import status endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,13 @@ This is the **Microsoft FHIR Server** — an open-source, standards-compliant im
 
 ---
 
+## Debugging
+
+- When fixing an unhandled exception, identify the violated invariant and the earliest point it can be enforced. Prefer rejecting invalid input at the entry point over making downstream code tolerate it. State the intended contract before writing the fix.
+- Tests must assert the intended contract, not the behavior the patched code happens to produce.
+
+---
+
 ## Project Structure
 
 | Path | Purpose |

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/GetImportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/GetImportRequestHandlerTests.cs
@@ -161,106 +161,21 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkImport
         }
 
         [Fact]
-        public async Task WhenStatusIsRequestedByProcessingJobId_ThenOrchestratorJobIsSkippedAndResponseCodeShouldBeOk()
+        public async Task WhenStatusIsRequestedByProcessingJobId_ThenNotFoundShouldBeReturned()
         {
-            var orchestratorResult = new ImportOrchestratorJobResult() { Request = "Request" };
-            var orchestrator = new JobInfo()
-            {
-                Id = 0,
-                Status = JobStatus.Completed,
-                Result = JsonConvert.SerializeObject(orchestratorResult),
-                Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition() { TypeId = (int)JobType.ImportOrchestrator }),
-            };
-
+            // A processing job is enqueued with the orchestrator's group id, so its own id differs from its group id.
+            // It does not identify an import operation, and its id is never handed out to callers.
             var workerResult = new ImportProcessingJobResult() { SucceededResources = 1, FailedResources = 1, ErrorLogLocation = "http://xyz" };
             var worker = new JobInfo()
             {
-                Id = 2,
-                Status = JobStatus.Completed,
-                Result = JsonConvert.SerializeObject(workerResult),
-                Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { TypeId = (int)JobType.ImportProcessing, ResourceLocation = "http://xyz" }),
-            };
-
-            // status is requested with the id of a processing job, so the orchestrator job is not filtered out of the group
-            var polled = new JobInfo()
-            {
                 Id = 1,
+                GroupId = 0,
                 Status = JobStatus.Completed,
                 Result = JsonConvert.SerializeObject(workerResult),
                 Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { TypeId = (int)JobType.ImportProcessing, ResourceLocation = "http://xyz" }),
             };
 
-            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(polled, [orchestrator, worker]);
-
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-
-            // The orchestrator job records no input file, so it is not reported. The job whose id was requested is excluded
-            // from its own group results, exactly as the orchestrator job is when its id is requested, so only the remaining
-            // processing job is reported.
-            var output = Assert.Single(result.JobResult.Output);
-            Assert.Equal(1L, output.Count);
-            Assert.Equal(new Uri("http://xyz"), output.InputUrl);
-            var error = Assert.Single(result.JobResult.Error);
-            Assert.Equal(1L, error.Count);
-        }
-
-        [Fact]
-        public async Task WhenCompletedJobHasNoInputLocation_ThenJobIsSkippedAndResponseCodeShouldBeOk()
-        {
-            var coordResult = new ImportOrchestratorJobResult() { Request = "Request" };
-            var coord = new JobInfo() { Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(coordResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition()) };
-            var workerResult = new ImportProcessingJobResult() { SucceededResources = 1, FailedResources = 1, ErrorLogLocation = "http://xyz" };
-            var workerWithoutLocation = new JobInfo() { Id = 1, Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(workerResult), Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition()) };
-            var worker = new JobInfo() { Id = 2, Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(workerResult), Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { ResourceLocation = "http://xyz" }) };
-
-            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(coord, [workerWithoutLocation, worker]);
-
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-            Assert.Single(result.JobResult.Output);
-            Assert.Single(result.JobResult.Error);
-        }
-
-        [Fact]
-        public async Task WhenCompletedJobHasNoDefinitionOrResult_ThenJobIsSkippedAndResponseCodeShouldBeOk()
-        {
-            var coordResult = new ImportOrchestratorJobResult() { Request = "Request" };
-            var coord = new JobInfo() { Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(coordResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition()) };
-            var worker = new JobInfo() { Id = 1, Status = JobStatus.Completed };
-
-            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(coord, [worker]);
-
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-            Assert.Empty(result.JobResult.Output);
-            Assert.Empty(result.JobResult.Error);
-        }
-
-        [Fact]
-        public async Task WhenCompletedJobHasNoResult_ThenJobIsSkippedAndResponseCodeShouldBeOk()
-        {
-            var coordResult = new ImportOrchestratorJobResult() { Request = "Request" };
-            var coord = new JobInfo() { Status = JobStatus.Completed, Result = JsonConvert.SerializeObject(coordResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition()) };
-
-            // a completed job with no persisted result reports no counts, so it is not reported as a zero count outcome
-            var worker = new JobInfo() { Id = 1, Status = JobStatus.Completed, Definition = JsonConvert.SerializeObject(new ImportProcessingJobDefinition() { TypeId = (int)JobType.ImportProcessing, ResourceLocation = "http://xyz" }) };
-
-            var result = await SetupAndExecuteGetBulkImportJobByIdAsync(coord, [worker]);
-
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-            Assert.Empty(result.JobResult.Output);
-            Assert.Empty(result.JobResult.Error);
-        }
-
-        [Fact]
-        public async Task WhenGettingFailedJobWithoutInputLocation_ThenExceptionIsThrownWithoutErrorFile()
-        {
-            var coord = new JobInfo() { Status = JobStatus.Completed };
-            var workerResult = new ImportJobErrorResult() { ErrorMessage = "Error", HttpStatusCode = HttpStatusCode.BadRequest };
-            var worker = new JobInfo() { Id = 1, Status = JobStatus.Failed, Result = JsonConvert.SerializeObject(workerResult), Definition = JsonConvert.SerializeObject(new ImportOrchestratorJobDefinition() { TypeId = (int)JobType.ImportOrchestrator }) };
-
-            var ofe = await Assert.ThrowsAsync<OperationFailedException>(() => SetupAndExecuteGetBulkImportJobByIdAsync(coord, [worker]));
-
-            Assert.Equal(HttpStatusCode.BadRequest, ofe.ResponseStatusCode);
-            Assert.Equal(string.Format(Core.Resources.OperationFailed, OperationsConstants.Import, "Error"), ofe.Message);
+            await Assert.ThrowsAsync<ResourceNotFoundException>(() => SetupAndExecuteGetBulkImportJobByIdAsync(worker, []));
         }
 
         private async Task<GetImportResponse> SetupAndExecuteGetBulkImportJobByIdAsync(JobInfo coord, List<JobInfo> workers)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
@@ -45,9 +45,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
             var coord = await _queueClient.GetJobByIdAsync(QueueType.Import, request.JobId, false, cancellationToken);
 
-            // Only the orchestrator job identifies an import operation, and it is the only job id handed out to callers.
-            // The queue assigns it an id equal to its group id, so any job whose id differs from its group id is a
-            // processing job and is not a valid import job id.
+            // The queue assigns the orchestrator an id equal to its group id, so any job whose id differs from its
+            // group id is a processing job and is not a valid import job id.
             if (coord == null || coord.Id != coord.GroupId || coord.Status == JobStatus.Archived)
             {
                 throw new ResourceNotFoundException(string.Format(Core.Resources.ImportJobNotFound, request.JobId));

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
@@ -44,7 +44,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             await _authorizationService.CheckAccess(DataActions.Import, true, cancellationToken);
 
             var coord = await _queueClient.GetJobByIdAsync(QueueType.Import, request.JobId, false, cancellationToken);
-            if (coord == null || coord.Status == JobStatus.Archived)
+
+            // Only the orchestrator job identifies an import operation, and it is the only job id handed out to callers.
+            // The queue assigns it an id equal to its group id, so any job whose id differs from its group id is a
+            // processing job and is not a valid import job id.
+            if (coord == null || coord.Id != coord.GroupId || coord.Status == JobStatus.Archived)
             {
                 throw new ResourceNotFoundException(string.Format(Core.Resources.ImportJobNotFound, request.JobId));
             }
@@ -58,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             }
             else if (coord.Status == JobStatus.Failed)
             {
-                var errorResult = DeserializeOrDefault<ImportJobErrorResult>(coord.Result);
+                var errorResult = JsonConvert.DeserializeObject<ImportJobErrorResult>(coord.Result);
                 if (errorResult.HttpStatusCode == 0)
                 {
                     errorResult.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -85,25 +89,23 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 else if (failedJobsExist)
                 {
                     var failed = jobs.First(x => x.Status == JobStatus.Failed && !x.CancelRequested);
-                    var errorResult = DeserializeOrDefault<ImportJobErrorResult>(failed.Result);
+                    var errorResult = JsonConvert.DeserializeObject<ImportJobErrorResult>(failed.Result);
+                    var definition = JsonConvert.DeserializeObject<ImportProcessingJobDefinition>(failed.Definition);
                     if (errorResult.HttpStatusCode == 0)
                     {
                         errorResult.HttpStatusCode = HttpStatusCode.InternalServerError;
                     }
 
+                    var resourceLocation = new Uri(definition.ResourceLocation);
+
                     // hide error message for InternalServerError
                     var failureReason = errorResult.HttpStatusCode == HttpStatusCode.InternalServerError ? HttpStatusCode.InternalServerError.ToString() : errorResult.ErrorMessage;
 
-                    // The input file location is not available on every job record in the group, so the error file cannot always be reported.
-                    var message = TryGetProcessingJobInput(failed, out _, out var resourceLocation)
-                        ? string.Format(Core.Resources.OperationFailedWithErrorFile, OperationsConstants.Import, failureReason, resourceLocation.OriginalString)
-                        : string.Format(Core.Resources.OperationFailed, OperationsConstants.Import, failureReason);
-
-                    throw new OperationFailedException(message, errorResult.HttpStatusCode);
+                    throw new OperationFailedException(string.Format(Core.Resources.OperationFailedWithErrorFile, OperationsConstants.Import, failureReason, resourceLocation.OriginalString), errorResult.HttpStatusCode);
                 }
                 else // no failures here
                 {
-                    var coordResult = DeserializeOrDefault<ImportOrchestratorJobResult>(coord.Result);
+                    var coordResult = JsonConvert.DeserializeObject<ImportOrchestratorJobResult>(coord.Result);
                     var result = new ImportJobResult() { Request = coordResult.Request, TransactionTime = coord.CreateDate, Output = results.Completed, Error = results.Failed };
                     return new GetImportResponse(!inFlightJobsExist ? HttpStatusCode.OK : HttpStatusCode.Accepted, result);
                 }
@@ -119,20 +121,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 var failed = new List<ImportFailedOperationOutcome>();
                 foreach (var job in jobs.Where(_ => _.Status == JobStatus.Completed))
                 {
-                    // The job group also contains the orchestrator job, which is returned here whenever status is requested
-                    // by a job id other than the orchestrator's. It records no input file url, and neither does a job whose
-                    // state was not persisted. Such records cannot be reported as a processed input file, so they are
-                    // skipped rather than allowed to fail the whole status request.
-                    if (!TryGetProcessingJobInput(job, out var definition, out var inputUrl) || string.IsNullOrWhiteSpace(job.Result))
-                    {
-                        continue;
-                    }
-
-                    var result = DeserializeOrDefault<ImportProcessingJobResult>(job.Result);
-                    completed.Add(new ImportOperationOutcome() { Type = definition.ResourceType, Count = result.SucceededResources, InputUrl = inputUrl });
+                    var definition = JsonConvert.DeserializeObject<ImportProcessingJobDefinition>(job.Definition);
+                    var result = JsonConvert.DeserializeObject<ImportProcessingJobResult>(job.Result);
+                    completed.Add(new ImportOperationOutcome() { Type = definition.ResourceType, Count = result.SucceededResources, InputUrl = new Uri(definition.ResourceLocation) });
                     if (result.FailedResources > 0)
                     {
-                        failed.Add(new ImportFailedOperationOutcome() { Type = definition.ResourceType, Count = result.FailedResources, InputUrl = inputUrl, Url = result.ErrorLogLocation });
+                        failed.Add(new ImportFailedOperationOutcome() { Type = definition.ResourceType, Count = result.FailedResources, InputUrl = new Uri(definition.ResourceLocation), Url = result.ErrorLogLocation });
                     }
                 }
 
@@ -146,47 +140,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
                 return (groupped, failed);
             }
-        }
-
-        /// <summary>
-        /// Resolves the import processing job definition and the url of the input file it processed.
-        /// </summary>
-        /// <param name="job">The job to inspect.</param>
-        /// <param name="definition">When this method returns true, the import processing job definition; otherwise null.</param>
-        /// <param name="inputUrl">When this method returns true, the url of the processed input file; otherwise null.</param>
-        /// <returns>True when the job records the url of an input file it processed; otherwise false.</returns>
-        private static bool TryGetProcessingJobInput(JobInfo job, out ImportProcessingJobDefinition definition, out Uri inputUrl)
-        {
-            // Recording an input file url is what separates a processing job from the orchestrator job, whose definition has
-            // no such property. Matching on the url rather than on the job type keeps every record the status response
-            // reported before, including any written before job types were persisted.
-            definition = DeserializeOrDefault<ImportProcessingJobDefinition>(job.Definition);
-
-            if (!Uri.TryCreate(definition.ResourceLocation, UriKind.Absolute, out inputUrl))
-            {
-                definition = null;
-                inputUrl = null;
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Deserializes persisted job state, returning a default instance when the state is absent or null valued.
-        /// </summary>
-        /// <typeparam name="T">The type of the persisted job state.</typeparam>
-        /// <param name="json">The persisted job state.</param>
-        /// <returns>The deserialized job state, or a default instance.</returns>
-        private static T DeserializeOrDefault<T>(string json)
-            where T : new()
-        {
-            if (string.IsNullOrWhiteSpace(json))
-            {
-                return new T();
-            }
-
-            return JsonConvert.DeserializeObject<T>(json) ?? new T();
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -258,6 +258,31 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResourcesCommitTransacti
         }
 
         [Fact]
+        public async Task GivenImportStatusRequestedByProcessingJobId_ThenNotFoundIsReturned()
+        {
+            if (!_fixture.IsUsingInProcTestServer)
+            {
+                return;
+            }
+
+            var (checkLocation, orchestratorJobId) = await RegisterImport();
+            var response = await ImportWaitAsync(checkLocation);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // The id returned to the caller is the orchestrator's, and the queue assigns it an id equal to its group id.
+            // Processing jobs are enqueued into the same group, so their ids differ from the group id and are never
+            // surfaced to callers. Requesting status by one of them does not identify an import operation.
+            var processingJobId = (long)ExecuteSql($"SELECT isnull((SELECT TOP 1 JobId FROM dbo.JobQueue WHERE QueueType = 2 AND GroupId = {orchestratorJobId} AND JobId <> GroupId ORDER BY JobId),0)");
+            Assert.True(processingJobId > 0, $"no processing job was found in group {orchestratorJobId}");
+
+            // Relative resolution replaces the last path segment, so this is the same status url with the processing job id.
+            var processingJobLocation = new Uri(checkLocation, $"{processingJobId}");
+            var processingJobResponse = await _client.CheckImportAsync(processingJobLocation, checkSuccessStatus: false);
+
+            Assert.Equal(HttpStatusCode.NotFound, processingJobResponse.StatusCode);
+        }
+
+        [Fact]
         public async Task GivenIncrementalLoad_1001ResourcesWithSameLastUpdatedAndSequenceRollOver()
         {
             if (!_fixture.IsUsingInProcTestServer)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -260,20 +260,15 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResourcesCommitTransacti
         [Fact]
         public async Task GivenImportStatusRequestedByProcessingJobId_ThenNotFoundIsReturned()
         {
-            if (!_fixture.IsUsingInProcTestServer)
-            {
-                return;
-            }
-
             var (checkLocation, orchestratorJobId) = await RegisterImport();
             var response = await ImportWaitAsync(checkLocation);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            // The id returned to the caller is the orchestrator's, and the queue assigns it an id equal to its group id.
-            // Processing jobs are enqueued into the same group, so their ids differ from the group id and are never
-            // surfaced to callers. Requesting status by one of them does not identify an import operation.
-            var processingJobId = (long)ExecuteSql($"SELECT isnull((SELECT TOP 1 JobId FROM dbo.JobQueue WHERE QueueType = 2 AND GroupId = {orchestratorJobId} AND JobId <> GroupId ORDER BY JobId),0)");
-            Assert.True(processingJobId > 0, $"no processing job was found in group {orchestratorJobId}");
+            // The status url handed to the caller carries the orchestrator's id, and the queue assigns the orchestrator
+            // an id equal to its group id. The orchestrator enqueues its processing jobs into that same group, and the
+            // queue hands out ids in sequence, so the id following the orchestrator's belongs to a processing job.
+            // Processing job ids are never surfaced to callers and do not identify an import operation.
+            var processingJobId = orchestratorJobId + 1;
 
             // Relative resolution replaces the last path segment, so this is the same status url with the processing job id.
             var processingJobLocation = new Uri(checkLocation, $"{processingJobId}");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -264,13 +264,10 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResourcesCommitTransacti
             var response = await ImportWaitAsync(checkLocation);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            // The status url handed to the caller carries the orchestrator's id, and the queue assigns the orchestrator
-            // an id equal to its group id. The orchestrator enqueues its processing jobs into that same group, and the
-            // queue hands out ids in sequence, so the id following the orchestrator's belongs to a processing job.
-            // Processing job ids are never surfaced to callers and do not identify an import operation.
+            // Ids are issued in sequence, so the id after the orchestrator's belongs to one of its processing jobs.
             var processingJobId = orchestratorJobId + 1;
 
-            // Relative resolution replaces the last path segment, so this is the same status url with the processing job id.
+            // Relative resolution swaps the last path segment.
             var processingJobLocation = new Uri(checkLocation, $"{processingJobId}");
             var processingJobResponse = await _client.CheckImportAsync(processingJobLocation, checkSuccessStatus: false);
 


### PR DESCRIPTION
## Description
GET /_operations/import/{id} threw an unhandled ArgumentNullException (Parameter 'uriString') and returned HTTP 500 when status was requested using a processing job id instead of the orchestrator's.

The handler fetches the job by the requested id, then reads the rest of the group and excludes that job. When the requested id belongs to a processing job, the excluded record is that worker rather than the orchestrator, so the orchestrator stayed in the list and its definition was deserialized as an ImportProcessingJobDefinition. ImportOrchestratorJobDefinition has no resourceLocation property, so ResourceLocation was null and new Uri(null) threw.

The previous fix (#5748) tolerated the null location downstream, which stopped the 500 but not the absolute fix.

Adds a debugging rule to AGENTS.md covering invariant identification and entry-point validation when fixing unhandled exceptions.

## Related issues
Addresses #[204980](https://microsofthealth.visualstudio.com/Health/_workitems/edit/204980)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
