### PR TITLE
Return 400 for out-of-range _lastUpdated

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -963,6 +963,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value specified for &apos;_lastUpdated&apos; is outside of the supported range. It must be no later than &apos;{0}&apos;..
+        /// </summary>
+        internal static string LastUpdatedValueOutOfRange {
+            get {
+                return ResourceManager.GetString("LastUpdatedValueOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bundle.link values omitted because they exceeded the maximum Uri length..
         /// </summary>
         internal static string LinksCantBeCreated {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -680,6 +680,10 @@
     <value>Search count returned {0} and exceeds the maximum defined limit of {1}.</value>
     <comment>{0} is the rows returned by the query, {1} is the defined limit of the bundle.Total field.</comment>
   </data>
+  <data name="LastUpdatedValueOutOfRange" xml:space="preserve">
+    <value>The value specified for '_lastUpdated' is outside of the supported range. It must be no later than '{0}'.</value>
+    <comment>{0} is the maximum date and time that the server is able to represent, in round-trip (ISO 8601) format.</comment>
+  </data>
   <data name="InvalidInnerUnionExpression" xml:space="preserve">
     <value>Inner '{0}' are not supported</value>
     <comment>Union expression can't have other union expressions as children.</comment>

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
@@ -37,6 +38,34 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             Assert.Equal(SqlFieldName.ResourceSurrogateId, binaryOutput.FieldName);
             Assert.Equal(expectedOperator, binaryOutput.BinaryOperator);
             Assert.Equal(DateTimeOffset.Parse(expectedDateTimeOffset), ((long)binaryOutput.Value).ToLastUpdated());
+        }
+
+        [InlineData(BinaryOperator.GreaterThan)]
+        [InlineData(BinaryOperator.GreaterThanOrEqual)]
+        [InlineData(BinaryOperator.LessThan)]
+        [InlineData(BinaryOperator.LessThanOrEqual)]
+        [Theory]
+        public void GivenAnExpressionOverLastUpdatedBeyondTheSupportedRange_WhenTranslatedToResourceSurrogateId_ThenBadRequestExceptionIsThrown(BinaryOperator inputOperator)
+        {
+            var input = new BinaryExpression(inputOperator, FieldName.DateTimeStart, null, DateTimeOffset.MaxValue);
+
+            Assert.Throws<BadRequestException>(() => input.AcceptVisitor(LastUpdatedToResourceSurrogateIdRewriter.Instance, null));
+        }
+
+        [InlineData(BinaryOperator.GreaterThan)]
+        [InlineData(BinaryOperator.GreaterThanOrEqual)]
+        [InlineData(BinaryOperator.LessThan)]
+        [InlineData(BinaryOperator.LessThanOrEqual)]
+        [Theory]
+        public void GivenAnExpressionOverLastUpdatedAtTheSupportedMaximum_WhenTranslatedToResourceSurrogateId_ThenNoExceptionIsThrown(BinaryOperator inputOperator)
+        {
+            var value = new DateTimeOffset(LastUpdatedToResourceSurrogateIdRewriter.MaxSupportedLastUpdated);
+            var input = new BinaryExpression(inputOperator, FieldName.DateTimeStart, null, value);
+
+            var output = input.AcceptVisitor(LastUpdatedToResourceSurrogateIdRewriter.Instance, null);
+
+            BinaryExpression binaryOutput = Assert.IsType<BinaryExpression>(output);
+            Assert.Equal(SqlFieldName.ResourceSurrogateId, binaryOutput.FieldName);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -4,7 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
@@ -17,6 +19,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
     internal class LastUpdatedToResourceSurrogateIdRewriter : SqlExpressionRewriterWithInitialContext<object>
     {
         internal static readonly LastUpdatedToResourceSurrogateIdRewriter Instance = new LastUpdatedToResourceSurrogateIdRewriter();
+
+        /// <summary>
+        /// The conversions below can round a boundary up by one millisecond, so a millisecond of headroom is reserved
+        /// below <see cref="ResourceSurrogateIdHelper.MaxDateTime"/> to keep that arithmetic representable.
+        /// </summary>
+        internal static readonly DateTime MaxSupportedLastUpdated = ResourceSurrogateIdHelper.MaxDateTime.UtcDateTime.AddTicks(-TimeSpan.TicksPerMillisecond);
 
         public override Expression VisitMissingSearchParameter(MissingSearchParameterExpression expression, object context)
         {
@@ -48,6 +56,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             // ResourceSurrogateId has millisecond datetime precision, with lower bits added in to make the value unique.
 
             DateTime original = ((DateTimeOffset)expression.Value).UtcDateTime;
+
+            if (original > MaxSupportedLastUpdated)
+            {
+                throw new BadRequestException(string.Format(
+                    CultureInfo.InvariantCulture,
+                    Core.Resources.LastUpdatedValueOutOfRange,
+                    MaxSupportedLastUpdated.ToString("o", CultureInfo.InvariantCulture)));
+            }
+
             DateTime truncated = original.TruncateToMillisecond();
 
             switch (expression.BinaryOperator)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -228,6 +228,42 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         /// <summary>
+        /// Regression test for IcM 848848621. Converting _lastUpdated into a ResourceSurrogateId rounds the boundary
+        /// up by a millisecond, which used to overflow and surface as a 500 for datetimes near the end of the range.
+        /// </summary>
+        /// <param name="lastUpdated">The out of range _lastUpdated query parameter value.</param>
+        /// <returns>Task</returns>
+        [Theory]
+        [InlineData("le9999-12-31T23:59:59.9999999")]
+        [InlineData("le9999-12-31")]
+        [InlineData("9999-12-31")]
+        [InlineData("gt9999-12-31T23:59:59.9999999")]
+        [InlineData("ge9999-12-31T23:59:59.9999999")]
+        [InlineData("lt9999-12-31T23:59:59.9999999")]
+        [InlineData("gt5000-01-01T00:00:00.0000000Z")]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)]
+        public async Task GivenALastUpdatedValueOutsideOfTheSupportedRange_WhenSearching_ThenBadRequestIsReturned(string lastUpdated)
+        {
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync($"Patient?_lastUpdated={lastUpdated}"));
+
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("lt3000-01-01T00:00:00.0000000Z")]
+        [InlineData("le3000-01-01T00:00:00.0000000Z")]
+        [InlineData("gt1900-01-01T00:00:00.0000000Z")]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)]
+        public async Task GivenALastUpdatedValueInsideOfTheSupportedRange_WhenSearching_ThenSearchSucceeds(string lastUpdated)
+        {
+            Bundle bundle = await Client.SearchAsync($"Patient?_lastUpdated={lastUpdated}&_summary=count");
+
+            Assert.NotNull(bundle);
+        }
+
+        /// <summary>
         /// This test is based on the details of user story #101268
         /// </summary>
         /// <returns>task</returns>


### PR DESCRIPTION
## Description
Fixes IcM 848848621 (FHIR001 – HTTP Internal Error threshold reached).

`GET /Patient?_lastUpdated=le9999-12-31T23:59:59.9999999` returned a 500.

`LastUpdatedToResourceSurrogateIdRewriter` converts `_lastUpdated` predicates
into `ResourceSurrogateId` predicates. Because surrogate IDs only carry
millisecond resolution, `<= T` is rewritten as `< trunc(T) + 1ms`. For values
in the last millisecond of `DateTime.MaxValue`, that addition throws
`ArgumentOutOfRangeException` from `DateTime.AddTicks`. Separately, because the
surrogate ID left-shifts ticks by 3 bits, `IdHelper.ToId` can only represent
datetimes up to ~year 3654 and throws via `EnsureArg.IsLte` beyond that.

Neither exception is mapped in `OperationOutcomeExceptionFilterAttribute`, so
both surfaced as 500s and counted against the FHIR001 internal-error monitor.

## Changes

- `LastUpdatedToResourceSurrogateIdRewriter` now validates the incoming value
  against `MaxSupportedLastUpdated` and throws `BadRequestException` (400)
  before the arithmetic can overflow. The bound reserves one millisecond of
  headroom below `IdHelper.MaxDateTime` so the `+1ms` rounding stays
  representable.
- New `LastUpdatedValueOutOfRange` resource string naming the max value.
- Unit tests covering all four operators past the bound and at the bound.
- E2E tests (SQL only) covering the ICM repro plus in-range regression guards.

`BadRequestException` was chosen deliberately: `InvalidSearchOperationException`
maps to 403, not 400.

## Affected queries

All of these returned 500 and now return 400:

- `_lastUpdated=le9999-12-31T23:59:59.9999999` (the ICM repro)
- `_lastUpdated=le9999-12-31` (date-only End expansion)
- `_lastUpdated=9999-12-31` (eq range upper bound)
- `_lastUpdated=gt|ge|lt9999-12-31T23:59:59.9999999`
- `_lastUpdated=gt5000-01-01T00:00:00Z` (surrogate-ID ceiling, ~year 3654)

Cosmos DB is unaffected — it filters on `lastUpdated` directly.

## Related issues
Addresses [AB#204940](https://dev.azure.com/microsofthealth/Health/_workitems/edit/204940).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
